### PR TITLE
(feat) add CLI framework & output formatting (#4)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,8 +17,8 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/program.d.ts",
-      "import": "./dist/program.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "bin": {
@@ -29,13 +29,14 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "lint": "eslint src/",
     "dev": "tsc --watch"
   },
   "dependencies": {
     "@qontoctl/core": "workspace:^",
-    "commander": "catalog:"
+    "commander": "catalog:",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/cli/src/formatters/csv.test.ts
+++ b/packages/cli/src/formatters/csv.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { formatCsv } from "./csv.js";
+
+describe("formatCsv", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatCsv([])).toBe("");
+  });
+
+  it("formats a single row with header", () => {
+    const result = formatCsv([{ name: "Alice", age: 30 }]);
+    const lines = result.split("\n");
+    expect(lines[0]).toBe("name,age");
+    expect(lines[1]).toBe("Alice,30");
+  });
+
+  it("formats multiple rows", () => {
+    const result = formatCsv([
+      { name: "Alice", age: 30 },
+      { name: "Bob", age: 25 },
+    ]);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe("name,age");
+    expect(lines[1]).toBe("Alice,30");
+    expect(lines[2]).toBe("Bob,25");
+  });
+
+  it("escapes fields containing commas", () => {
+    const result = formatCsv([{ note: "hello, world" }]);
+    const lines = result.split("\n");
+    expect(lines[1]).toBe('"hello, world"');
+  });
+
+  it("escapes fields containing double quotes", () => {
+    const result = formatCsv([{ note: 'say "hello"' }]);
+    const lines = result.split("\n");
+    expect(lines[1]).toBe('"say ""hello"""');
+  });
+
+  it("escapes fields containing newlines", () => {
+    const result = formatCsv([{ note: "line1\nline2" }]);
+    const lines = result.split("\n");
+    expect(lines[1]).toContain('"line1');
+  });
+
+  it("handles null and undefined values as empty strings", () => {
+    const result = formatCsv([{ a: null, b: undefined, c: "ok" }]);
+    const lines = result.split("\n");
+    expect(lines[1]).toBe(",,ok");
+  });
+
+  it("serializes nested objects as JSON", () => {
+    const result = formatCsv([{ data: { nested: true } }]);
+    const lines = result.split("\n");
+    expect(lines[1]).toContain("{");
+  });
+
+  it("produces empty cells for missing keys", () => {
+    const result = formatCsv([
+      { a: 1, b: 2 },
+      { a: 3 } as Record<string, unknown>,
+    ]);
+    const lines = result.split("\n");
+    expect(lines[2]).toBe("3,");
+  });
+});

--- a/packages/cli/src/formatters/csv.ts
+++ b/packages/cli/src/formatters/csv.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsvValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return escapeCsvField(JSON.stringify(value));
+  }
+  return escapeCsvField(String(value));
+}
+
+/**
+ * Format an array of records as CSV with a header row.
+ *
+ * Each record is a plain object. Column order is derived from the keys
+ * of the first record. Missing keys in subsequent records produce empty cells.
+ */
+export function formatCsv(rows: readonly Record<string, unknown>[]): string {
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const first = rows[0];
+  if (first === undefined) {
+    return "";
+  }
+  const columns = Object.keys(first);
+
+  const header = columns.map(escapeCsvField).join(",");
+  const body = rows.map((row) => columns.map((col) => toCsvValue(row[col])).join(","));
+
+  return [header, ...body].join("\n");
+}

--- a/packages/cli/src/formatters/index.test.ts
+++ b/packages/cli/src/formatters/index.test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { formatOutput } from "./index.js";
+
+describe("formatOutput", () => {
+  const rows = [
+    { name: "Alice", age: 30 },
+    { name: "Bob", age: 25 },
+  ];
+
+  it("routes to JSON formatter", () => {
+    const result = formatOutput(rows, "json");
+    expect(JSON.parse(result)).toEqual(rows);
+  });
+
+  it("routes to YAML formatter", () => {
+    const result = formatOutput(rows, "yaml");
+    expect(result).toContain("name: Alice");
+  });
+
+  it("routes to CSV formatter", () => {
+    const result = formatOutput(rows, "csv");
+    expect(result).toContain("name,age");
+    expect(result).toContain("Alice,30");
+  });
+
+  it("routes to table formatter", () => {
+    const result = formatOutput(rows, "table");
+    expect(result).toContain("name");
+    expect(result).toContain("Alice");
+    expect(result).toContain("---");
+  });
+});

--- a/packages/cli/src/formatters/index.ts
+++ b/packages/cli/src/formatters/index.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { OutputFormat } from "../options.js";
+import { formatCsv } from "./csv.js";
+import { formatJson } from "./json.js";
+import { formatTable } from "./table.js";
+import { formatYaml } from "./yaml.js";
+
+export { formatCsv } from "./csv.js";
+export { formatJson } from "./json.js";
+export { formatTable } from "./table.js";
+export { formatYaml } from "./yaml.js";
+
+/**
+ * Route output formatting to the appropriate renderer based on the
+ * selected output format.
+ *
+ * For `table` and `csv`, `data` must be an array of plain objects.
+ * For `json` and `yaml`, any serializable value is accepted.
+ */
+export function formatOutput(data: unknown, format: OutputFormat): string {
+  switch (format) {
+    case "json":
+      return formatJson(data);
+    case "yaml":
+      return formatYaml(data);
+    case "csv":
+      return formatCsv(data as Record<string, unknown>[]);
+    case "table":
+      return formatTable(data as Record<string, unknown>[]);
+  }
+}

--- a/packages/cli/src/formatters/json.test.ts
+++ b/packages/cli/src/formatters/json.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { formatJson } from "./json.js";
+
+describe("formatJson", () => {
+  it("formats an object as indented JSON", () => {
+    const result = formatJson({ name: "Alice", age: 30 });
+    expect(result).toBe('{\n  "name": "Alice",\n  "age": 30\n}');
+  });
+
+  it("formats an array of objects", () => {
+    const result = formatJson([{ id: 1 }, { id: 2 }]);
+    expect(JSON.parse(result)).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it("formats null", () => {
+    expect(formatJson(null)).toBe("null");
+  });
+
+  it("formats a string", () => {
+    expect(formatJson("hello")).toBe('"hello"');
+  });
+});

--- a/packages/cli/src/formatters/json.ts
+++ b/packages/cli/src/formatters/json.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Format data as indented JSON.
+ */
+export function formatJson(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}

--- a/packages/cli/src/formatters/table.test.ts
+++ b/packages/cli/src/formatters/table.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { formatTable } from "./table.js";
+
+describe("formatTable", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatTable([])).toBe("");
+  });
+
+  it("formats a single row with aligned columns", () => {
+    const result = formatTable([{ name: "Alice", age: 30 }]);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3); // header, separator, data
+    expect(lines[0]).toContain("name");
+    expect(lines[0]).toContain("age");
+    expect(lines[1]).toMatch(/^-+\s+-+$/);
+    expect(lines[2]).toContain("Alice");
+    expect(lines[2]).toContain("30");
+  });
+
+  it("pads shorter values to column width", () => {
+    const result = formatTable([
+      { name: "Alice", city: "Paris" },
+      { name: "Bob", city: "Amsterdam" },
+    ]);
+    const lines = result.split("\n");
+    // "Amsterdam" is 9 chars, "Paris" should be padded to 9
+    expect(lines[2]).toContain("Alice");
+    expect(lines[3]).toContain("Bob");
+    // Check alignment: all "city" values start at the same column
+    const header = lines[0] ?? "";
+    const row1 = lines[2] ?? "";
+    const row2 = lines[3] ?? "";
+    const headerCityIdx = header.indexOf("city");
+    const row1CityIdx = row1.indexOf("Paris");
+    const row2CityIdx = row2.indexOf("Amsterdam");
+    expect(row1CityIdx).toBe(headerCityIdx);
+    expect(row2CityIdx).toBe(headerCityIdx);
+  });
+
+  it("handles null and undefined as empty strings", () => {
+    const result = formatTable([{ a: null, b: undefined, c: "ok" }]);
+    const lines = result.split("\n");
+    expect(lines[2]).toContain("ok");
+  });
+
+  it("serializes nested objects as JSON", () => {
+    const result = formatTable([{ data: { nested: true } }]);
+    const lines = result.split("\n");
+    expect(lines[2]).toContain('{"nested":true}');
+  });
+
+  it("widens columns to fit header names", () => {
+    const result = formatTable([{ longheadername: "x" }]);
+    const lines = result.split("\n");
+    // Separator should be at least as wide as the header
+    const separator = lines[1] ?? "";
+    expect(separator.length).toBeGreaterThanOrEqual("longheadername".length);
+  });
+});

--- a/packages/cli/src/formatters/table.ts
+++ b/packages/cli/src/formatters/table.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+function toDisplayValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * Format an array of records as a column-aligned text table.
+ *
+ * Column headers are derived from the keys of the first record.
+ * All columns are left-aligned and padded with spaces.
+ */
+export function formatTable(rows: readonly Record<string, unknown>[]): string {
+  if (rows.length === 0) {
+    return "";
+  }
+
+  const first = rows[0];
+  if (first === undefined) {
+    return "";
+  }
+  const columns = Object.keys(first);
+
+  const cells = rows.map((row) => columns.map((col) => toDisplayValue(row[col])));
+
+  const widths = columns.map((col, i) =>
+    Math.max(col.length, ...cells.map((row) => (row[i] ?? "").length)),
+  );
+
+  const header = columns.map((col, i) => col.padEnd(widths[i] ?? 0)).join("  ");
+  const separator = widths.map((w) => "-".repeat(w)).join("  ");
+  const body = cells.map((row) =>
+    row.map((cell, i) => (cell ?? "").padEnd(widths[i] ?? 0)).join("  "),
+  );
+
+  return [header, separator, ...body].join("\n");
+}

--- a/packages/cli/src/formatters/yaml.test.ts
+++ b/packages/cli/src/formatters/yaml.test.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { formatYaml } from "./yaml.js";
+
+describe("formatYaml", () => {
+  it("formats an object as YAML", () => {
+    const result = formatYaml({ name: "Alice", age: 30 });
+    expect(result).toContain("name: Alice");
+    expect(result).toContain("age: 30");
+  });
+
+  it("formats an array of objects", () => {
+    const result = formatYaml([{ id: 1 }, { id: 2 }]);
+    expect(result).toContain("- id: 1");
+    expect(result).toContain("- id: 2");
+  });
+
+  it("formats null as YAML", () => {
+    const result = formatYaml(null);
+    expect(result.trim()).toBe("null");
+  });
+});

--- a/packages/cli/src/formatters/yaml.ts
+++ b/packages/cli/src/formatters/yaml.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { stringify } from "yaml";
+
+/**
+ * Format data as YAML.
+ */
+export function formatYaml(data: unknown): string {
+  return stringify(data, { lineWidth: 0 });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export { createProgram } from "./program.js";
+
+export {
+  OUTPUT_FORMATS,
+  type GlobalOptions,
+  type OutputFormat,
+  type PaginationOptions,
+} from "./options.js";
+
+export {
+  formatOutput,
+  formatCsv,
+  formatJson,
+  formatTable,
+  formatYaml,
+} from "./formatters/index.js";
+
+export {
+  fetchPage,
+  fetchAllPages,
+  fetchPaginated,
+  type Page,
+  type PaginatedResult,
+  type PaginationMeta,
+} from "./pagination.js";

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Supported output formats for CLI commands.
+ */
+export type OutputFormat = "table" | "json" | "yaml" | "csv";
+
+/**
+ * All valid output format values, used for Commander choices validation.
+ */
+export const OUTPUT_FORMATS: readonly OutputFormat[] = [
+  "table",
+  "json",
+  "yaml",
+  "csv",
+] as const;
+
+/**
+ * Global CLI options parsed from Commander.
+ */
+export interface GlobalOptions {
+  readonly profile?: string | undefined;
+  readonly output: OutputFormat;
+  readonly sandbox?: true | undefined;
+  readonly verbose?: true | undefined;
+  readonly debug?: true | undefined;
+}
+
+/**
+ * Pagination options parsed from Commander.
+ */
+export interface PaginationOptions {
+  readonly page?: number | undefined;
+  readonly perPage?: number | undefined;
+  readonly paginate: boolean;
+}

--- a/packages/cli/src/pagination.test.ts
+++ b/packages/cli/src/pagination.test.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient } from "@qontoctl/core";
+import { fetchPage, fetchAllPages, fetchPaginated } from "./pagination.js";
+import type { PaginationMeta } from "./pagination.js";
+
+function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      ...init,
+    }),
+  );
+}
+
+describe("pagination", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("fetchPage", () => {
+    it("fetches a single page with correct query params", async () => {
+      const items = [{ id: "1" }, { id: "2" }];
+      const meta = makeMeta({ current_page: 1, total_count: 2 });
+      fetchSpy.mockReturnValue(jsonResponse({ transactions: items, meta }));
+
+      const result = await fetchPage(client, "/v2/transactions", "transactions", 1, 100);
+
+      expect(result.items).toEqual(items);
+      expect(result.meta).toEqual(meta);
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("current_page")).toBe("1");
+      expect(url.searchParams.get("per_page")).toBe("100");
+    });
+
+    it("passes additional query params", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({ transactions: [], meta: makeMeta() }),
+      );
+
+      await fetchPage(client, "/v2/transactions", "transactions", 1, 50, {
+        bank_account_id: "abc",
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("bank_account_id")).toBe("abc");
+    });
+
+    it("returns empty items when collection key is missing", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({ meta: makeMeta() }),
+      );
+
+      const result = await fetchPage(client, "/v2/things", "things", 1, 100);
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe("fetchAllPages", () => {
+    it("fetches all pages and combines items", async () => {
+      const page1Items = [{ id: "1" }, { id: "2" }];
+      const page2Items = [{ id: "3" }];
+
+      fetchSpy
+        .mockReturnValueOnce(
+          jsonResponse({
+            items: page1Items,
+            meta: makeMeta({
+              current_page: 1,
+              next_page: 2,
+              total_pages: 2,
+              total_count: 3,
+            }),
+          }),
+        )
+        .mockReturnValueOnce(
+          jsonResponse({
+            items: page2Items,
+            meta: makeMeta({
+              current_page: 2,
+              next_page: null,
+              prev_page: 1,
+              total_pages: 2,
+              total_count: 3,
+            }),
+          }),
+        );
+
+      const result = await fetchAllPages(client, "/v2/items", "items", 100);
+
+      expect(result.items).toEqual([...page1Items, ...page2Items]);
+      expect(result.meta.total_count).toBe(3);
+      expect(result.meta.total_pages).toBe(2);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns single page when there is only one", async () => {
+      const items = [{ id: "1" }];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          items,
+          meta: makeMeta({ total_count: 1 }),
+        }),
+      );
+
+      const result = await fetchAllPages(client, "/v2/items", "items", 100);
+      expect(result.items).toEqual(items);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("fetchPaginated", () => {
+    it("fetches a specific page when --page is set", async () => {
+      const items = [{ id: "3" }];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          items,
+          meta: makeMeta({ current_page: 2, total_pages: 3, total_count: 5 }),
+        }),
+      );
+
+      const result = await fetchPaginated(client, "/v2/items", "items", {
+        page: 2,
+        paginate: true,
+      });
+
+      expect(result.items).toEqual(items);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("current_page")).toBe("2");
+    });
+
+    it("fetches only first page when --no-paginate is set", async () => {
+      const items = [{ id: "1" }, { id: "2" }];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          items,
+          meta: makeMeta({
+            current_page: 1,
+            next_page: 2,
+            total_pages: 3,
+            total_count: 50,
+          }),
+        }),
+      );
+
+      const result = await fetchPaginated(client, "/v2/items", "items", {
+        paginate: false,
+      });
+
+      expect(result.items).toEqual(items);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("auto-paginates all pages by default", async () => {
+      fetchSpy
+        .mockReturnValueOnce(
+          jsonResponse({
+            items: [{ id: "1" }],
+            meta: makeMeta({
+              current_page: 1,
+              next_page: 2,
+              total_pages: 2,
+              total_count: 2,
+            }),
+          }),
+        )
+        .mockReturnValueOnce(
+          jsonResponse({
+            items: [{ id: "2" }],
+            meta: makeMeta({
+              current_page: 2,
+              next_page: null,
+              prev_page: 1,
+              total_pages: 2,
+              total_count: 2,
+            }),
+          }),
+        );
+
+      const result = await fetchPaginated(client, "/v2/items", "items", {
+        paginate: true,
+      });
+
+      expect(result.items).toEqual([{ id: "1" }, { id: "2" }]);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses custom --per-page value", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          items: [{ id: "1" }],
+          meta: makeMeta({ per_page: 25 }),
+        }),
+      );
+
+      await fetchPaginated(client, "/v2/items", "items", {
+        perPage: 25,
+        paginate: false,
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("per_page")).toBe("25");
+    });
+  });
+});

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { HttpClient } from "@qontoctl/core";
+import type { PaginationOptions } from "./options.js";
+
+/**
+ * Pagination metadata returned by the Qonto API.
+ */
+export interface PaginationMeta {
+  readonly current_page: number;
+  readonly next_page: number | null;
+  readonly prev_page: number | null;
+  readonly total_pages: number;
+  readonly total_count: number;
+  readonly per_page: number;
+}
+
+/**
+ * A single page of results from a paginated API endpoint.
+ */
+export interface Page<T> {
+  readonly items: readonly T[];
+  readonly meta: PaginationMeta;
+}
+
+/**
+ * Combined result from fetching one or more pages.
+ */
+export interface PaginatedResult<T> {
+  readonly items: readonly T[];
+  readonly meta: PaginationMeta;
+}
+
+const DEFAULT_PER_PAGE = 100;
+const MAX_PAGES = 1000;
+
+/**
+ * Fetch a single page from a paginated Qonto API endpoint.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param path - The API path (e.g., `/v2/transactions`).
+ * @param collectionKey - The key in the response containing the items array.
+ * @param page - The page number (1-based).
+ * @param perPage - Number of items per page.
+ * @param params - Additional query parameters.
+ */
+export async function fetchPage<T>(
+  client: HttpClient,
+  path: string,
+  collectionKey: string,
+  page: number,
+  perPage: number,
+  params?: Readonly<Record<string, string>>,
+): Promise<Page<T>> {
+  const queryParams: Record<string, string> = {
+    ...params,
+    current_page: String(page),
+    per_page: String(perPage),
+  };
+
+  const response = await client.get<Record<string, unknown>>(path, queryParams);
+  const items = (response[collectionKey] ?? []) as T[];
+  const meta = response["meta"] as PaginationMeta;
+
+  return { items, meta };
+}
+
+/**
+ * Fetch all pages from a paginated endpoint, combining items into a single array.
+ *
+ * @param client - The HTTP client to use for requests.
+ * @param path - The API path.
+ * @param collectionKey - The key in the response containing the items array.
+ * @param perPage - Number of items per page.
+ * @param params - Additional query parameters.
+ */
+export async function fetchAllPages<T>(
+  client: HttpClient,
+  path: string,
+  collectionKey: string,
+  perPage: number,
+  params?: Readonly<Record<string, string>>,
+): Promise<PaginatedResult<T>> {
+  const firstPage = await fetchPage<T>(client, path, collectionKey, 1, perPage, params);
+  const allItems: T[] = [...firstPage.items];
+
+  let currentMeta = firstPage.meta;
+  let pagesFetched = 1;
+  while (currentMeta.next_page !== null) {
+    if (pagesFetched >= MAX_PAGES) {
+      break;
+    }
+    const nextPage = await fetchPage<T>(
+      client,
+      path,
+      collectionKey,
+      currentMeta.next_page,
+      perPage,
+      params,
+    );
+    allItems.push(...nextPage.items);
+    currentMeta = nextPage.meta;
+    pagesFetched++;
+  }
+
+  return {
+    items: allItems,
+    meta: {
+      ...currentMeta,
+      current_page: 1,
+      next_page: null,
+      prev_page: null,
+      total_pages: currentMeta.total_pages,
+      total_count: currentMeta.total_count,
+      per_page: perPage,
+    },
+  };
+}
+
+/**
+ * Fetch data from a paginated endpoint based on CLI pagination options.
+ *
+ * - Default (no flags): auto-paginate across all pages.
+ * - `--page N`: fetch only page N.
+ * - `--no-paginate`: fetch only the first page (disable auto-pagination).
+ *
+ * @param client - The HTTP client to use for requests.
+ * @param path - The API path.
+ * @param collectionKey - The key in the response containing the items array.
+ * @param paginationOptions - Parsed pagination CLI options.
+ * @param params - Additional query parameters.
+ */
+export async function fetchPaginated<T>(
+  client: HttpClient,
+  path: string,
+  collectionKey: string,
+  paginationOptions: PaginationOptions,
+  params?: Readonly<Record<string, string>>,
+): Promise<PaginatedResult<T>> {
+  const perPage = paginationOptions.perPage ?? DEFAULT_PER_PAGE;
+
+  if (paginationOptions.page !== undefined) {
+    const page = await fetchPage<T>(
+      client,
+      path,
+      collectionKey,
+      paginationOptions.page,
+      perPage,
+      params,
+    );
+    return { items: page.items, meta: page.meta };
+  }
+
+  if (!paginationOptions.paginate) {
+    const page = await fetchPage<T>(client, path, collectionKey, 1, perPage, params);
+    return { items: page.items, meta: page.meta };
+  }
+
+  return fetchAllPages<T>(client, path, collectionKey, perPage, params);
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { createProgram } from "./program.js";
+
+describe("createProgram", () => {
+  it("returns a Commander program with name 'qontoctl'", () => {
+    const program = createProgram();
+    expect(program.name()).toBe("qontoctl");
+  });
+
+  describe("global options", () => {
+    it("parses --profile option", () => {
+      const program = createProgram();
+      program.parse(["--profile", "work"], { from: "user" });
+      expect(program.opts()["profile"]).toBe("work");
+    });
+
+    it("parses --output option with valid format", () => {
+      const program = createProgram();
+      program.parse(["--output", "json"], { from: "user" });
+      expect(program.opts()["output"]).toBe("json");
+    });
+
+    it("defaults --output to table", () => {
+      const program = createProgram();
+      program.parse([], { from: "user" });
+      expect(program.opts()["output"]).toBe("table");
+    });
+
+    it("rejects invalid --output format", () => {
+      const program = createProgram();
+      program.exitOverride();
+      expect(() => program.parse(["--output", "xml"], { from: "user" })).toThrow();
+    });
+
+    it("parses --sandbox flag", () => {
+      const program = createProgram();
+      program.parse(["--sandbox"], { from: "user" });
+      expect(program.opts()["sandbox"]).toBe(true);
+    });
+
+    it("parses --verbose flag", () => {
+      const program = createProgram();
+      program.parse(["--verbose"], { from: "user" });
+      expect(program.opts()["verbose"]).toBe(true);
+    });
+
+    it("parses --debug flag", () => {
+      const program = createProgram();
+      program.parse(["--debug"], { from: "user" });
+      expect(program.opts()["debug"]).toBe(true);
+    });
+
+    it("parses short -p alias for --profile", () => {
+      const program = createProgram();
+      program.parse(["-p", "staging"], { from: "user" });
+      expect(program.opts()["profile"]).toBe("staging");
+    });
+
+    it("parses short -o alias for --output", () => {
+      const program = createProgram();
+      program.parse(["-o", "yaml"], { from: "user" });
+      expect(program.opts()["output"]).toBe("yaml");
+    });
+  });
+
+  describe("pagination options", () => {
+    it("parses --page option", () => {
+      const program = createProgram();
+      program.parse(["--page", "3"], { from: "user" });
+      expect(program.opts()["page"]).toBe(3);
+    });
+
+    it("parses --per-page option", () => {
+      const program = createProgram();
+      program.parse(["--per-page", "50"], { from: "user" });
+      expect(program.opts()["perPage"]).toBe(50);
+    });
+
+    it("defaults paginate to true", () => {
+      const program = createProgram();
+      program.parse([], { from: "user" });
+      expect(program.opts()["paginate"]).toBe(true);
+    });
+
+    it("parses --no-paginate flag", () => {
+      const program = createProgram();
+      program.parse(["--no-paginate"], { from: "user" });
+      expect(program.opts()["paginate"]).toBe(false);
+    });
+
+    it("rejects non-integer --page value", () => {
+      const program = createProgram();
+      program.exitOverride();
+      expect(() => program.parse(["--page", "abc"], { from: "user" })).toThrow();
+    });
+
+    it("rejects zero --page value", () => {
+      const program = createProgram();
+      program.exitOverride();
+      expect(() => program.parse(["--page", "0"], { from: "user" })).toThrow();
+    });
+
+    it("rejects negative --per-page value", () => {
+      const program = createProgram();
+      program.exitOverride();
+      expect(() => program.parse(["--per-page", "-5"], { from: "user" })).toThrow();
+    });
+  });
+});

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
+import { OUTPUT_FORMATS } from "./options.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -11,5 +12,43 @@ export function createProgram(): Command {
     .description("The complete CLI & MCP for Qonto")
     .version("0.0.0");
 
+  program
+    .addOption(
+      new Option("-p, --profile <name>", "configuration profile to use"),
+    )
+    .addOption(
+      new Option("-o, --output <format>", "output format")
+        .choices([...OUTPUT_FORMATS])
+        .default("table"),
+    )
+    .addOption(
+      new Option("--sandbox", "use the Qonto sandbox environment"),
+    )
+    .addOption(
+      new Option("--verbose", "enable verbose output"),
+    )
+    .addOption(
+      new Option("--debug", "enable debug output (implies --verbose)"),
+    )
+    .addOption(
+      new Option("--page <number>", "fetch a specific page of results")
+        .argParser(parsePositiveInt),
+    )
+    .addOption(
+      new Option("--per-page <number>", "number of results per page")
+        .argParser(parsePositiveInt),
+    )
+    .addOption(
+      new Option("--no-paginate", "disable auto-pagination"),
+    );
+
   return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       commander:
         specifier: 'catalog:'
         version: 14.0.3
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

- Add global options to Commander program: `--profile`, `--output`, `--sandbox`, `--verbose`, `--debug`
- Implement output formatters: table (column-aligned, default), JSON, YAML, CSV
- Add pagination framework: `--page`, `--per-page`, `--no-paginate` with auto-pagination across all pages
- Export all new types and utilities from `@qontoctl/cli` package entry point
- 52 unit tests covering all new modules

## Acceptance Criteria Coverage

- [x] Global options `--profile`, `--output`, `--sandbox`, `--verbose`, `--debug` are parsed
- [x] `--output json` produces JSON to stdout
- [x] `--output yaml` produces YAML to stdout
- [x] `--output csv` produces CSV for list commands
- [x] `--output table` (default) produces formatted aligned table
- [x] `--page` and `--per-page` fetch a specific page
- [x] `--no-paginate` disables auto-pagination
- [x] Default behavior auto-paginates across all pages

## Test plan

- [x] `pnpm build` passes across all packages
- [x] `pnpm lint` passes with zero errors
- [x] `pnpm test` passes: 52 CLI tests, 76 core tests, 2 umbrella tests
- [x] Commander option parsing tested (valid/invalid formats, short aliases, defaults)
- [x] Each formatter tested independently (empty input, edge cases, escaping)
- [x] Pagination tested with mocked HttpClient (single page, multi-page, auto-paginate)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)