### PR TITLE
(feat) add HTTP client foundation for Qonto API

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient, QontoApiError, QontoRateLimitError } from "./http-client.js";
+
+/**
+ * Test-friendly subclass that stubs `sleep` to avoid real delays.
+ */
+class TestableHttpClient extends HttpClient {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override sleep(_ms: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function createMockLogger() {
+  return {
+    verbose: vi.fn<(message: string) => void>(),
+    debug: vi.fn<(message: string) => void>(),
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    }),
+  );
+}
+
+describe("HttpClient", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("request basics", () => {
+    it("sends GET request to configured base URL with path", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.toString()).toBe("https://thirdparty.qonto.com/v2/organizations");
+      expect(init.method).toBe("GET");
+    });
+
+    it("strips trailing slashes from base URL", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com///",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.toString()).toBe("https://thirdparty.qonto.com/v2/organizations");
+    });
+
+    it("appends query parameters to request URL", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/transactions", {
+        status: "completed",
+        page: "2",
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("status")).toBe("completed");
+      expect(url.searchParams.get("page")).toBe("2");
+    });
+
+    it("sends POST request with JSON body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "123" }, { status: 201 }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.post("/v2/internal_transfers", {
+        amount: 100,
+        currency: "EUR",
+      });
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(init.method).toBe("POST");
+      expect(init.body).toBe(JSON.stringify({ amount: 100, currency: "EUR" }));
+    });
+
+    it("returns parsed JSON response body", async () => {
+      const responseData = { organization: { slug: "acme" } };
+      fetchSpy.mockReturnValue(jsonResponse(responseData));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const result = await client.get("/v2/organizations");
+
+      expect(result).toEqual(responseData);
+    });
+
+    it("returns undefined for 204 No Content responses", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const result = await client.request("DELETE", "/v2/something");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("headers", () => {
+    it("includes Authorization header on all requests", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "acme-corp:secret-key-123",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("acme-corp:secret-key-123");
+    });
+
+    it("includes User-Agent header on all requests", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["User-Agent"]).toMatch(/^QontoCtl\/[\d.]+\s+\(Node\.js\/[\d.]+;\s+\w+\)$/);
+    });
+
+    it("includes Accept: application/json header", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Accept"]).toBe("application/json");
+    });
+
+    it("includes Content-Type header only when body is present", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+      const [, getInit] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const getHeaders = getInit.headers as Record<string, string>;
+      expect(getHeaders["Content-Type"]).toBeUndefined();
+
+      await client.post("/v2/transfers", { amount: 50 });
+      const [, postInit] = fetchSpy.mock.calls[1] as [URL, RequestInit];
+      const postHeaders = postInit.headers as Record<string, string>;
+      expect(postHeaders["Content-Type"]).toBe("application/json");
+    });
+
+    it("includes X-Qonto-Staging-Token in sandbox mode", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "staging-token-value",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Qonto-Staging-Token"]).toBe("staging-token-value");
+    });
+
+    it("omits X-Qonto-Staging-Token when not in sandbox mode", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Qonto-Staging-Token"]).toBeUndefined();
+    });
+  });
+
+  describe("error handling", () => {
+    it("throws QontoApiError on 4xx responses with structured errors", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "not_found",
+                detail: "Organization not found",
+              },
+            ],
+          },
+          { status: 404 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      const apiError = error as QontoApiError;
+      expect(apiError.status).toBe(404);
+      expect(apiError.errors).toEqual([{ code: "not_found", detail: "Organization not found" }]);
+      expect(apiError.message).toContain("404");
+      expect(apiError.message).toContain("not_found");
+    });
+
+    it("throws QontoApiError on 5xx responses", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "internal_error",
+                detail: "Internal server error",
+              },
+            ],
+          },
+          { status: 500 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect((error as QontoApiError).status).toBe(500);
+    });
+
+    it("handles non-JSON error responses gracefully", async () => {
+      fetchSpy.mockReturnValue(
+        Promise.resolve(
+          new Response("Bad Gateway", {
+            status: 502,
+            headers: { "Content-Type": "text/plain" },
+          }),
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      const apiError = error as QontoApiError;
+      expect(apiError.status).toBe(502);
+      expect(apiError.errors[0]?.code).toBe("unknown");
+    });
+
+    it("preserves source information in error entries", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "not_in_list",
+                detail: "status must be one of: pending, approved, declined",
+                source: { parameter: "status" },
+              },
+            ],
+          },
+          { status: 422 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.get("/v2/transactions").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      const apiError = error as QontoApiError;
+      expect(apiError.errors[0]?.source?.parameter).toBe("status");
+    });
+  });
+
+  describe("rate limiting", () => {
+    it("retries on 429 with exponential backoff", async () => {
+      fetchSpy
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        maxRetries: 3,
+      });
+
+      const result = await client.get("/v2/organizations");
+
+      expect(result).toEqual({ data: "ok" });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it("respects Retry-After header", async () => {
+      const sleepCalls: number[] = [];
+
+      class TrackingSleepClient extends HttpClient {
+        protected override sleep(ms: number): Promise<void> {
+          sleepCalls.push(ms);
+          return Promise.resolve();
+        }
+      }
+
+      fetchSpy
+        .mockReturnValueOnce(
+          Promise.resolve(
+            new Response(null, {
+              status: 429,
+              headers: { "Retry-After": "3" },
+            }),
+          ),
+        )
+        .mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const client = new TrackingSleepClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      expect(sleepCalls[0]).toBe(3000);
+    });
+
+    it("throws QontoRateLimitError after max retries exhausted", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 429 })));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        maxRetries: 2,
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoRateLimitError);
+      expect(fetchSpy).toHaveBeenCalledTimes(3); // initial + 2 retries
+    });
+
+    it("uses exponential backoff when no Retry-After header", async () => {
+      const sleepCalls: number[] = [];
+
+      class TrackingSleepClient extends HttpClient {
+        protected override sleep(ms: number): Promise<void> {
+          sleepCalls.push(ms);
+          return Promise.resolve();
+        }
+      }
+
+      fetchSpy
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const client = new TrackingSleepClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      expect(sleepCalls).toEqual([1000, 2000, 4000]);
+    });
+  });
+
+  describe("logging", () => {
+    it("logs request and response in verbose mode", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining("GET"));
+      expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining("200"));
+    });
+
+    it("logs request body and response body in debug mode", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/transfers", { amount: 100 });
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("Request body"));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("Response body"));
+    });
+
+    it("redacts Authorization header in debug logs", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "acme-corp:secret-key-123",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      expect(headerLogCalls.length).toBeGreaterThan(0);
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).toContain("[REDACTED]");
+      expect(headerLog).not.toContain("secret-key-123");
+    });
+
+    it("does not throw when logger is not provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await expect(client.get("/v2/organizations")).resolves.toEqual({
+        data: "ok",
+      });
+    });
+
+    it("logs retry attempts", async () => {
+      fetchSpy
+        .mockReturnValueOnce(Promise.resolve(new Response(null, { status: 429 })))
+        .mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining("retry 1"));
+      expect(logger.verbose).toHaveBeenCalledWith(expect.stringContaining("Rate limited"));
+    });
+  });
+
+  describe("QontoApiError", () => {
+    it("has correct name property", () => {
+      const error = new QontoApiError(400, [{ code: "invalid", detail: "Bad request" }]);
+      expect(error.name).toBe("QontoApiError");
+    });
+
+    it("formats message with status and error details", () => {
+      const error = new QontoApiError(422, [
+        { code: "not_in_list", detail: "invalid status" },
+        { code: "required", detail: "missing field" },
+      ]);
+      expect(error.message).toContain("422");
+      expect(error.message).toContain("not_in_list");
+      expect(error.message).toContain("required");
+    });
+
+    it("is an instance of Error", () => {
+      const error = new QontoApiError(400, [{ code: "test", detail: "test" }]);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("QontoRateLimitError", () => {
+    it("has correct name property", () => {
+      const error = new QontoRateLimitError(30);
+      expect(error.name).toBe("QontoRateLimitError");
+    });
+
+    it("includes retry-after in message when provided", () => {
+      const error = new QontoRateLimitError(30);
+      expect(error.message).toContain("30");
+    });
+
+    it("omits retry-after from message when undefined", () => {
+      const error = new QontoRateLimitError(undefined);
+      expect(error.message).toBe("Rate limit exceeded");
+    });
+
+    it("is an instance of Error", () => {
+      const error = new QontoRateLimitError(10);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+});

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Logger interface for HTTP client wire logging.
+ */
+export interface HttpClientLogger {
+  verbose(message: string): void;
+  debug(message: string): void;
+}
+
+/**
+ * A single error entry from the Qonto API (JSON:API format).
+ */
+export interface QontoApiErrorEntry {
+  readonly code: string;
+  readonly detail: string;
+  readonly source?: {
+    readonly pointer?: string;
+    readonly parameter?: string;
+  };
+}
+
+/**
+ * Structured error for Qonto API error responses (4xx/5xx).
+ */
+export class QontoApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly errors: readonly QontoApiErrorEntry[],
+  ) {
+    const summary = errors.map((e) => `${e.code}: ${e.detail}`).join("; ");
+    super(`Qonto API error ${status}: ${summary}`);
+    this.name = "QontoApiError";
+  }
+}
+
+/**
+ * Error thrown when all retry attempts are exhausted on 429 responses.
+ */
+export class QontoRateLimitError extends Error {
+  constructor(public readonly retryAfter: number | undefined) {
+    super(`Rate limit exceeded${retryAfter !== undefined ? ` (retry after ${retryAfter}s)` : ""}`);
+    this.name = "QontoRateLimitError";
+  }
+}
+
+export interface HttpClientOptions {
+  /** Base URL for API requests. */
+  readonly baseUrl: string;
+
+  /** Value for the Authorization header. */
+  readonly authorization: string;
+
+  /**
+   * Staging token for sandbox mode.
+   * When set, the `X-Qonto-Staging-Token` header is included.
+   */
+  readonly stagingToken?: string | undefined;
+
+  /** Logger for verbose/debug output. */
+  readonly logger?: HttpClientLogger | undefined;
+
+  /** Maximum number of retries on 429 responses. Defaults to 5. */
+  readonly maxRetries?: number | undefined;
+}
+
+const DEFAULT_MAX_RETRIES = 5;
+const BASE_BACKOFF_MS = 1000;
+
+function buildUserAgent(): string {
+  return `QontoCtl/0.0.0 (Node.js/${process.versions.node}; ${process.platform})`;
+}
+
+/**
+ * Core HTTP client for the Qonto API.
+ *
+ * Features:
+ * - Configurable base URL (production/sandbox)
+ * - User-Agent header on all requests
+ * - Exponential backoff on 429 responses
+ * - Structured error handling for 4xx/5xx
+ * - Wire logging (verbose/debug) via injected logger
+ * - Sandbox mode with X-Qonto-Staging-Token header
+ */
+export class HttpClient {
+  private readonly baseUrl: string;
+  private readonly authorization: string;
+  private readonly stagingToken: string | undefined;
+  private readonly logger: HttpClientLogger | undefined;
+  private readonly maxRetries: number;
+  private readonly userAgent: string;
+
+  constructor(options: HttpClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.authorization = options.authorization;
+    this.stagingToken = options.stagingToken;
+    this.logger = options.logger;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.userAgent = buildUserAgent();
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    options?: {
+      readonly body?: unknown;
+      readonly params?: Readonly<Record<string, string>>;
+    },
+  ): Promise<T> {
+    const url = this.buildUrl(path, options?.params);
+    const headers = this.buildHeaders(options?.body !== undefined);
+    const body = options?.body !== undefined ? JSON.stringify(options.body) : undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      this.logVerbose(`${method} ${url.toString()}${attempt > 0 ? ` (retry ${attempt})` : ""}`);
+      if (body !== undefined) {
+        this.logDebug(`Request body: ${body}`);
+      }
+
+      const startTime = performance.now();
+      const response = await fetch(url, body !== undefined ? { method, headers, body } : { method, headers });
+      const elapsed = performance.now() - startTime;
+
+      this.logVerbose(`${response.status} ${response.statusText} (${elapsed.toFixed(0)}ms)`);
+      this.logDebug(`Response headers: ${JSON.stringify(Object.fromEntries(response.headers.entries()))}`);
+
+      if (response.status === 429) {
+        const retryAfter = this.parseRetryAfter(response);
+
+        if (attempt === this.maxRetries) {
+          throw new QontoRateLimitError(retryAfter);
+        }
+
+        const delay = retryAfter !== undefined ? retryAfter * 1000 : BASE_BACKOFF_MS * Math.pow(2, attempt);
+        this.logVerbose(`Rate limited, waiting ${delay}ms before retry ${attempt + 1}`);
+        await this.sleep(delay);
+        continue;
+      }
+
+      if (!response.ok) {
+        const errorBody = await this.safeReadJson(response);
+        const errors: readonly QontoApiErrorEntry[] = this.extractErrors(errorBody);
+        throw new QontoApiError(response.status, errors);
+      }
+
+      if (response.status === 204) {
+        return undefined as T;
+      }
+
+      const responseBody: unknown = await response.json();
+      this.logDebug(`Response body: ${JSON.stringify(responseBody)}`);
+      return responseBody as T;
+    }
+
+    // Unreachable in practice: the loop always returns or throws
+    throw new QontoRateLimitError(undefined);
+  }
+
+  async get<T>(path: string, params?: Readonly<Record<string, string>>): Promise<T> {
+    return this.request<T>("GET", path, params !== undefined ? { params } : undefined);
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body !== undefined ? { body } : undefined);
+  }
+
+  private buildUrl(path: string, params?: Readonly<Record<string, string>>): URL {
+    const url = new URL(`${this.baseUrl}${path}`);
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url;
+  }
+
+  private buildHeaders(hasBody: boolean): Record<string, string> {
+    const headers: Record<string, string> = {
+      Authorization: this.authorization,
+      "User-Agent": this.userAgent,
+      Accept: "application/json",
+    };
+
+    if (hasBody) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    if (this.stagingToken !== undefined) {
+      headers["X-Qonto-Staging-Token"] = this.stagingToken;
+    }
+
+    this.logDebug(`Request headers: ${JSON.stringify({ ...headers, Authorization: "[REDACTED]" })}`);
+
+    return headers;
+  }
+
+  private parseRetryAfter(response: Response): number | undefined {
+    const header = response.headers.get("Retry-After");
+    if (header === null) {
+      return undefined;
+    }
+    const seconds = Number(header);
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+  }
+
+  private extractErrors(body: unknown): readonly QontoApiErrorEntry[] {
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "errors" in body &&
+      Array.isArray((body as { errors: unknown }).errors)
+    ) {
+      return (body as { errors: QontoApiErrorEntry[] }).errors;
+    }
+    return [{ code: "unknown", detail: "Unknown error" }];
+  }
+
+  private async safeReadJson(response: Response): Promise<unknown> {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  private logVerbose(message: string): void {
+    this.logger?.verbose(message);
+  }
+
+  private logDebug(message: string): void {
+    this.logger?.debug(message);
+  }
+
+  protected sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
+
+export {
+  HttpClient,
+  QontoApiError,
+  QontoRateLimitError,
+  type HttpClientLogger,
+  type HttpClientOptions,
+  type QontoApiErrorEntry,
+} from "./http-client.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["**/*.e2e.test.ts"]
+  "exclude": ["**/*.test.ts", "**/*.e2e.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Implement core `HttpClient` class in `@qontoctl/core` with all features from #2
- Configurable base URL (production `https://thirdparty.qonto.com` / sandbox `https://thirdparty-sandbox.staging.qonto.co`)
- `User-Agent: QontoCtl/{version} (Node.js/{node-version}; {platform})` header on all requests
- Exponential backoff retries on 429 responses with `Retry-After` header support
- Structured `QontoApiError` with typed error entries (JSON:API format) for 4xx/5xx responses
- Wire logging via injected `HttpClientLogger` (verbose: headers/timing, debug: bodies/full wire)
- Sandbox mode with `X-Qonto-Staging-Token` header when staging token is provided
- 32 unit tests covering all acceptance criteria

Closes #2

## Test plan

- [x] All 32 unit tests pass covering: request basics, headers, error handling, rate limiting, logging
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] License check passes (`pnpm license-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)