### PR TITLE
(test) add profile and config system tests (#31)

### DIFF
--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -88,6 +88,32 @@ describe("applyEnvOverlay", () => {
     });
   });
 
+  it("defaults secretKey to empty string when only organization_slug env var is set and no existing apiKey", () => {
+    const result = applyEnvOverlay(
+      {},
+      {
+        env: { QONTOCTL_ORGANIZATION_SLUG: "env-org" },
+      },
+    );
+    expect(result.apiKey).toEqual({
+      organizationSlug: "env-org",
+      secretKey: "",
+    });
+  });
+
+  it("defaults organizationSlug to empty string when only secret_key env var is set and no existing apiKey", () => {
+    const result = applyEnvOverlay(
+      {},
+      {
+        env: { QONTOCTL_SECRET_KEY: "env-secret" },
+      },
+    );
+    expect(result.apiKey).toEqual({
+      organizationSlug: "",
+      secretKey: "env-secret",
+    });
+  });
+
   it("env var overrides file value for one field only", () => {
     const config = {
       apiKey: { organizationSlug: "file-org", secretKey: "file-secret" },

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -187,6 +187,14 @@ describe("resolveConfig", () => {
     ).rejects.toThrow(/~\/\.qontoctl\/nonexistent\.yaml/);
   });
 
+  it("describes config path in error when file exists but has no api-key", async () => {
+    await writeFile(join(testDir, ".qontoctl.yaml"), "endpoint: https://example.com\n");
+
+    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
+      /Found config at .* but it contains no api-key credentials/,
+    );
+  });
+
   it("defaults endpoint to production URL", async () => {
     const result = await resolveConfig({
       cwd: testDir,


### PR DESCRIPTION
## Summary

- Add tests for uncovered branches in the profile & config system (`@qontoctl/core`)
- Covers partial env var credential defaults when no existing apiKey is present
- Covers resolve error message when config file exists but contains no api-key section
- Improves config module branch coverage (env.ts: 85% → 95%, overall config: 94.33% → 96.22%)

## Test plan

- [x] All 127 core tests pass
- [x] ESLint clean
- [x] No production code changes

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)