### PR TITLE
(feat) add profile and config system

### DIFF
--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { applyEnvOverlay } from "./env.js";
+
+describe("applyEnvOverlay", () => {
+  it("returns config unchanged when no env vars are set", () => {
+    const config = {
+      apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },
+    };
+    const result = applyEnvOverlay(config, { env: {} });
+    expect(result).toEqual(config);
+  });
+
+  it("overlays bare env vars without profile", () => {
+    const config = {
+      apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },
+    };
+    const result = applyEnvOverlay(config, {
+      env: {
+        QONTOCTL_ORGANIZATION_SLUG: "env-org",
+        QONTOCTL_SECRET_KEY: "env-secret",
+      },
+    });
+    expect(result.apiKey).toEqual({
+      organizationSlug: "env-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("partially overlays env vars", () => {
+    const config = {
+      apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },
+    };
+    const result = applyEnvOverlay(config, {
+      env: { QONTOCTL_ORGANIZATION_SLUG: "env-org" },
+    });
+    expect(result.apiKey).toEqual({
+      organizationSlug: "env-org",
+      secretKey: "file-secret",
+    });
+  });
+
+  it("overlays named profile env vars", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      profile: "staging",
+      env: {
+        QONTOCTL_STAGING_ORGANIZATION_SLUG: "staging-org",
+        QONTOCTL_STAGING_SECRET_KEY: "staging-secret",
+      },
+    });
+    expect(result.apiKey).toEqual({
+      organizationSlug: "staging-org",
+      secretKey: "staging-secret",
+    });
+  });
+
+  it("normalizes hyphenated profile names to underscores", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      profile: "my-profile",
+      env: {
+        QONTOCTL_MY_PROFILE_ORGANIZATION_SLUG: "org",
+        QONTOCTL_MY_PROFILE_SECRET_KEY: "secret",
+      },
+    });
+    expect(result.apiKey).toEqual({
+      organizationSlug: "org",
+      secretKey: "secret",
+    });
+  });
+
+  it("creates apiKey from env vars when config has none", () => {
+    const result = applyEnvOverlay(
+      {},
+      {
+        env: {
+          QONTOCTL_ORGANIZATION_SLUG: "env-org",
+          QONTOCTL_SECRET_KEY: "env-secret",
+        },
+      },
+    );
+    expect(result.apiKey).toEqual({
+      organizationSlug: "env-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("env var overrides file value for one field only", () => {
+    const config = {
+      apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },
+    };
+    const result = applyEnvOverlay(config, {
+      env: { QONTOCTL_SECRET_KEY: "env-secret" },
+    });
+    expect(result.apiKey).toEqual({
+      organizationSlug: "file-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("ignores bare env vars when profile is specified", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      profile: "staging",
+      env: {
+        QONTOCTL_ORGANIZATION_SLUG: "bare-org",
+        QONTOCTL_SECRET_KEY: "bare-secret",
+      },
+    });
+    // With profile "staging", it looks for QONTOCTL_STAGING_* not QONTOCTL_*
+    expect(result).toEqual({});
+  });
+
+  it("does not mutate the original config", () => {
+    const config = {
+      apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },
+    };
+    const original = structuredClone(config);
+    applyEnvOverlay(config, {
+      env: { QONTOCTL_ORGANIZATION_SLUG: "env-org" },
+    });
+    expect(config).toEqual(original);
+  });
+});

--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { QontoctlConfig } from "./types.js";
+
+const ENV_PREFIX = "QONTOCTL";
+const ORG_SLUG_SUFFIX = "ORGANIZATION_SLUG";
+const SECRET_KEY_SUFFIX = "SECRET_KEY";
+
+/**
+ * Overlays environment variables onto a config.
+ *
+ * - Without profile: reads `QONTOCTL_ORGANIZATION_SLUG` and `QONTOCTL_SECRET_KEY`
+ * - With profile: reads `QONTOCTL_{PROFILE}_ORGANIZATION_SLUG` and
+ *   `QONTOCTL_{PROFILE}_SECRET_KEY` (profile name uppercased, hyphens→underscores)
+ *
+ * Env vars take precedence over file values.
+ */
+export function applyEnvOverlay(
+  config: QontoctlConfig,
+  options?: {
+    profile?: string | undefined;
+    env?: Record<string, string | undefined> | undefined;
+  },
+): QontoctlConfig {
+  const env = options?.env ?? (process.env as Record<string, string | undefined>);
+  const prefix = buildPrefix(options?.profile);
+
+  const orgSlug = env[`${prefix}_${ORG_SLUG_SUFFIX}`];
+  const secretKey = env[`${prefix}_${SECRET_KEY_SUFFIX}`];
+
+  if (orgSlug === undefined && secretKey === undefined) {
+    return config;
+  }
+
+  const existing = config.apiKey;
+
+  return {
+    ...config,
+    apiKey: {
+      organizationSlug: orgSlug ?? existing?.organizationSlug ?? "",
+      secretKey: secretKey ?? existing?.secretKey ?? "",
+    },
+  };
+}
+
+function buildPrefix(profile: string | undefined): string {
+  if (profile === undefined) {
+    return ENV_PREFIX;
+  }
+  const normalized = profile.toUpperCase().replaceAll("-", "_");
+  return `${ENV_PREFIX}_${normalized}`;
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export type { ApiKeyCredentials, QontoctlConfig, ConfigResult, ResolveOptions } from "./types.js";
+export { resolveConfig, ConfigError } from "./resolve.js";
+export { loadConfigFile } from "./loader.js";
+export type { LoadResult } from "./loader.js";
+export { validateConfig } from "./validate.js";
+export type { ValidationResult } from "./validate.js";
+export { applyEnvOverlay } from "./env.js";

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { loadConfigFile } from "./loader.js";
+
+describe("loadConfigFile", () => {
+  let baseDir: string;
+  let testDir: string;
+  let testHome: string;
+
+  beforeEach(async () => {
+    baseDir = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    testDir = join(baseDir, "project");
+    testHome = join(baseDir, "home");
+    await mkdir(testDir, { recursive: true });
+    await mkdir(testHome, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when no config file exists", async () => {
+    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    expect(result.raw).toBeUndefined();
+    expect(result.path).toBeUndefined();
+  });
+
+  it("loads .qontoctl.yaml from CWD", async () => {
+    const configPath = join(testDir, ".qontoctl.yaml");
+    await writeFile(configPath, "api-key:\n  organization_slug: cwd-org\n  secret_key: cwd-secret\n");
+
+    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    expect(result.path).toBe(configPath);
+    expect(result.raw).toEqual({
+      "api-key": { organization_slug: "cwd-org", secret_key: "cwd-secret" },
+    });
+  });
+
+  it("falls back to ~/.qontoctl.yaml when CWD has no config", async () => {
+    const homePath = join(testHome, ".qontoctl.yaml");
+    await writeFile(homePath, "api-key:\n  organization_slug: home-org\n  secret_key: home-secret\n");
+
+    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    expect(result.path).toBe(homePath);
+    expect(result.raw).toEqual({
+      "api-key": { organization_slug: "home-org", secret_key: "home-secret" },
+    });
+  });
+
+  it("prefers CWD config over home config", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: cwd-org\n  secret_key: cwd-secret\n",
+    );
+    await writeFile(
+      join(testHome, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: home-org\n  secret_key: home-secret\n",
+    );
+
+    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    expect(result.raw).toEqual({
+      "api-key": { organization_slug: "cwd-org", secret_key: "cwd-secret" },
+    });
+  });
+
+  it("loads named profile from ~/.qontoctl/{name}.yaml", async () => {
+    const profileDir = join(testHome, ".qontoctl");
+    await mkdir(profileDir, { recursive: true });
+    const profilePath = join(profileDir, "staging.yaml");
+    await writeFile(profilePath, "api-key:\n  organization_slug: staging-org\n  secret_key: staging-secret\n");
+
+    const result = await loadConfigFile({
+      profile: "staging",
+      cwd: testDir,
+      home: testHome,
+    });
+    expect(result.path).toBe(profilePath);
+    expect(result.raw).toEqual({
+      "api-key": {
+        organization_slug: "staging-org",
+        secret_key: "staging-secret",
+      },
+    });
+  });
+
+  it("returns undefined when named profile file does not exist", async () => {
+    const result = await loadConfigFile({
+      profile: "nonexistent",
+      cwd: testDir,
+      home: testHome,
+    });
+    expect(result.raw).toBeUndefined();
+    expect(result.path).toBeUndefined();
+  });
+
+  it("handles empty YAML file", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), "");
+
+    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    expect(result.raw).toBeNull();
+    expect(result.path).toBe(join(testDir, ".qontoctl.yaml"));
+  });
+
+  it("throws on malformed YAML", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), ":\n  :\n  invalid: [unclosed");
+
+    await expect(loadConfigFile({ cwd: testDir, home: testHome })).rejects.toThrow(/Failed to read config file/);
+  });
+});

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { parse as parseYaml } from "yaml";
+
+const CONFIG_FILENAME = ".qontoctl.yaml";
+const CONFIG_DIR = ".qontoctl";
+
+export interface LoadResult {
+  /** Parsed YAML content, or `undefined` if no file was found. */
+  raw: unknown;
+  /** Path of the file that was loaded, or `undefined` if none found. */
+  path: string | undefined;
+}
+
+/**
+ * Resolves and loads the appropriate config file.
+ *
+ * - With `profile`: loads `~/.qontoctl/{profile}.yaml`
+ * - Without `profile`: tries CWD `.qontoctl.yaml`, then `~/.qontoctl.yaml`
+ */
+export async function loadConfigFile(options?: {
+  profile?: string | undefined;
+  cwd?: string | undefined;
+  home?: string | undefined;
+}): Promise<LoadResult> {
+  const home = options?.home ?? homedir();
+  const profile = options?.profile;
+
+  if (profile !== undefined) {
+    const path = join(home, CONFIG_DIR, `${profile}.yaml`);
+    return loadFromPath(path);
+  }
+
+  const cwd = options?.cwd ?? process.cwd();
+
+  // Try CWD first
+  const cwdPath = join(cwd, CONFIG_FILENAME);
+  const cwdResult = await loadFromPath(cwdPath);
+  if (cwdResult.raw !== undefined) {
+    return cwdResult;
+  }
+
+  // Fall back to home directory
+  const homePath = join(home, CONFIG_FILENAME);
+  return loadFromPath(homePath);
+}
+
+async function loadFromPath(path: string): Promise<LoadResult> {
+  try {
+    const content = await readFile(path, "utf-8");
+    const raw: unknown = parseYaml(content);
+    return { raw, path };
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return { raw: undefined, path: undefined };
+    }
+    throw new Error(`Failed to read config file "${path}": ${String(error)}`);
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { resolveConfig, ConfigError } from "./resolve.js";
+
+describe("resolveConfig", () => {
+  let testDir: string;
+  let testHome: string;
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    testDir = join(baseDir, "project");
+    testHome = join(baseDir, "home");
+    await mkdir(testDir, { recursive: true });
+    await mkdir(testHome, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it("resolves config from CWD file", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: my-org\n  secret_key: my-secret\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: {},
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "my-org",
+      secretKey: "my-secret",
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("resolves config from home fallback", async () => {
+    await writeFile(
+      join(testHome, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: home-org\n  secret_key: home-secret\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: {},
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "home-org",
+      secretKey: "home-secret",
+    });
+  });
+
+  it("resolves config from named profile", async () => {
+    const profileDir = join(testHome, ".qontoctl");
+    await mkdir(profileDir);
+    await writeFile(
+      join(profileDir, "staging.yaml"),
+      "api-key:\n  organization_slug: staging-org\n  secret_key: staging-secret\n",
+    );
+
+    const result = await resolveConfig({
+      profile: "staging",
+      cwd: testDir,
+      home: testHome,
+      env: {},
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "staging-org",
+      secretKey: "staging-secret",
+    });
+  });
+
+  it("env vars overlay onto file values", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: file-org\n  secret_key: file-secret\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: { QONTOCTL_SECRET_KEY: "env-secret" },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "file-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("resolves credentials from env vars only", async () => {
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: {
+        QONTOCTL_ORGANIZATION_SLUG: "env-org",
+        QONTOCTL_SECRET_KEY: "env-secret",
+      },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "env-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("throws ConfigError when no credentials found", async () => {
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(ConfigError);
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(/No credentials found/);
+  });
+
+  it("throws ConfigError on schema validation errors", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key: not-a-mapping\n");
+
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(ConfigError);
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(/Invalid configuration/);
+  });
+
+  it("throws ConfigError when organization_slug is missing", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key:\n  secret_key: my-secret\n");
+
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
+      /Missing required field "organization_slug"/,
+    );
+  });
+
+  it("throws ConfigError when secret_key is missing", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key:\n  organization_slug: my-org\n");
+
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
+      /Missing required field "secret_key"/,
+    );
+  });
+
+  it("returns warnings for unknown keys", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization_slug: my-org\n  secret_key: my-secret\n  extra: value\nfuture-feature: true\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: {},
+    });
+    expect(result.warnings).toContain('Unknown key in "api-key": "extra"');
+    expect(result.warnings).toContain('Unknown configuration key: "future-feature"');
+    expect(result.config.apiKey).toBeDefined();
+  });
+
+  it("named profile env vars overlay correctly", async () => {
+    const profileDir = join(testHome, ".qontoctl");
+    await mkdir(profileDir);
+    await writeFile(
+      join(profileDir, "prod.yaml"),
+      "api-key:\n  organization_slug: file-org\n  secret_key: file-secret\n",
+    );
+
+    const result = await resolveConfig({
+      profile: "prod",
+      cwd: testDir,
+      home: testHome,
+      env: { QONTOCTL_PROD_SECRET_KEY: "env-secret" },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "file-org",
+      secretKey: "env-secret",
+    });
+  });
+
+  it("provides helpful error message for missing named profile", async () => {
+    await expect(
+      resolveConfig({
+        profile: "nonexistent",
+        cwd: testDir,
+        home: testHome,
+        env: {},
+      }),
+    ).rejects.toThrow(/~\/\.qontoctl\/nonexistent\.yaml/);
+  });
+});

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { ConfigResult, ResolveOptions } from "./types.js";
+import { loadConfigFile } from "./loader.js";
+import { validateConfig } from "./validate.js";
+import { applyEnvOverlay } from "./env.js";
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * Resolves the full configuration by:
+ * 1. Loading the appropriate YAML config file (profile-aware)
+ * 2. Validating the schema (producing warnings for unknown keys)
+ * 3. Overlaying environment variables
+ * 4. Verifying that credentials are present
+ *
+ * @throws {ConfigError} on validation errors or missing credentials
+ */
+export async function resolveConfig(options?: ResolveOptions): Promise<ConfigResult> {
+  const profile = options?.profile;
+
+  // 1. Load config file
+  const { raw, path } = await loadConfigFile({
+    profile,
+    cwd: options?.cwd,
+    home: options?.home,
+  });
+
+  // 2. Validate
+  const { config: fileConfig, warnings, errors } = validateConfig(raw);
+
+  if (errors.length > 0) {
+    const location = path !== undefined ? ` (${path})` : "";
+    throw new ConfigError(`Invalid configuration${location}:\n  - ${errors.join("\n  - ")}`);
+  }
+
+  // 3. Overlay env vars
+  const config = applyEnvOverlay(fileConfig, {
+    profile,
+    env: options?.env,
+  });
+
+  // 4. Verify credentials are present
+  if (config.apiKey === undefined) {
+    const searchedLocations = describeSearchLocations(profile, path);
+    throw new ConfigError(`No credentials found. ${searchedLocations}`);
+  }
+
+  if (config.apiKey.organizationSlug === "") {
+    throw new ConfigError('Missing required field "organization_slug" in api-key credentials');
+  }
+
+  if (config.apiKey.secretKey === "") {
+    throw new ConfigError('Missing required field "secret_key" in api-key credentials');
+  }
+
+  return { config, warnings };
+}
+
+function describeSearchLocations(profile: string | undefined, loadedPath: string | undefined): string {
+  if (profile !== undefined) {
+    return `Checked ~/.qontoctl/${profile}.yaml and QONTOCTL_${profile.toUpperCase().replaceAll("-", "_")}_* env vars.`;
+  }
+  if (loadedPath !== undefined) {
+    return `Found config at ${loadedPath} but it contains no api-key credentials. Also checked QONTOCTL_* env vars.`;
+  }
+  return "Checked .qontoctl.yaml (CWD), ~/.qontoctl.yaml (home), and QONTOCTL_* env vars.";
+}

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * API key credentials for authenticating with the Qonto API.
+ */
+export interface ApiKeyCredentials {
+  organizationSlug: string;
+  secretKey: string;
+}
+
+/**
+ * Parsed configuration from a `.qontoctl.yaml` file.
+ */
+export interface QontoctlConfig {
+  apiKey?: ApiKeyCredentials;
+}
+
+/**
+ * Result of resolving configuration, including any warnings encountered.
+ */
+export interface ConfigResult {
+  config: QontoctlConfig;
+  warnings: string[];
+}
+
+/**
+ * Options for resolving configuration.
+ */
+export interface ResolveOptions {
+  /** Named profile to load from `~/.qontoctl/{profile}.yaml`. */
+  profile?: string | undefined;
+  /** Override CWD for file resolution (useful for testing). */
+  cwd?: string | undefined;
+  /** Override home directory for file resolution (useful for testing). */
+  home?: string | undefined;
+  /** Override environment variables (useful for testing). */
+  env?: Record<string, string | undefined> | undefined;
+}

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { validateConfig } from "./validate.js";
+
+describe("validateConfig", () => {
+  it("returns empty config for null input", () => {
+    const result = validateConfig(null);
+    expect(result.config).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns empty config for undefined input", () => {
+    const result = validateConfig(undefined);
+    expect(result.config).toEqual({});
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("errors on non-object input", () => {
+    const result = validateConfig("not an object");
+    expect(result.errors).toContain("Configuration must be a YAML mapping");
+  });
+
+  it("errors on array input", () => {
+    const result = validateConfig([1, 2, 3]);
+    expect(result.errors).toContain("Configuration must be a YAML mapping");
+  });
+
+  it("warns on unknown top-level keys", () => {
+    const result = validateConfig({ "unknown-key": "value", another: 42 });
+    expect(result.warnings).toContain('Unknown configuration key: "unknown-key"');
+    expect(result.warnings).toContain('Unknown configuration key: "another"');
+    expect(result.errors).toEqual([]);
+  });
+
+  it("parses valid api-key section", () => {
+    const result = validateConfig({
+      "api-key": {
+        organization_slug: "my-org",
+        secret_key: "sk_test_123",
+      },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "my-org",
+      secretKey: "sk_test_123",
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("allows null api-key section", () => {
+    const result = validateConfig({ "api-key": null });
+    expect(result.config.apiKey).toBeUndefined();
+    expect(result.errors).toEqual([]);
+  });
+
+  it("errors when api-key is not a mapping", () => {
+    const result = validateConfig({ "api-key": "invalid" });
+    expect(result.errors).toContain('"api-key" must be a mapping');
+  });
+
+  it("errors when api-key is an array", () => {
+    const result = validateConfig({ "api-key": [1, 2] });
+    expect(result.errors).toContain('"api-key" must be a mapping');
+  });
+
+  it("warns on unknown keys inside api-key", () => {
+    const result = validateConfig({
+      "api-key": {
+        organization_slug: "my-org",
+        secret_key: "sk_test_123",
+        extra_field: "value",
+      },
+    });
+    expect(result.warnings).toContain('Unknown key in "api-key": "extra_field"');
+    expect(result.errors).toEqual([]);
+    expect(result.config.apiKey).toBeDefined();
+  });
+
+  it("errors when organization_slug is not a string", () => {
+    const result = validateConfig({
+      "api-key": { organization_slug: 123, secret_key: "sk_test" },
+    });
+    expect(result.errors).toContain('"api-key.organization_slug" must be a string');
+  });
+
+  it("errors when secret_key is not a string", () => {
+    const result = validateConfig({
+      "api-key": { organization_slug: "my-org", secret_key: true },
+    });
+    expect(result.errors).toContain('"api-key.secret_key" must be a string');
+  });
+
+  it("allows partial api-key with only organization_slug", () => {
+    const result = validateConfig({
+      "api-key": { organization_slug: "my-org" },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "my-org",
+      secretKey: "",
+    });
+    expect(result.errors).toEqual([]);
+  });
+
+  it("allows partial api-key with only secret_key", () => {
+    const result = validateConfig({
+      "api-key": { secret_key: "sk_test" },
+    });
+    expect(result.config.apiKey).toEqual({
+      organizationSlug: "",
+      secretKey: "sk_test",
+    });
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns empty config for empty api-key mapping", () => {
+    const result = validateConfig({ "api-key": {} });
+    expect(result.config.apiKey).toBeUndefined();
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { QontoctlConfig } from "./types.js";
+
+const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key"]);
+const KNOWN_API_KEY_KEYS = new Set(["organization_slug", "secret_key"]);
+
+export interface ValidationResult {
+  config: QontoctlConfig;
+  warnings: string[];
+  errors: string[];
+}
+
+/**
+ * Validates a parsed YAML document against the expected config schema.
+ *
+ * - Known keys with wrong types produce errors.
+ * - Unknown keys produce warnings (forward compatibility).
+ * - Returns a partially-populated config for valid fields.
+ */
+export function validateConfig(raw: unknown): ValidationResult {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const config: QontoctlConfig = {};
+
+  if (raw === null || raw === undefined) {
+    return { config, warnings, errors };
+  }
+
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    errors.push("Configuration must be a YAML mapping");
+    return { config, warnings, errors };
+  }
+
+  const doc = raw as Record<string, unknown>;
+
+  for (const key of Object.keys(doc)) {
+    if (!KNOWN_TOP_LEVEL_KEYS.has(key)) {
+      warnings.push(`Unknown configuration key: "${key}"`);
+    }
+  }
+
+  if ("api-key" in doc) {
+    const apiKeySection = doc["api-key"];
+
+    if (apiKeySection === null || apiKeySection === undefined) {
+      // api-key section present but empty — not an error, just no credentials from file
+    } else if (typeof apiKeySection !== "object" || Array.isArray(apiKeySection)) {
+      errors.push('"api-key" must be a mapping');
+    } else {
+      const apiKey = apiKeySection as Record<string, unknown>;
+
+      for (const key of Object.keys(apiKey)) {
+        if (!KNOWN_API_KEY_KEYS.has(key)) {
+          warnings.push(`Unknown key in "api-key": "${key}"`);
+        }
+      }
+
+      const orgSlug = apiKey["organization_slug"];
+      const secretKey = apiKey["secret_key"];
+
+      if (orgSlug !== undefined && typeof orgSlug !== "string") {
+        errors.push('"api-key.organization_slug" must be a string');
+      }
+
+      if (secretKey !== undefined && typeof secretKey !== "string") {
+        errors.push('"api-key.secret_key" must be a string');
+      }
+
+      if (typeof orgSlug === "string" || typeof secretKey === "string") {
+        config.apiKey = {
+          organizationSlug: typeof orgSlug === "string" ? orgSlug : "",
+          secretKey: typeof secretKey === "string" ? secretKey : "",
+        };
+      }
+    }
+  }
+
+  return { config, warnings, errors };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,20 @@ export {
   type HttpClientOptions,
   type QontoApiErrorEntry,
 } from "./http-client.js";
+
+export {
+  resolveConfig,
+  ConfigError,
+  loadConfigFile,
+  validateConfig,
+  applyEnvOverlay,
+} from "./config/index.js";
+
+export type {
+  ApiKeyCredentials,
+  QontoctlConfig,
+  ConfigResult,
+  ResolveOptions,
+  LoadResult,
+  ValidationResult,
+} from "./config/index.js";


### PR DESCRIPTION
## Summary

Implements the profile & config system for `@qontoctl/core` (closes #3).

- **YAML profile schema**: `api-key` section with `organization_slug` and `secret_key`
- **Config file locations**: `.qontoctl.yaml` (CWD), `~/.qontoctl.yaml` (home), `~/.qontoctl/{name}.yaml` (named profiles)
- **Profile resolution**: `--profile` → named file; without → CWD → home fallback
- **Env var overlay**: bare `QONTOCTL_*` and named `QONTOCTL_{NAME}_*` override file values
- **Schema validation**: known keys validated for correct types, clear error messages for missing required fields
- **Forward compatibility**: unknown keys produce warnings, not errors

## Test plan

- [x] 44 unit tests covering all modules (validate, loader, env overlay, resolve)
- [x] CWD config loading and home directory fallback
- [x] Named profile resolution from `~/.qontoctl/{name}.yaml`
- [x] Env var overlay (bare and named, partial and full)
- [x] Schema validation errors for wrong types
- [x] Unknown key warnings for forward compatibility
- [x] Missing credentials error with helpful search location messages
- [x] Build, lint, and all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)