### PR TITLE
(feat) add profile management commands (#6)

### DIFF
--- a/packages/cli/src/commands/profile/add.test.ts
+++ b/packages/cli/src/commands/profile/add.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createProgram } from "../../program.js";
+import { registerProfileCommands } from "./index.js";
+
+let mockHomeDir = "";
+let mockQuestionResponses: string[] = [];
+
+vi.mock("node:os", async (importOriginal) => {
+  const os = await importOriginal<typeof import("node:os")>();
+  return { ...os, homedir: () => mockHomeDir };
+});
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: () => ({
+    question: vi.fn().mockImplementation(() => {
+      const response = mockQuestionResponses.shift();
+      return Promise.resolve(response ?? "");
+    }),
+    close: vi.fn(),
+  }),
+}));
+
+describe("profile add", () => {
+  let testHome: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    mockHomeDir = testHome;
+    mockQuestionResponses = [];
+    await mkdir(testHome, { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it("creates a new profile yaml file", async () => {
+    mockQuestionResponses = ["my-org", "sk_test_12345678"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "work"], { from: "user" });
+
+    const path = join(testHome, ".qontoctl", "work.yaml");
+    const content = await readFile(path, "utf-8");
+    expect(content).toContain("organization_slug: my-org");
+    expect(content).toContain("secret_key: sk_test_12345678");
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Profile "work" created'));
+  });
+
+  it("creates config directory if it does not exist", async () => {
+    mockQuestionResponses = ["org-slug", "secret-key-value"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "new-profile"], { from: "user" });
+
+    const path = join(testHome, ".qontoctl", "new-profile.yaml");
+    const content = await readFile(path, "utf-8");
+    expect(content).toContain("organization_slug: org-slug");
+  });
+
+  it("refuses to overwrite existing profile", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "existing.yaml"), "api-key:\n  organization_slug: org\n  secret_key: key\n");
+
+    mockQuestionResponses = ["new-org", "new-key"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "existing"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Profile "existing" already exists. Remove it first to recreate.',
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects empty organization slug", async () => {
+    mockQuestionResponses = ["", "some-key"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Organization slug cannot be empty.");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects empty secret key", async () => {
+    mockQuestionResponses = ["my-org", ""];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Secret key cannot be empty.");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createInterface } from "node:readline/promises";
+import { stringify as stringifyYaml } from "yaml";
+import type { Command } from "commander";
+import { loadConfigFile } from "@qontoctl/core";
+
+const CONFIG_DIR = ".qontoctl";
+
+/**
+ * Register the `profile add <name>` subcommand.
+ */
+export function registerAddCommand(parent: Command): void {
+  parent
+    .command("add <name>")
+    .description("create a new profile interactively")
+    .action(async (name: string) => {
+      await addProfile(name);
+    });
+}
+
+async function addProfile(name: string): Promise<void> {
+  if (/[/\\]/.test(name) || name.includes("..")) {
+    console.error("Invalid profile name: must not contain path separators or '..'.");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Check if profile already exists
+  const { raw } = await loadConfigFile({ profile: name });
+  if (raw !== undefined) {
+    console.error(`Profile "${name}" already exists. Remove it first to recreate.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+
+  try {
+    const organizationSlug = await rl.question("Organization slug: ");
+    const secretKey = await rl.question("Secret key: ");
+
+    if (organizationSlug.trim() === "") {
+      console.error("Organization slug cannot be empty.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (secretKey.trim() === "") {
+      console.error("Secret key cannot be empty.");
+      process.exitCode = 1;
+      return;
+    }
+
+    const config = {
+      "api-key": {
+        organization_slug: organizationSlug.trim(),
+        secret_key: secretKey.trim(),
+      },
+    };
+
+    const dir = join(homedir(), CONFIG_DIR);
+    await mkdir(dir, { recursive: true });
+
+    const path = join(dir, `${name}.yaml`);
+    await writeFile(path, stringifyYaml(config), "utf-8");
+
+    console.log(`Profile "${name}" created at ${path}`);
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/cli/src/commands/profile/index.ts
+++ b/packages/cli/src/commands/profile/index.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { registerListCommand } from "./list.js";
+import { registerShowCommand } from "./show.js";
+import { registerAddCommand } from "./add.js";
+import { registerRemoveCommand } from "./remove.js";
+import { registerTestCommand } from "./test.js";
+
+/**
+ * Register all `profile` subcommands on the given parent command.
+ */
+export function registerProfileCommands(program: Command): void {
+  const profile = program.command("profile").description("manage credential profiles");
+
+  registerListCommand(profile);
+  registerShowCommand(profile);
+  registerAddCommand(profile);
+  registerRemoveCommand(profile);
+  registerTestCommand(profile);
+}

--- a/packages/cli/src/commands/profile/list.test.ts
+++ b/packages/cli/src/commands/profile/list.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createProgram } from "../../program.js";
+import { registerProfileCommands } from "./index.js";
+
+let mockHomeDir = "";
+
+vi.mock("node:os", async (importOriginal) => {
+  const os = await importOriginal<typeof import("node:os")>();
+  return { ...os, homedir: () => mockHomeDir };
+});
+
+describe("profile list", () => {
+  let testHome: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    mockHomeDir = testHome;
+    await mkdir(testHome, { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it("shows 'No profiles found' when config dir does not exist", async () => {
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("No profiles found.");
+  });
+
+  it("shows 'No profiles found' when config dir is empty", async () => {
+    await mkdir(join(testHome, ".qontoctl"), { recursive: true });
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "list"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("No profiles found.");
+  });
+
+  it("lists profile names from yaml files", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "work.yaml"), "api-key:\n  organization_slug: org\n  secret_key: key\n");
+    await writeFile(join(configDir, "personal.yaml"), "api-key:\n  organization_slug: org2\n  secret_key: key2\n");
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "list"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("personal");
+    expect(output).toContain("work");
+  });
+
+  it("ignores non-yaml files", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "work.yaml"), "api-key:\n  organization_slug: org\n  secret_key: key\n");
+    await writeFile(join(configDir, "notes.txt"), "some notes");
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "list"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("work");
+    expect(output).not.toContain("notes");
+  });
+
+  it("outputs json format with --output json", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "staging.yaml"), "api-key:\n  organization_slug: org\n  secret_key: key\n");
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "profile", "list"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed: unknown = JSON.parse(output);
+    expect(parsed).toEqual([{ name: "staging" }]);
+  });
+});

--- a/packages/cli/src/commands/profile/list.ts
+++ b/packages/cli/src/commands/profile/list.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { Command } from "commander";
+import { formatOutput } from "../../formatters/index.js";
+import type { GlobalOptions } from "../../options.js";
+
+const CONFIG_DIR = ".qontoctl";
+const YAML_EXT = ".yaml";
+
+/**
+ * Register the `profile list` subcommand.
+ */
+export function registerListCommand(parent: Command): void {
+  parent
+    .command("list")
+    .description("list named profiles from ~/.qontoctl/")
+    .action(async (_options: unknown, cmd: Command) => {
+      const globalOpts = cmd.optsWithGlobals<GlobalOptions>();
+      await listProfiles(globalOpts);
+    });
+}
+
+async function listProfiles(options: GlobalOptions): Promise<void> {
+  const dir = join(homedir(), CONFIG_DIR);
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      entries = [];
+    } else {
+      throw error;
+    }
+  }
+
+  const profiles = entries
+    .filter((name) => name.endsWith(YAML_EXT))
+    .map((name) => name.slice(0, -YAML_EXT.length))
+    .sort()
+    .map((name) => ({ name }));
+
+  if (profiles.length === 0) {
+    console.log("No profiles found.");
+    return;
+  }
+
+  console.log(formatOutput(profiles, options.output));
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/packages/cli/src/commands/profile/remove.test.ts
+++ b/packages/cli/src/commands/profile/remove.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createProgram } from "../../program.js";
+import { registerProfileCommands } from "./index.js";
+
+let mockHomeDir = "";
+let mockQuestionResponses: string[] = [];
+
+vi.mock("node:os", async (importOriginal) => {
+  const os = await importOriginal<typeof import("node:os")>();
+  return { ...os, homedir: () => mockHomeDir };
+});
+
+vi.mock("node:readline/promises", () => ({
+  createInterface: () => ({
+    question: vi.fn().mockImplementation(() => {
+      const response = mockQuestionResponses.shift();
+      return Promise.resolve(response ?? "");
+    }),
+    close: vi.fn(),
+  }),
+}));
+
+describe("profile remove", () => {
+  let testHome: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    mockHomeDir = testHome;
+    mockQuestionResponses = [];
+    await mkdir(testHome, { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it("shows error when profile does not exist", async () => {
+    mockQuestionResponses = ["yes"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "remove", "nonexistent"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Profile "nonexistent" not found.');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("removes profile file when confirmed", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    const filePath = join(configDir, "work.yaml");
+    await writeFile(filePath, "api-key:\n  organization_slug: org\n  secret_key: key\n");
+
+    mockQuestionResponses = ["yes"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "remove", "work"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith('Profile "work" removed.');
+    await expect(access(filePath)).rejects.toThrow();
+  });
+
+  it("aborts when user does not confirm", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    const filePath = join(configDir, "work.yaml");
+    await writeFile(filePath, "api-key:\n  organization_slug: org\n  secret_key: key\n");
+
+    mockQuestionResponses = ["no"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "remove", "work"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Aborted.");
+    // File should still exist
+    await expect(access(filePath)).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/profile/remove.ts
+++ b/packages/cli/src/commands/profile/remove.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createInterface } from "node:readline/promises";
+import type { Command } from "commander";
+import { loadConfigFile } from "@qontoctl/core";
+
+const CONFIG_DIR = ".qontoctl";
+
+/**
+ * Register the `profile remove <name>` subcommand.
+ */
+export function registerRemoveCommand(parent: Command): void {
+  parent
+    .command("remove <name>")
+    .description("delete a named profile (with confirmation)")
+    .action(async (name: string) => {
+      await removeProfile(name);
+    });
+}
+
+async function removeProfile(name: string): Promise<void> {
+  if (/[/\\]/.test(name) || name.includes("..")) {
+    console.error("Invalid profile name: must not contain path separators or '..'.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const { raw } = await loadConfigFile({ profile: name });
+
+  if (raw === undefined) {
+    console.error(`Profile "${name}" not found.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+
+  try {
+    const answer = await rl.question(`Remove profile "${name}"? (yes/no): `);
+
+    if (answer.trim().toLowerCase() !== "yes") {
+      console.log("Aborted.");
+      return;
+    }
+
+    const path = join(homedir(), CONFIG_DIR, `${name}.yaml`);
+    await unlink(path);
+
+    console.log(`Profile "${name}" removed.`);
+  } finally {
+    rl.close();
+  }
+}

--- a/packages/cli/src/commands/profile/show.test.ts
+++ b/packages/cli/src/commands/profile/show.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createProgram } from "../../program.js";
+import { registerProfileCommands } from "./index.js";
+
+let mockHomeDir = "";
+
+vi.mock("node:os", async (importOriginal) => {
+  const os = await importOriginal<typeof import("node:os")>();
+  return { ...os, homedir: () => mockHomeDir };
+});
+
+describe("profile show", () => {
+  let testHome: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    mockHomeDir = testHome;
+    await mkdir(testHome, { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it("shows error when profile does not exist", async () => {
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "show", "nonexistent"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Profile "nonexistent" not found.');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("shows profile details with redacted secret key", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "work.yaml"),
+      "api-key:\n  organization_slug: my-org-slug\n  secret_key: sk_test_abcdef1234\n",
+    );
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "show", "work"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("work");
+    expect(output).toContain("my-org-slug");
+    expect(output).toContain("****1234");
+    expect(output).not.toContain("sk_test_abcdef1234");
+  });
+
+  it("outputs json format with --output json", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "dev.yaml"),
+      "api-key:\n  organization_slug: dev-org\n  secret_key: sk_dev_xyz789\n",
+    );
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "profile", "show", "dev"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>[];
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      name: "dev",
+      organization_slug: "dev-org",
+      secret_key: "****z789",
+    });
+  });
+
+  it("redacts short secret keys completely", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "short.yaml"), "api-key:\n  organization_slug: org\n  secret_key: abc\n");
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "profile", "show", "short"], { from: "user" });
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>[];
+    expect(parsed[0]?.["secret_key"]).toBe("****");
+  });
+});

--- a/packages/cli/src/commands/profile/show.ts
+++ b/packages/cli/src/commands/profile/show.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { loadConfigFile, validateConfig } from "@qontoctl/core";
+import { formatOutput } from "../../formatters/index.js";
+import type { GlobalOptions } from "../../options.js";
+
+/**
+ * Register the `profile show <name>` subcommand.
+ */
+export function registerShowCommand(parent: Command): void {
+  parent
+    .command("show <name>")
+    .description("show profile details with secrets redacted")
+    .action(async (name: string, _options: unknown, cmd: Command) => {
+      const globalOpts = cmd.optsWithGlobals<GlobalOptions>();
+      await showProfile(name, globalOpts);
+    });
+}
+
+async function showProfile(name: string, options: GlobalOptions): Promise<void> {
+  const { raw, path } = await loadConfigFile({ profile: name });
+
+  if (raw === undefined) {
+    console.error(`Profile "${name}" not found.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { config, warnings, errors } = validateConfig(raw);
+
+  for (const warning of warnings) {
+    console.error(`Warning: ${warning}`);
+  }
+
+  for (const error of errors) {
+    console.error(`Error: ${error}`);
+  }
+
+  if (errors.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  const details = {
+    name,
+    path: path ?? "unknown",
+    organization_slug: config.apiKey?.organizationSlug ?? "",
+    secret_key: redactSecret(config.apiKey?.secretKey ?? ""),
+  };
+
+  console.log(formatOutput([details], options.output));
+}
+
+/**
+ * Redact a secret key, showing only the last 4 characters.
+ */
+function redactSecret(secret: string): string {
+  if (secret.length <= 4) {
+    return "****";
+  }
+  return "****" + secret.slice(-4);
+}

--- a/packages/cli/src/commands/profile/test.test.ts
+++ b/packages/cli/src/commands/profile/test.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { createProgram } from "../../program.js";
+import { registerProfileCommands } from "./index.js";
+
+let mockHomeDir = "";
+
+vi.mock("node:os", async (importOriginal) => {
+  const os = await importOriginal<typeof import("node:os")>();
+  return { ...os, homedir: () => mockHomeDir };
+});
+
+describe("profile test", () => {
+  let testHome: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
+    mockHomeDir = testHome;
+    await mkdir(testHome, { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    process.exitCode = undefined;
+    await rm(testHome, { recursive: true, force: true });
+  });
+
+  it("reports success with organization name", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "work.yaml"),
+      "api-key:\n  organization_slug: my-org\n  secret_key: sk_test_1234\n",
+    );
+
+    fetchSpy.mockReturnValue(
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            organization: { name: "My Company", slug: "my-company-1234" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--profile", "work", "profile", "test"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Success: connected to organization "My Company" (my-company-1234)',
+    );
+  });
+
+  it("reports failure on API error", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "bad.yaml"),
+      "api-key:\n  organization_slug: bad-org\n  secret_key: sk_invalid\n",
+    );
+
+    fetchSpy.mockReturnValue(
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            errors: [{ code: "unauthorized", detail: "Invalid credentials" }],
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--profile", "bad", "profile", "test"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("API error (401)"));
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports failure when no config found", async () => {
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["--profile", "nonexistent", "profile", "test"], { from: "user" });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Configuration error"));
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/profile/test.ts
+++ b/packages/cli/src/commands/profile/test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import {
+  type HttpClientLogger,
+  HttpClient,
+  resolveConfig,
+  buildApiKeyAuthorization,
+  ConfigError,
+  AuthError,
+  QontoApiError,
+  QontoRateLimitError,
+} from "@qontoctl/core";
+import type { GlobalOptions } from "../../options.js";
+
+const PRODUCTION_BASE_URL = "https://thirdparty.qonto.com";
+const SANDBOX_BASE_URL = "https://thirdparty-sandbox.staging.qonto.co";
+
+interface OrganizationResponse {
+  readonly organization: {
+    readonly name: string;
+    readonly slug: string;
+  };
+}
+
+/**
+ * Register the `profile test` subcommand.
+ */
+export function registerTestCommand(parent: Command): void {
+  parent
+    .command("test")
+    .description("test credentials via GET /v2/organization")
+    .action(async (_options: unknown, cmd: Command) => {
+      const globalOpts = cmd.optsWithGlobals<GlobalOptions>();
+      await testProfile(globalOpts);
+    });
+}
+
+async function testProfile(options: GlobalOptions): Promise<void> {
+  let logger: HttpClientLogger | undefined;
+  if (options.debug === true) {
+    logger = {
+      verbose: (msg: string) => console.error(`[verbose] ${msg}`),
+      debug: (msg: string) => console.error(`[debug] ${msg}`),
+    };
+  } else if (options.verbose === true) {
+    logger = {
+      verbose: (msg: string) => console.error(`[verbose] ${msg}`),
+      debug: () => {},
+    };
+  }
+
+  try {
+    const { config } = await resolveConfig({ profile: options.profile });
+
+    if (config.apiKey === undefined) {
+      console.error("Configuration error: no credentials found.");
+      process.exitCode = 1;
+      return;
+    }
+
+    const authorization = buildApiKeyAuthorization(config.apiKey);
+
+    const client = new HttpClient({
+      baseUrl: options.sandbox === true ? SANDBOX_BASE_URL : PRODUCTION_BASE_URL,
+      authorization,
+      logger,
+    });
+
+    const response = await client.get<OrganizationResponse>("/v2/organization");
+    const { name, slug } = response.organization;
+    console.log(`Success: connected to organization "${name}" (${slug})`);
+  } catch (error: unknown) {
+    if (error instanceof ConfigError) {
+      console.error(`Configuration error: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (error instanceof AuthError) {
+      console.error(`Authentication failed: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (error instanceof QontoApiError) {
+      console.error(`API error (${error.status}): ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (error instanceof QontoRateLimitError) {
+      console.error(`Rate limited: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,8 @@
 
 export { createProgram } from "./program.js";
 
+export { registerProfileCommands } from "./commands/profile/index.js";
+
 export {
   OUTPUT_FORMATS,
   type GlobalOptions,

--- a/packages/qontoctl/src/cli.ts
+++ b/packages/qontoctl/src/cli.ts
@@ -7,6 +7,7 @@ import {
   createProgram,
   createLabelCommand,
   createMembershipCommand,
+  registerProfileCommands,
   registerStatementCommands,
 } from "@qontoctl/cli";
 import { runStdioServer } from "@qontoctl/mcp/stdio";
@@ -15,6 +16,7 @@ const program = createProgram();
 
 program.addCommand(createLabelCommand());
 program.addCommand(createMembershipCommand());
+registerProfileCommands(program);
 registerStatementCommands(program);
 
 program


### PR DESCRIPTION
## Summary

- Implements 5 profile management subcommands: `profile list`, `profile show <name>`, `profile add <name>`, `profile remove <name>`, and `profile test` (#6)
- Commands are registered in the umbrella `@qontoctl/cli` package and support all global output format options (table/json/yaml/csv)
- `profile test` validates credentials by calling the Qonto `GET /v2/organization` endpoint
- Includes path traversal protection, confirmation prompts, and secret key redaction

## Test plan

- [x] 20 new unit tests across 5 test files covering all commands
- [x] Build passes across all packages
- [x] 155 total tests pass (72 in CLI package)
- [x] ESLint clean
- [x] License check passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)