### PR TITLE
Tests: Shell completions (#40)

### DIFF
--- a/packages/e2e/src/completions/bash.e2e.test.ts
+++ b/packages/e2e/src/completions/bash.e2e.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function hasBash(): boolean {
+  try {
+    execFileSync("bash", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!hasBash())("bash completion (e2e)", () => {
+  let tempDir: string;
+  let completionScript: string;
+  let scriptPath: string;
+
+  beforeAll(() => {
+    completionScript = execFileSync("node", [CLI_PATH, "completion", "bash"], {
+      encoding: "utf-8",
+    });
+    tempDir = mkdtempSync(join(tmpdir(), "qontoctl-bash-e2e-"));
+    scriptPath = join(tempDir, "completion.bash");
+    writeFileSync(scriptPath, completionScript);
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Simulate bash completion by setting COMP_WORDS and COMP_CWORD,
+   * calling the _qontoctl function, and returning COMPREPLY entries.
+   */
+  function complete(words: string[]): string[] {
+    const compWords = words.map((w) => `"${w}"`).join(" ");
+    const cword = words.length - 1;
+    const testScript = [
+      `source "${scriptPath}"`,
+      `COMP_WORDS=(${compWords})`,
+      `COMP_CWORD=${String(cword)}`,
+      "_qontoctl",
+      'printf "%s\\n" "${COMPREPLY[@]}"',
+    ].join("\n");
+
+    const result = execFileSync("bash", ["-c", testScript], {
+      encoding: "utf-8",
+    });
+    return result.trim().split("\n").filter(Boolean);
+  }
+
+  it("generates a sourceable script without errors", () => {
+    execFileSync("bash", ["-c", `source "${scriptPath}"`], {
+      encoding: "utf-8",
+    });
+  });
+
+  it("completes top-level commands when no input given", () => {
+    const completions = complete(["qontoctl", ""]);
+    expect(completions).toContain("completion");
+    expect(completions).toContain("org");
+    expect(completions).toContain("account");
+    expect(completions).toContain("transaction");
+    expect(completions).toContain("profile");
+  });
+
+  it("completes top-level options when dash prefix typed", () => {
+    const completions = complete(["qontoctl", "-"]);
+    expect(completions).toContain("--output");
+    expect(completions).toContain("--verbose");
+    expect(completions).toContain("--help");
+    expect(completions).toContain("--version");
+  });
+
+  it("completes subcommands for a command", () => {
+    const completions = complete(["qontoctl", "completion", ""]);
+    expect(completions).toContain("bash");
+    expect(completions).toContain("zsh");
+    expect(completions).toContain("fish");
+  });
+
+  it("completes option choices for --output", () => {
+    const completions = complete(["qontoctl", "--output", ""]);
+    expect(completions).toContain("json");
+    expect(completions).toContain("table");
+    expect(completions).toContain("yaml");
+    expect(completions).toContain("csv");
+  });
+});

--- a/packages/e2e/src/completions/fish.e2e.test.ts
+++ b/packages/e2e/src/completions/fish.e2e.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function hasFish(): boolean {
+  try {
+    execFileSync("fish", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!hasFish())("fish completion (e2e)", () => {
+  let tempDir: string;
+  let completionScript: string;
+  let scriptPath: string;
+
+  beforeAll(() => {
+    completionScript = execFileSync("node", [CLI_PATH, "completion", "fish"], {
+      encoding: "utf-8",
+    });
+    tempDir = mkdtempSync(join(tmpdir(), "qontoctl-fish-e2e-"));
+    scriptPath = join(tempDir, "qontoctl.fish");
+    writeFileSync(scriptPath, completionScript);
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("generates a sourceable script without errors", () => {
+    execFileSync("fish", ["-c", `source "${scriptPath}"`], {
+      encoding: "utf-8",
+    });
+  });
+
+  it("completes top-level commands", () => {
+    const result = execFileSync(
+      "fish",
+      [
+        "-c",
+        [
+          `source "${scriptPath}"`,
+          'complete --do-complete "qontoctl "',
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+    const completions = result.trim().split("\n").map((l) => l.split("\t")[0] ?? "");
+    expect(completions).toContain("completion");
+    expect(completions).toContain("org");
+    expect(completions).toContain("account");
+    expect(completions).toContain("transaction");
+    expect(completions).toContain("profile");
+  });
+
+  it("completes subcommands for completion command", () => {
+    const result = execFileSync(
+      "fish",
+      [
+        "-c",
+        [
+          `source "${scriptPath}"`,
+          'complete --do-complete "qontoctl completion "',
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+    const completions = result.trim().split("\n").map((l) => l.split("\t")[0] ?? "");
+    expect(completions).toContain("bash");
+    expect(completions).toContain("zsh");
+    expect(completions).toContain("fish");
+  });
+
+  it("disables file completions by default", () => {
+    expect(completionScript).toContain("complete -c qontoctl -f");
+  });
+
+  it("includes global options", () => {
+    expect(completionScript).toContain("-l output");
+    expect(completionScript).toContain("-l verbose");
+    expect(completionScript).toContain("-l help");
+    expect(completionScript).toContain("-l version");
+  });
+});

--- a/packages/e2e/src/completions/zsh.e2e.test.ts
+++ b/packages/e2e/src/completions/zsh.e2e.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function hasZsh(): boolean {
+  try {
+    execFileSync("zsh", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!hasZsh())("zsh completion (e2e)", () => {
+  let tempDir: string;
+  let completionScript: string;
+  let scriptPath: string;
+
+  beforeAll(() => {
+    completionScript = execFileSync("node", [CLI_PATH, "completion", "zsh"], {
+      encoding: "utf-8",
+    });
+    tempDir = mkdtempSync(join(tmpdir(), "qontoctl-zsh-e2e-"));
+    scriptPath = join(tempDir, "_qontoctl");
+    writeFileSync(scriptPath, completionScript);
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("generates a sourceable script without errors", () => {
+    // zsh -f disables all user startup files; source the completion script
+    // and verify it loads without syntax errors
+    execFileSync(
+      "zsh",
+      [
+        "-f",
+        "-c",
+        [
+          "autoload -Uz compinit",
+          `fpath=("${tempDir}" $fpath)`,
+          "compinit -u",
+          `source "${scriptPath}"`,
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  it("defines the _qontoctl completion function", () => {
+    const result = execFileSync(
+      "zsh",
+      [
+        "-f",
+        "-c",
+        [
+          "autoload -Uz compinit",
+          `fpath=("${tempDir}" $fpath)`,
+          "compinit -u",
+          `source "${scriptPath}"`,
+          'whence -w _qontoctl | grep "function"',
+        ].join("; "),
+      ],
+      { encoding: "utf-8" },
+    );
+    expect(result).toContain("function");
+  });
+
+  it("starts with the #compdef directive", () => {
+    expect(completionScript).toMatch(/^#compdef qontoctl/);
+  });
+
+  it("registers compdef for qontoctl", () => {
+    expect(completionScript).toContain("compdef _qontoctl qontoctl");
+  });
+
+  it("includes top-level command descriptions", () => {
+    expect(completionScript).toContain("completion:");
+    expect(completionScript).toContain("org:");
+    expect(completionScript).toContain("account:");
+    expect(completionScript).toContain("transaction:");
+    expect(completionScript).toContain("profile:");
+  });
+
+  it("includes option definitions for output format", () => {
+    expect(completionScript).toContain("--output");
+    expect(completionScript).toContain("--verbose");
+  });
+});

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.e2e.test.ts"],
+    exclude: ["**/node_modules/**", "**/dist/**"],
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Add E2E tests for shell completion generation (bash, zsh, fish)
- Create `vitest.e2e.config.ts` for the E2E test runner configuration
- Tests run the actual `qontoctl` CLI binary, generate completion scripts, then verify they work when sourced in real shells

## Test approach

| Shell | Method | Tests |
|-------|--------|-------|
| **bash** | Source script, simulate `COMP_WORDS`/`COMP_CWORD`, call `_qontoctl`, read `COMPREPLY` | 5 tests: sourcing, top-level commands, options, subcommands, option choices |
| **zsh** | Source script with `compinit`, verify function definition and `compdef` registration | 6 tests: sourcing, function existence, `#compdef` directive, `compdef` registration, commands, options |
| **fish** | Source script, use `complete --do-complete` for programmatic verification | 5 tests: sourcing, top-level commands, subcommands, file completion disabled, global options |

All tests skip gracefully when the target shell is not installed (e.g., fish on macOS CI, all shells on Windows).

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test:e2e` — bash 5/5 pass, zsh 6/6 pass, fish 5/5 skipped (not installed locally)
- [ ] CI passes on all 3 OS matrix entries

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)