### PR TITLE
(test) add e2e tests for organization and accounts commands (#35)

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
     "@qontoctl/mcp": "workspace:^"

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(
+  import.meta.dirname,
+  "../../../qontoctl/dist/cli.js",
+);
+
+function hasSandboxCredentials(): boolean {
+  return (
+    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+    process.env["QONTOCTL_SECRET_KEY"] !== undefined
+  );
+}
+
+function cli(args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      QONTOCTL_SANDBOX: "1",
+    },
+  });
+}
+
+describe.skipIf(!hasSandboxCredentials())(
+  "organization & accounts CLI (e2e)",
+  () => {
+    let knownAccountId: string;
+
+    beforeAll(() => {
+      // Discover an account ID from the sandbox for use in `account show`
+      const json = cli(["account", "list", "--output", "json"]);
+      const accounts = JSON.parse(json) as { id: string }[];
+      expect(accounts.length).toBeGreaterThan(0);
+      knownAccountId = (accounts[0] as { id: string }).id;
+    });
+
+    // ── org show ────────────────────────────────────────────────────
+
+    it("org show displays organization details in table format", () => {
+      const output = cli(["org", "show"]);
+      expect(output).toContain("slug");
+      expect(output).toContain("legal_name");
+      expect(output).toContain("bank_accounts");
+    });
+
+    it("org show --output json produces valid JSON with expected fields", () => {
+      const output = cli(["org", "show", "--output", "json"]);
+      const org = JSON.parse(output) as Record<string, unknown>;
+      expect(org).toHaveProperty("slug");
+      expect(org).toHaveProperty("legal_name");
+      expect(org).toHaveProperty("bank_accounts");
+      expect(typeof org["slug"]).toBe("string");
+      expect(typeof org["legal_name"]).toBe("string");
+      expect(Array.isArray(org["bank_accounts"])).toBe(true);
+    });
+
+    // ── account list ───────────────────────────────────────────────
+
+    it("account list displays accounts in table format", () => {
+      const output = cli(["account", "list"]);
+      expect(output).toContain("id");
+      expect(output).toContain("name");
+      expect(output).toContain("iban");
+      expect(output).toContain("balance");
+      expect(output).toContain("status");
+    });
+
+    it("account list --output json produces valid JSON array", () => {
+      const output = cli(["account", "list", "--output", "json"]);
+      const accounts = JSON.parse(output) as Record<string, unknown>[];
+      expect(Array.isArray(accounts)).toBe(true);
+      expect(accounts.length).toBeGreaterThan(0);
+
+      const account = accounts[0] as Record<string, unknown>;
+      expect(account).toHaveProperty("id");
+      expect(account).toHaveProperty("name");
+      expect(account).toHaveProperty("iban");
+      expect(account).toHaveProperty("balance");
+      expect(account).toHaveProperty("currency");
+      expect(account).toHaveProperty("status");
+    });
+
+    // ── account show ───────────────────────────────────────────────
+
+    it("account show displays account details in table format", () => {
+      const output = cli(["account", "show", knownAccountId]);
+      expect(output).toContain(knownAccountId);
+      expect(output).toContain("iban");
+      expect(output).toContain("balance");
+      expect(output).toContain("status");
+    });
+
+    it("account show --output json produces valid JSON object", () => {
+      const output = cli([
+        "account",
+        "show",
+        knownAccountId,
+        "--output",
+        "json",
+      ]);
+      const account = JSON.parse(output) as Record<string, unknown>;
+      expect(account).toHaveProperty("id", knownAccountId);
+      expect(account).toHaveProperty("name");
+      expect(account).toHaveProperty("iban");
+      expect(account).toHaveProperty("bic");
+      expect(account).toHaveProperty("balance");
+      expect(account).toHaveProperty("authorized_balance");
+      expect(account).toHaveProperty("currency");
+      expect(account).toHaveProperty("status");
+    });
+  },
+);

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(
+  import.meta.dirname,
+  "../../../qontoctl/dist/cli.js",
+);
+
+function hasSandboxCredentials(): boolean {
+  return (
+    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+    process.env["QONTOCTL_SECRET_KEY"] !== undefined
+  );
+}
+
+describe.skipIf(!hasSandboxCredentials())(
+  "organization & accounts MCP (e2e)",
+  () => {
+    let client: Client;
+    let transport: StdioClientTransport;
+
+    beforeAll(async () => {
+      transport = new StdioClientTransport({
+        command: "node",
+        args: [CLI_PATH, "mcp"],
+        env: {
+          ...(process.env as Record<string, string>),
+          QONTOCTL_SANDBOX: "1",
+        },
+        stderr: "pipe",
+      });
+
+      client = new Client({ name: "e2e-test", version: "0.0.0" });
+      await client.connect(transport);
+    });
+
+    afterAll(async () => {
+      await client.close();
+    });
+
+    // ── org_show ───────────────────────────────────────────────────
+
+    it("org_show returns organization details", async () => {
+      const result = await client.callTool({
+        name: "org_show",
+        arguments: {},
+      });
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toBeDefined();
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      expect((content[0] as { type: string }).type).toBe("text");
+
+      const org = JSON.parse(
+        (content[0] as { text: string }).text,
+      ) as Record<string, unknown>;
+      expect(org).toHaveProperty("slug");
+      expect(org).toHaveProperty("legal_name");
+      expect(org).toHaveProperty("bank_accounts");
+      expect(typeof org["slug"]).toBe("string");
+      expect(typeof org["legal_name"]).toBe("string");
+      expect(Array.isArray(org["bank_accounts"])).toBe(true);
+    });
+
+    // ── account_list ───────────────────────────────────────────────
+
+    it("account_list returns bank accounts", async () => {
+      const result = await client.callTool({
+        name: "account_list",
+        arguments: {},
+      });
+      expect(result.isError).not.toBe(true);
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      expect((content[0] as { type: string }).type).toBe("text");
+
+      const accounts = JSON.parse(
+        (content[0] as { text: string }).text,
+      ) as Record<string, unknown>[];
+      expect(Array.isArray(accounts)).toBe(true);
+      expect(accounts.length).toBeGreaterThan(0);
+
+      const account = accounts[0] as Record<string, unknown>;
+      expect(account).toHaveProperty("id");
+      expect(account).toHaveProperty("name");
+      expect(account).toHaveProperty("iban");
+      expect(account).toHaveProperty("balance");
+      expect(account).toHaveProperty("currency");
+      expect(account).toHaveProperty("status");
+    });
+
+    // ── account_show ───────────────────────────────────────────────
+
+    it("account_show returns details for a specific account", async () => {
+      // First, get an account ID from account_list
+      const listResult = await client.callTool({
+        name: "account_list",
+        arguments: {},
+      });
+      const listContent = listResult.content as {
+        type: string;
+        text: string;
+      }[];
+      const accounts = JSON.parse(
+        (listContent[0] as { text: string }).text,
+      ) as { id: string }[];
+      const accountId = (accounts[0] as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "account_show",
+        arguments: { id: accountId },
+      });
+      expect(result.isError).not.toBe(true);
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      expect((content[0] as { type: string }).type).toBe("text");
+
+      const account = JSON.parse(
+        (content[0] as { text: string }).text,
+      ) as Record<string, unknown>;
+      expect(account).toHaveProperty("id", accountId);
+      expect(account).toHaveProperty("name");
+      expect(account).toHaveProperty("iban");
+      expect(account).toHaveProperty("bic");
+      expect(account).toHaveProperty("balance");
+      expect(account).toHaveProperty("authorized_balance");
+      expect(account).toHaveProperty("currency");
+      expect(account).toHaveProperty("status");
+    });
+  },
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(zod@4.3.6)
       '@qontoctl/cli':
         specifier: workspace:^
         version: link:../cli


### PR DESCRIPTION
## Summary

- Add CLI e2e tests for `org show`, `account list`, `account show` commands (table + JSON output)
- Add MCP e2e tests for `org_show`, `account_list`, `account_show` tools via stdio transport
- Add `@modelcontextprotocol/sdk` dependency to e2e package for MCP client testing

## Test plan

- [ ] CLI tests invoke the built CLI binary against the Qonto sandbox API
- [ ] MCP tests spawn the MCP server via `StdioClientTransport` and call tools
- [ ] Tests skip gracefully when sandbox credentials are not set (`QONTOCTL_ORGANIZATION_SLUG`, `QONTOCTL_SECRET_KEY`)
- [ ] Lint passes with no errors
- [ ] Unit tests pass with no regressions
- [ ] Build succeeds

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)