### PR TITLE
Add CI gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,16 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  ci-gate:
+    name: CI
+    if: always()
+    needs: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - run: |
+          if [[ "${{ needs.ci.result }}" != "success" ]]; then
+            echo "CI failed: ${{ needs.ci.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Add a `ci-gate` job (display name: `CI`) that aggregates the 3-OS matrix result into a single status check
- Enables the new `main-branch-protection` ruleset to gate merges on one stable check context instead of tracking each OS leg independently

The corresponding GitHub ruleset (`main-branch-protection`) has already been created and is active. It enforces:
- Branch deletion protection
- Force-push (non-fast-forward) protection
- PR requirement with thread resolution
- Required `CI` status check

## Test plan

- [ ] Verify `CI` status check appears on this PR
- [ ] Verify PR cannot merge until `CI` passes
- [ ] Verify `gh api /repos/alexey-pelykh/qontoctl/rulesets` shows active ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)