### PR TITLE
(feat) add shell completions for bash, zsh, and fish (#12)

### DIFF
--- a/packages/cli/src/completions/bash.test.ts
+++ b/packages/cli/src/completions/bash.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { generateBashCompletion } from "./bash.js";
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.name("testcli").version("1.0.0");
+  program.addOption(
+    new Option("-o, --output <format>", "output format")
+      .choices(["json", "table"])
+      .default("table"),
+  );
+  program.addOption(
+    new Option("--verbose", "enable verbose output"),
+  );
+
+  const list = program
+    .command("list")
+    .description("list items");
+  list.command("all").description("list all items");
+  list.command("recent").description("list recent items");
+
+  return program;
+}
+
+describe("generateBashCompletion", () => {
+  it("starts with a comment header", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toMatch(/^# bash completion for testcli/);
+  });
+
+  it("defines the completion function", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("_testcli()");
+  });
+
+  it("registers with the complete builtin", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain(
+      "complete -o default -F _testcli testcli",
+    );
+  });
+
+  it("includes top-level commands", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("list");
+  });
+
+  it("includes global option flags", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("--output");
+    expect(script).toContain("-o");
+    expect(script).toContain("--verbose");
+  });
+
+  it("includes --help and --version flags", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("--help");
+    expect(script).toContain("-h");
+    expect(script).toContain("--version");
+    expect(script).toContain("-V");
+  });
+
+  it("completes option choices for --output", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain(
+      'compgen -W "json table" -- "$cur"',
+    );
+  });
+
+  it("includes subcommands for list command", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("all");
+    expect(script).toContain("recent");
+  });
+
+  it("tracks value-taking options to skip their args", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    expect(script).toContain("--output|-o)");
+    expect(script).toContain("skip_next=true");
+  });
+
+  it("generates valid bash syntax", () => {
+    const program = createTestProgram();
+    const script = generateBashCompletion(program);
+    // Basic structural checks
+    expect(script).toContain("COMPREPLY=()");
+    expect(script).toContain("COMP_WORDS[COMP_CWORD]");
+    expect(script).toContain("case");
+    expect(script).toContain("esac");
+  });
+});

--- a/packages/cli/src/completions/bash.ts
+++ b/packages/cli/src/completions/bash.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+
+/**
+ * Generates a bash completion script for the given Commander program.
+ */
+export function generateBashCompletion(program: Command): string {
+  const name = program.name();
+  const lines: string[] = [];
+
+  lines.push(`# bash completion for ${name}`);
+  lines.push("");
+  lines.push(`_${name}() {`);
+  lines.push("  COMPREPLY=()");
+  lines.push('  local cur="${COMP_WORDS[COMP_CWORD]}"');
+  lines.push('  local prev="${COMP_WORDS[COMP_CWORD-1]}"');
+  lines.push("");
+
+  // Complete option values based on previous word
+  const optionChoices = collectOptionChoices(program);
+  if (optionChoices.length > 0) {
+    lines.push('  case "$prev" in');
+    for (const { flags, choices } of optionChoices) {
+      lines.push(`    ${flags.join("|")})`);
+      lines.push(
+        `      COMPREPLY=($(compgen -W "${choices.join(" ")}" -- "$cur"))`,
+      );
+      lines.push("      return");
+      lines.push("      ;;");
+    }
+    lines.push("  esac");
+    lines.push("");
+  }
+
+  // Determine command context by scanning COMP_WORDS
+  const valueTakingFlags = collectValueTakingFlags(program);
+  lines.push('  local cmd="" subcmd=""');
+  lines.push("  local skip_next=false");
+  lines.push("  for ((i=1; i < COMP_CWORD; i++)); do");
+  lines.push("    if $skip_next; then");
+  lines.push("      skip_next=false");
+  lines.push("      continue");
+  lines.push("    fi");
+  lines.push('    case "${COMP_WORDS[i]}" in');
+  if (valueTakingFlags.length > 0) {
+    lines.push(`      ${valueTakingFlags.join("|")})`);
+    lines.push("        skip_next=true");
+    lines.push("        ;;");
+  }
+  lines.push("      -*)");
+  lines.push("        ;;");
+  lines.push("      *)");
+  lines.push('        if [[ -z "$cmd" ]]; then');
+  lines.push('          cmd="${COMP_WORDS[i]}"');
+  lines.push('        elif [[ -z "$subcmd" ]]; then');
+  lines.push('          subcmd="${COMP_WORDS[i]}"');
+  lines.push("        fi");
+  lines.push("        ;;");
+  lines.push("    esac");
+  lines.push("  done");
+  lines.push("");
+
+  // Root-level completions
+  const rootCmds = program.commands.map((c) => c.name());
+  const rootFlags = collectFlags(program, true);
+
+  lines.push('  if [[ -z "$cmd" ]]; then');
+  lines.push('    if [[ "$cur" == -* ]]; then');
+  lines.push(
+    `      COMPREPLY=($(compgen -W "${rootFlags.join(" ")}" -- "$cur"))`,
+  );
+  lines.push("    else");
+  lines.push(
+    `      COMPREPLY=($(compgen -W "${rootCmds.join(" ")}" -- "$cur"))`,
+  );
+  lines.push("    fi");
+  lines.push("    return");
+  lines.push("  fi");
+  lines.push("");
+
+  // Per-subcommand completions
+  if (program.commands.length > 0) {
+    lines.push('  case "$cmd" in');
+    for (const cmd of program.commands) {
+      const subCmds = cmd.commands.map((c) => c.name());
+      const cmdFlags = collectFlags(cmd, false);
+
+      lines.push(`    ${cmd.name()})`);
+      if (subCmds.length > 0) {
+        lines.push('      if [[ -z "$subcmd" ]]; then');
+        if (cmdFlags.length > 0) {
+          lines.push('        if [[ "$cur" == -* ]]; then');
+          lines.push(
+            "          COMPREPLY=" +
+              `($(compgen -W "${cmdFlags.join(" ")}" -- "$cur"))`,
+          );
+          lines.push("        else");
+          lines.push(
+            "          COMPREPLY=" +
+              `($(compgen -W "${subCmds.join(" ")}" -- "$cur"))`,
+          );
+          lines.push("        fi");
+        } else {
+          lines.push(
+            "        COMPREPLY=" +
+              `($(compgen -W "${subCmds.join(" ")}" -- "$cur"))`,
+          );
+        }
+        lines.push("      fi");
+      } else if (cmdFlags.length > 0) {
+        lines.push('      if [[ "$cur" == -* ]]; then');
+        lines.push(
+          "        COMPREPLY=" +
+            `($(compgen -W "${cmdFlags.join(" ")}" -- "$cur"))`,
+        );
+        lines.push("      fi");
+      }
+      lines.push("      ;;");
+    }
+    lines.push("  esac");
+  }
+
+  lines.push("}");
+  lines.push("");
+  lines.push(`complete -o default -F _${name} ${name}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function collectFlags(
+  command: Command,
+  includeVersion: boolean,
+): string[] {
+  const flags: string[] = [];
+  for (const opt of command.options) {
+    if (opt.hidden) continue;
+    if (opt.long) flags.push(opt.long);
+    if (opt.short) flags.push(opt.short);
+  }
+  if (!flags.includes("--help")) {
+    flags.push("--help");
+    flags.push("-h");
+  }
+  if (includeVersion && !flags.includes("--version")) {
+    flags.push("--version");
+    flags.push("-V");
+  }
+  return flags;
+}
+
+function collectValueTakingFlags(root: Command): string[] {
+  const flags: string[] = [];
+  const seen = new Set<string>();
+
+  function walk(cmd: Command): void {
+    for (const opt of cmd.options) {
+      if (opt.required || opt.optional) {
+        for (const flag of [opt.long, opt.short]) {
+          if (flag && !seen.has(flag)) {
+            flags.push(flag);
+            seen.add(flag);
+          }
+        }
+      }
+    }
+    for (const sub of cmd.commands) {
+      walk(sub);
+    }
+  }
+
+  walk(root);
+  return flags;
+}
+
+function collectOptionChoices(
+  root: Command,
+): Array<{ flags: string[]; choices: string[] }> {
+  const result: Array<{ flags: string[]; choices: string[] }> = [];
+  const seen = new Set<string>();
+
+  function walk(cmd: Command): void {
+    for (const opt of cmd.options) {
+      if (opt.argChoices && opt.argChoices.length > 0) {
+        const key = opt.long ?? opt.short ?? "";
+        if (!seen.has(key)) {
+          const flags: string[] = [];
+          if (opt.long) flags.push(opt.long);
+          if (opt.short) flags.push(opt.short);
+          result.push({ flags, choices: [...opt.argChoices] });
+          seen.add(key);
+        }
+      }
+    }
+    for (const sub of cmd.commands) {
+      walk(sub);
+    }
+  }
+
+  walk(root);
+  return result;
+}

--- a/packages/cli/src/completions/fish.test.ts
+++ b/packages/cli/src/completions/fish.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { generateFishCompletion } from "./fish.js";
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.name("testcli").version("1.0.0");
+  program.addOption(
+    new Option("-o, --output <format>", "output format")
+      .choices(["json", "table"])
+      .default("table"),
+  );
+  program.addOption(
+    new Option("--verbose", "enable verbose output"),
+  );
+
+  const list = program
+    .command("list")
+    .description("list items");
+  list.command("all").description("list all items");
+  list.command("recent").description("list recent items");
+
+  return program;
+}
+
+describe("generateFishCompletion", () => {
+  it("starts with a comment header", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toMatch(/^# fish completion for testcli/);
+  });
+
+  it("disables file completions", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain("complete -c testcli -f");
+  });
+
+  it("includes global options with short and long flags", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain("-s o -l output");
+  });
+
+  it("includes option choices with -a flag", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain("-a 'json table'");
+  });
+
+  it("marks value-taking options with -r", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toMatch(/-l output.*-r/);
+  });
+
+  it("includes boolean options without -r", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    const verboseLine = script
+      .split("\n")
+      .find((l) => l.includes("-l verbose"));
+    expect(verboseLine).toBeDefined();
+    expect(verboseLine).not.toContain("-r");
+  });
+
+  it("includes --help and --version", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain("-l help");
+    expect(script).toContain("-l version");
+  });
+
+  it("lists top-level commands with __fish_use_subcommand", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain(
+      "__fish_use_subcommand' -a list",
+    );
+  });
+
+  it("lists subcommands with __fish_seen_subcommand_from", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain(
+      "__fish_seen_subcommand_from list' -a all",
+    );
+    expect(script).toContain(
+      "__fish_seen_subcommand_from list' -a recent",
+    );
+  });
+
+  it("includes descriptions for commands", () => {
+    const program = createTestProgram();
+    const script = generateFishCompletion(program);
+    expect(script).toContain("-d 'list items'");
+    expect(script).toContain("-d 'list all items'");
+  });
+
+  it("escapes single quotes in descriptions", () => {
+    const program = new Command();
+    program.name("testcli");
+    program.addOption(
+      new Option("--test", "it's a test"),
+    );
+    const script = generateFishCompletion(program);
+    expect(script).toContain("it\\'s a test");
+  });
+});

--- a/packages/cli/src/completions/fish.ts
+++ b/packages/cli/src/completions/fish.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+
+/**
+ * Generates a fish completion script for the given Commander program.
+ */
+export function generateFishCompletion(program: Command): string {
+  const name = program.name();
+  const lines: string[] = [];
+
+  lines.push(`# fish completion for ${name}`);
+  lines.push("");
+
+  // Disable file completions by default
+  lines.push(`complete -c ${name} -f`);
+  lines.push("");
+
+  // Global options
+  lines.push("# Global options");
+  for (const opt of program.options) {
+    if (opt.hidden) continue;
+    lines.push(formatFishOption(name, opt));
+  }
+
+  // Always add --help and --version if not present
+  const hasHelp = program.options.some(
+    (o) => o.long === "--help",
+  );
+  if (!hasHelp) {
+    lines.push(
+      `complete -c ${name} -s h -l help -d '${escapeFishString("display help")}'`,
+    );
+  }
+
+  const hasVersion = program.options.some(
+    (o) => o.long === "--version",
+  );
+  if (!hasVersion) {
+    lines.push(
+      `complete -c ${name} -s V -l version -d '${escapeFishString("display version")}'`,
+    );
+  }
+  lines.push("");
+
+  // Top-level commands
+  if (program.commands.length > 0) {
+    lines.push("# Commands");
+    for (const cmd of program.commands) {
+      const desc = escapeFishString(cmd.description());
+      lines.push(
+        `complete -c ${name}` +
+          ` -n '__fish_use_subcommand'` +
+          ` -a ${cmd.name()}` +
+          ` -d '${desc}'`,
+      );
+    }
+    lines.push("");
+
+    // Subcommand-specific completions
+    for (const cmd of program.commands) {
+      const subCmds = cmd.commands;
+      const cmdOpts = cmd.options.filter((o) => !o.hidden);
+
+      if (subCmds.length === 0 && cmdOpts.length === 0) {
+        continue;
+      }
+
+      lines.push(`# ${cmd.name()} subcommands`);
+
+      for (const sub of subCmds) {
+        const desc = escapeFishString(sub.description());
+        lines.push(
+          `complete -c ${name}` +
+            ` -n '__fish_seen_subcommand_from ${cmd.name()}'` +
+            ` -a ${sub.name()}` +
+            ` -d '${desc}'`,
+        );
+      }
+
+      for (const opt of cmdOpts) {
+        lines.push(
+          formatFishOption(
+            name,
+            opt,
+            `__fish_seen_subcommand_from ${cmd.name()}`,
+          ),
+        );
+      }
+
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatFishOption(
+  name: string,
+  opt: {
+    short?: string;
+    long?: string;
+    description: string;
+    required: boolean;
+    optional: boolean;
+    negate: boolean;
+    argChoices?: string[];
+  },
+  condition?: string,
+): string {
+  const parts = [`complete -c ${name}`];
+
+  if (condition) {
+    parts.push(`-n '${condition}'`);
+  }
+
+  if (opt.short) {
+    parts.push(`-s ${opt.short.replace(/^-/, "")}`);
+  }
+  if (opt.long) {
+    parts.push(`-l ${opt.long.replace(/^--/, "")}`);
+  }
+
+  const desc = escapeFishString(opt.description);
+  parts.push(`-d '${desc}'`);
+
+  if (opt.required || opt.optional) {
+    parts.push("-r");
+    if (opt.argChoices && opt.argChoices.length > 0) {
+      parts.push(`-a '${opt.argChoices.join(" ")}'`);
+    }
+  }
+
+  return parts.join(" ");
+}
+
+function escapeFishString(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}

--- a/packages/cli/src/completions/index.ts
+++ b/packages/cli/src/completions/index.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+
+import { generateBashCompletion } from "./bash.js";
+import { generateFishCompletion } from "./fish.js";
+import { generateZshCompletion } from "./zsh.js";
+
+/**
+ * Registers the `completion` command with bash, zsh, and fish
+ * subcommands on the given Commander program.
+ */
+export function registerCompletionCommand(
+  program: Command,
+): void {
+  const completion = program
+    .command("completion")
+    .description("generate shell completion scripts");
+
+  completion
+    .command("bash")
+    .description("generate bash completion script")
+    .action(() => {
+      process.stdout.write(generateBashCompletion(program));
+    });
+
+  completion
+    .command("zsh")
+    .description("generate zsh completion script")
+    .action(() => {
+      process.stdout.write(generateZshCompletion(program));
+    });
+
+  completion
+    .command("fish")
+    .description("generate fish completion script")
+    .action(() => {
+      process.stdout.write(generateFishCompletion(program));
+    });
+}

--- a/packages/cli/src/completions/zsh.test.ts
+++ b/packages/cli/src/completions/zsh.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+
+import { generateZshCompletion } from "./zsh.js";
+
+function createTestProgram(): Command {
+  const program = new Command();
+  program.name("testcli").version("1.0.0");
+  program.addOption(
+    new Option("-o, --output <format>", "output format")
+      .choices(["json", "table"])
+      .default("table"),
+  );
+  program.addOption(
+    new Option("--verbose", "enable verbose output"),
+  );
+
+  const list = program
+    .command("list")
+    .description("list items");
+  list.command("all").description("list all items");
+  list.command("recent").description("list recent items");
+
+  return program;
+}
+
+describe("generateZshCompletion", () => {
+  it("starts with #compdef directive", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toMatch(/^#compdef testcli/);
+  });
+
+  it("defines the completion function", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("_testcli()");
+  });
+
+  it("registers with compdef", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("compdef _testcli testcli");
+  });
+
+  it("includes option specs with _arguments", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("_arguments -s -S");
+  });
+
+  it("formats options with short and long flags", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("{-o,--output}");
+  });
+
+  it("includes option choices in parentheses", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain(":output:(json table)");
+  });
+
+  it("includes boolean options without value spec", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain(
+      "'--verbose[enable verbose output]'",
+    );
+  });
+
+  it("includes --help and --version specs", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("--help");
+    expect(script).toContain("-h");
+    expect(script).toContain("--version");
+    expect(script).toContain("-V");
+  });
+
+  it("lists commands with _describe", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("_describe 'command' commands");
+    expect(script).toContain("'list:list items'");
+  });
+
+  it("includes subcommand completions", () => {
+    const program = createTestProgram();
+    const script = generateZshCompletion(program);
+    expect(script).toContain("1:subcommand:(all recent)");
+  });
+
+  it("escapes special characters in descriptions", () => {
+    const program = new Command();
+    program.name("testcli");
+    program.addOption(
+      new Option(
+        "--test",
+        "uses [brackets] and: colons",
+      ),
+    );
+    const script = generateZshCompletion(program);
+    expect(script).toContain("\\[brackets\\]");
+    expect(script).toContain("and\\: colons");
+  });
+});

--- a/packages/cli/src/completions/zsh.ts
+++ b/packages/cli/src/completions/zsh.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+
+/**
+ * Generates a zsh completion script for the given Commander program.
+ */
+export function generateZshCompletion(program: Command): string {
+  const name = program.name();
+  const lines: string[] = [];
+
+  lines.push(`#compdef ${name}`);
+  lines.push("");
+  lines.push(`_${name}() {`);
+
+  // Root-level arguments
+  const rootArgSpecs = buildArgumentSpecs(program, true);
+  lines.push("  _arguments -s -S \\");
+  for (let i = 0; i < rootArgSpecs.length; i++) {
+    const trailing = i < rootArgSpecs.length - 1 ? " \\" : "";
+    lines.push(`    ${rootArgSpecs[i]}${trailing}`);
+  }
+  lines.push("");
+
+  // Subcommand dispatch
+  const subcommands = program.commands;
+  if (subcommands.length > 0) {
+    lines.push("  case $state in");
+    lines.push("    commands)");
+    lines.push("      local -a commands=(");
+    for (const cmd of subcommands) {
+      const desc = escapeZshDescription(cmd.description());
+      lines.push(`        '${cmd.name()}:${desc}'`);
+    }
+    lines.push("      )");
+    lines.push("      _describe 'command' commands");
+    lines.push("      ;;");
+    lines.push("    args)");
+    lines.push("      case $words[1] in");
+
+    for (const cmd of subcommands) {
+      const subSubs = cmd.commands;
+      const cmdOptSpecs = buildOptionSpecs(cmd, false);
+
+      lines.push(`        ${cmd.name()})`);
+      if (subSubs.length > 0) {
+        const allSpecs = [
+          ...cmdOptSpecs,
+          `'1:subcommand:(${subSubs.map((s) => s.name()).join(" ")})'`,
+        ];
+        lines.push("          _arguments -s -S \\");
+        for (let i = 0; i < allSpecs.length; i++) {
+          const trailing =
+            i < allSpecs.length - 1 ? " \\" : "";
+          lines.push(
+            `            ${allSpecs[i]}${trailing}`,
+          );
+        }
+      } else if (cmdOptSpecs.length > 0) {
+        lines.push("          _arguments -s -S \\");
+        for (let i = 0; i < cmdOptSpecs.length; i++) {
+          const trailing =
+            i < cmdOptSpecs.length - 1 ? " \\" : "";
+          lines.push(
+            `            ${cmdOptSpecs[i]}${trailing}`,
+          );
+        }
+      }
+      lines.push("          ;;");
+    }
+
+    lines.push("      esac");
+    lines.push("      ;;");
+    lines.push("  esac");
+  }
+
+  lines.push("}");
+  lines.push("");
+  lines.push(`compdef _${name} ${name}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function buildOptionSpecs(
+  command: Command,
+  isRoot: boolean,
+): string[] {
+  const specs: string[] = [];
+
+  for (const opt of command.options) {
+    if (opt.hidden) continue;
+    specs.push(formatZshOption(opt));
+  }
+
+  // Add --help
+  const hasHelp = command.options.some(
+    (o) => o.long === "--help",
+  );
+  if (!hasHelp) {
+    specs.push("'(- *)'{-h,--help}'[display help]'");
+  }
+
+  // Add --version for root only
+  if (isRoot) {
+    const hasVersion = command.options.some(
+      (o) => o.long === "--version",
+    );
+    if (!hasVersion) {
+      specs.push(
+        "'(- *)'{-V,--version}'[display version]'",
+      );
+    }
+  }
+
+  return specs;
+}
+
+function buildArgumentSpecs(
+  command: Command,
+  isRoot: boolean,
+): string[] {
+  const specs = buildOptionSpecs(command, isRoot);
+
+  // Add subcommand argument if command has subcommands
+  if (command.commands.length > 0) {
+    specs.push("'1:command:->commands'");
+    specs.push("'*::arg:->args'");
+  }
+
+  return specs;
+}
+
+function formatZshOption(opt: {
+  short?: string;
+  long?: string;
+  description: string;
+  required: boolean;
+  optional: boolean;
+  negate: boolean;
+  argChoices?: string[];
+}): string {
+  const desc = escapeZshDescription(opt.description);
+  const takesValue = opt.required || opt.optional;
+
+  let valueSuffix = "";
+  if (takesValue) {
+    const argName = opt.long
+      ? opt.long.replace(/^--/, "")
+      : "value";
+    if (opt.argChoices && opt.argChoices.length > 0) {
+      valueSuffix = `:${argName}:(${opt.argChoices.join(" ")})`;
+    } else {
+      valueSuffix = `:${argName}:`;
+    }
+  }
+
+  if (opt.short && opt.long) {
+    const exclusion = `(${opt.short} ${opt.long})`;
+    return (
+      `'${exclusion}'` +
+      `{${opt.short},${opt.long}}` +
+      `'[${desc}]${valueSuffix}'`
+    );
+  }
+
+  const flag = opt.long ?? opt.short ?? "";
+  return `'${flag}[${desc}]${valueSuffix}'`;
+}
+
+function escapeZshDescription(desc: string): string {
+  return desc
+    .replace(/\\/g, "\\\\")
+    .replace(/'/g, "'\\''")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]")
+    .replace(/:/g, "\\:");
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, Option } from "commander";
+import { registerCompletionCommand } from "./completions/index.js";
 import { OUTPUT_FORMATS } from "./options.js";
 
 export function createProgram(): Command {
@@ -41,6 +42,12 @@ export function createProgram(): Command {
     .addOption(
       new Option("--no-paginate", "disable auto-pagination"),
     );
+
+  registerCompletionCommand(program);
+
+  program.action(() => {
+    program.outputHelp();
+  });
 
   return program;
 }


### PR DESCRIPTION
## Summary

- Add `qontoctl completion bash|zsh|fish` commands that generate shell completion scripts
- Completion generators walk the Commander program tree to dynamically produce shell-specific scripts
- Add default action to program root to show help when no subcommand is given

## Implementation

New files in `packages/cli/src/completions/`:
- `bash.ts` — bash completion generator using `compgen`/`complete`
- `zsh.ts` — zsh completion generator using `_arguments`/`compdef`
- `fish.ts` — fish completion generator using `complete -c`
- `index.ts` — registers the `completion` command with subcommands

## Test plan

- [x] Unit tests for all three generators (bash, zsh, fish) verifying script structure, commands, options, and choices
- [x] Build passes across all packages
- [x] Lint passes with zero errors
- [x] All 84 CLI tests pass (including 32 new completion tests)
- [x] License check passes

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)