### PR TITLE
(docs) update commit message convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,9 @@ ESLint enforces this via `eslint-plugin-header`.
 
 ### Commit Messages
 
-- Imperative mood: "Add feature" not "Added feature"
-- Reference issues: `Fix transaction sync (#12)`
+- Format: `(type) lowercase message` — e.g. `(feat) add transaction sync`
+- Types: `feat`, `fix`, `chore`, `docs`, `ci`, `refactor`, `test`
+- Reference issues: `(fix) resolve transaction sync (#12)`
 - One logical change per commit
 
 ### Formatting


### PR DESCRIPTION
## Summary

- Document the `(type) lowercase message` commit convention in CLAUDE.md
- Add list of standard types: feat, fix, chore, docs, ci, refactor, test

## Test plan

- [ ] Verify CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)