### PR TITLE
(test) add e2e tests for statement commands (#37)

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
     "@qontoctl/mcp": "workspace:^"

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+const hasSandboxCreds =
+  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+
+/**
+ * Build environment with sandbox credentials for CLI invocations.
+ * Inherits the current process environment and ensures sandbox mode is on.
+ */
+function sandboxEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    QONTOCTL_SANDBOX: "true",
+  };
+}
+
+function listStatements(): Record<string, unknown>[] {
+  const output = execFileSync(
+    "node",
+    [CLI_PATH, "statement", "list", "--no-paginate", "-o", "json"],
+    { encoding: "utf-8", env: sandboxEnv() },
+  );
+  return JSON.parse(output) as Record<string, unknown>[];
+}
+
+describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
+  // -- statement list --
+
+  describe("statement list", () => {
+    it("lists statements with expected fields", () => {
+      const rows = listStatements();
+      expect(rows.length).toBeGreaterThan(0);
+
+      const first = rows[0] as Record<string, unknown>;
+      expect(first).toHaveProperty("id");
+      expect(first).toHaveProperty("bank_account_id");
+      expect(first).toHaveProperty("period");
+      expect(first).toHaveProperty("file_name");
+      expect(first).toHaveProperty("file_content_type");
+      expect(first).toHaveProperty("file_size");
+    });
+
+    it("filters by bank account ID", () => {
+      const allRows = listStatements();
+      expect(allRows.length).toBeGreaterThan(0);
+
+      const bankAccountId = (allRows[0] as Record<string, unknown>)["bank_account_id"] as string;
+
+      const filteredOutput = execFileSync(
+        "node",
+        [
+          CLI_PATH,
+          "statement",
+          "list",
+          "--bank-account",
+          bankAccountId,
+          "--no-paginate",
+          "-o",
+          "json",
+        ],
+        { encoding: "utf-8", env: sandboxEnv() },
+      );
+      const filteredRows = JSON.parse(filteredOutput) as Record<string, unknown>[];
+
+      for (const row of filteredRows) {
+        expect(row["bank_account_id"]).toBe(bankAccountId);
+      }
+    });
+
+    it("filters by period range", () => {
+      const output = execFileSync(
+        "node",
+        [
+          CLI_PATH,
+          "statement",
+          "list",
+          "--from",
+          "01-2025",
+          "--to",
+          "12-2025",
+          "--no-paginate",
+          "-o",
+          "json",
+        ],
+        { encoding: "utf-8", env: sandboxEnv() },
+      );
+
+      // The command should succeed; results may be empty if no statements in range
+      const rows = JSON.parse(output) as unknown[];
+      expect(Array.isArray(rows)).toBe(true);
+    });
+  });
+
+  // -- statement show --
+
+  describe("statement show", () => {
+    it("shows full details of a statement", () => {
+      const allRows = listStatements();
+      expect(allRows.length).toBeGreaterThan(0);
+
+      const statementId = (allRows[0] as Record<string, unknown>)["id"] as string;
+
+      const showOutput = execFileSync(
+        "node",
+        [CLI_PATH, "statement", "show", statementId, "-o", "json"],
+        { encoding: "utf-8", env: sandboxEnv() },
+      );
+      const showRows = JSON.parse(showOutput) as Record<string, unknown>[];
+      expect(showRows).toHaveLength(1);
+
+      const row = showRows[0] as Record<string, unknown>;
+      expect(row["id"]).toBe(statementId);
+      expect(row).toHaveProperty("bank_account_id");
+      expect(row).toHaveProperty("period");
+      expect(row).toHaveProperty("file_name");
+      expect(row).toHaveProperty("file_content_type");
+      expect(row).toHaveProperty("file_size");
+    });
+  });
+
+  // -- statement download --
+
+  describe("statement download", () => {
+    let tempDir: string;
+
+    beforeAll(() => {
+      tempDir = mkdtempSync(join(tmpdir(), "qontoctl-stmt-download-e2e-"));
+    });
+
+    afterAll(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it("downloads a statement PDF to the current directory", () => {
+      const allRows = listStatements();
+      expect(allRows.length).toBeGreaterThan(0);
+
+      const firstRow = allRows[0] as Record<string, unknown>;
+      const statementId = firstRow["id"] as string;
+      const expectedFileName = firstRow["file_name"] as string;
+
+      const downloadDir = mkdtempSync(join(tempDir, "cwd-"));
+      execFileSync(
+        "node",
+        [CLI_PATH, "statement", "download", statementId],
+        { encoding: "utf-8", env: sandboxEnv(), cwd: downloadDir },
+      );
+
+      const downloadedFile = join(downloadDir, expectedFileName);
+      expect(existsSync(downloadedFile)).toBe(true);
+    });
+
+    it("downloads a statement PDF to a specified output directory", () => {
+      const allRows = listStatements();
+      expect(allRows.length).toBeGreaterThan(0);
+
+      const firstRow = allRows[0] as Record<string, unknown>;
+      const statementId = firstRow["id"] as string;
+      const expectedFileName = firstRow["file_name"] as string;
+
+      const outputDir = mkdtempSync(join(tempDir, "outdir-"));
+      execFileSync(
+        "node",
+        [CLI_PATH, "statement", "download", statementId, "--output-dir", outputDir],
+        { encoding: "utf-8", env: sandboxEnv() },
+      );
+
+      const downloadedFile = join(outputDir, expectedFileName);
+      expect(existsSync(downloadedFile)).toBe(true);
+
+      // Verify it's the only file in the directory
+      const files = readdirSync(outputDir);
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBe(expectedFileName);
+    });
+  });
+});

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+const hasSandboxCreds =
+  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+
+describe.skipIf(!hasSandboxCreds)("statement MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: {
+        ...(process.env as Record<string, string>),
+        QONTOCTL_SANDBOX: "true",
+      },
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("statement_list", () => {
+    it("lists statements and returns expected fields", async () => {
+      const result = await client.callTool({ name: "statement_list", arguments: {} });
+
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toHaveLength(1);
+
+      const textContent = result.content[0] as { type: string; text: string };
+      expect(textContent.type).toBe("text");
+
+      const parsed = JSON.parse(textContent.text) as {
+        statements: Record<string, unknown>[];
+        meta: Record<string, unknown>;
+      };
+      expect(parsed.statements.length).toBeGreaterThan(0);
+      expect(parsed.meta).toHaveProperty("current_page");
+
+      const first = parsed.statements[0] as Record<string, unknown>;
+      expect(first).toHaveProperty("id");
+      expect(first).toHaveProperty("bank_account_id");
+      expect(first).toHaveProperty("period");
+    });
+
+    it("filters by period range", async () => {
+      const result = await client.callTool({
+        name: "statement_list",
+        arguments: {
+          period_from: "01-2025",
+          period_to: "12-2025",
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+
+      const textContent = result.content[0] as { type: string; text: string };
+      const parsed = JSON.parse(textContent.text) as {
+        statements: unknown[];
+        meta: unknown;
+      };
+      expect(Array.isArray(parsed.statements)).toBe(true);
+    });
+  });
+
+  describe("statement_show", () => {
+    it("shows details of a specific statement", async () => {
+      // First, get a statement ID from the list
+      const listResult = await client.callTool({
+        name: "statement_list",
+        arguments: {},
+      });
+      const listText = (listResult.content[0] as { type: string; text: string }).text;
+      const listParsed = JSON.parse(listText) as {
+        statements: Record<string, unknown>[];
+      };
+      expect(listParsed.statements.length).toBeGreaterThan(0);
+
+      const statementId = (listParsed.statements[0] as Record<string, unknown>)["id"] as string;
+
+      // Now show that specific statement
+      const showResult = await client.callTool({
+        name: "statement_show",
+        arguments: { id: statementId },
+      });
+
+      expect(showResult.isError).not.toBe(true);
+
+      const showText = (showResult.content[0] as { type: string; text: string }).text;
+      const showParsed = JSON.parse(showText) as Record<string, unknown>;
+      expect(showParsed["id"]).toBe(statementId);
+      expect(showParsed).toHaveProperty("bank_account_id");
+      expect(showParsed).toHaveProperty("period");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(zod@4.3.6)
       '@qontoctl/cli':
         specifier: workspace:^
         version: link:../cli


### PR DESCRIPTION
## Summary

- Add E2E tests for statement CLI commands (`statement list`, `statement show`, `statement download`) against the Qonto sandbox
- Add E2E tests for MCP statement tools (`statement_list`, `statement_show`) via MCP SDK client over stdio
- Add `@modelcontextprotocol/sdk` dependency to `@qontoctl/e2e` for MCP client transport
- Tests are skipped when sandbox credentials (`QONTOCTL_ORGANIZATION_SLUG`, `QONTOCTL_SECRET_KEY`) are not available

## Test plan

- [x] Build succeeds (`pnpm build`)
- [x] Unit tests pass (`pnpm test` — 150 passed)
- [x] E2E tests load and skip gracefully without sandbox credentials (`pnpm test:e2e` — 14 skipped)
- [x] Lint passes (`pnpm lint`)
- [x] License check passes (`pnpm license-check`)
- [ ] E2E tests pass with sandbox credentials (CI with secrets)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)