### PR TITLE
(test) add e2e tests for label and membership commands (#38)

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,9 +16,11 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
-    "@qontoctl/mcp": "workspace:^"
+    "@qontoctl/mcp": "workspace:^",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(
+  import.meta.dirname,
+  "../../../qontoctl/dist/cli.js",
+);
+
+const hasCredentials =
+  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+
+/**
+ * Run the CLI with the given arguments, inheriting sandbox credentials
+ * from the environment.
+ */
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, QONTOCTL_SANDBOX: "1" },
+    timeout: 15_000,
+  });
+}
+
+describe.skipIf(!hasCredentials)("label commands (e2e)", () => {
+  describe("label list", () => {
+    it("lists labels with id, name, parent_id", () => {
+      const output = cli("label", "list");
+      expect(output).toBeTruthy();
+    });
+
+    it("produces valid JSON with --output json", () => {
+      const output = cli("--output", "json", "label", "list");
+      const parsed = JSON.parse(output) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const item of parsed) {
+        const label = item as Record<string, unknown>;
+        expect(label).toHaveProperty("id");
+        expect(label).toHaveProperty("name");
+        expect(label).toHaveProperty("parent_id");
+      }
+    });
+  });
+
+  describe("label show", () => {
+    it("shows label details including hierarchy fields", () => {
+      // First, get a label ID from the list
+      const listOutput = cli("--output", "json", "label", "list");
+      const labels = JSON.parse(listOutput) as { id: string; name: string; parent_id: string }[];
+      if (labels.length === 0) {
+        return; // No labels in sandbox — nothing to show
+      }
+
+      const firstLabel = labels[0];
+      expect(firstLabel).toBeDefined();
+      const labelId = (firstLabel as { id: string }).id;
+      const output = cli("--output", "json", "label", "show", labelId);
+      const parsed = JSON.parse(output) as unknown[];
+      expect(parsed).toHaveLength(1);
+
+      const label = parsed[0] as Record<string, unknown>;
+      expect(label).toHaveProperty("id", labelId);
+      expect(label).toHaveProperty("name");
+      expect(label).toHaveProperty("parent_id");
+    });
+  });
+});

--- a/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(
+  import.meta.dirname,
+  "../../../qontoctl/dist/cli.js",
+);
+
+const hasCredentials =
+  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+
+/**
+ * Extract the text content from a single-entry MCP tool result.
+ */
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials)("MCP label & membership tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: {
+        ...process.env,
+        QONTOCTL_SANDBOX: "1",
+      } as Record<string, string>,
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("label_list", () => {
+    it("returns a list of labels with expected structure", async () => {
+      const result = await client.callTool({
+        name: "label_list",
+        arguments: {},
+      });
+
+      const parsed = JSON.parse(firstText(result)) as {
+        labels: unknown[];
+        meta: Record<string, unknown>;
+      };
+      expect(parsed).toHaveProperty("labels");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.labels)).toBe(true);
+
+      for (const item of parsed.labels) {
+        const label = item as Record<string, unknown>;
+        expect(label).toHaveProperty("id");
+        expect(label).toHaveProperty("name");
+        expect(label).toHaveProperty("parent_id");
+      }
+    });
+  });
+
+  describe("label_show", () => {
+    it("returns details for a specific label", async () => {
+      // First, get a label ID from the list
+      const listResult = await client.callTool({
+        name: "label_list",
+        arguments: {},
+      });
+      const listParsed = JSON.parse(firstText(listResult)) as {
+        labels: { id: string }[];
+      };
+      if (listParsed.labels.length === 0) {
+        return; // No labels in sandbox
+      }
+
+      const firstLabel = listParsed.labels[0];
+      expect(firstLabel).toBeDefined();
+      const labelId = (firstLabel as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "label_show",
+        arguments: { id: labelId },
+      });
+
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", labelId);
+      expect(parsed).toHaveProperty("name");
+      expect(parsed).toHaveProperty("parent_id");
+    });
+  });
+
+  describe("membership_list", () => {
+    it("returns a list of memberships with expected structure", async () => {
+      const result = await client.callTool({
+        name: "membership_list",
+        arguments: {},
+      });
+
+      const parsed = JSON.parse(firstText(result)) as {
+        memberships: unknown[];
+        meta: Record<string, unknown>;
+      };
+      expect(parsed).toHaveProperty("memberships");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.memberships)).toBe(true);
+
+      for (const item of parsed.memberships) {
+        const membership = item as Record<string, unknown>;
+        expect(membership).toHaveProperty("id");
+        expect(membership).toHaveProperty("first_name");
+        expect(membership).toHaveProperty("last_name");
+        expect(membership).toHaveProperty("role");
+        expect(membership).toHaveProperty("team_id");
+        expect(membership).toHaveProperty("status");
+      }
+    });
+  });
+});

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(
+  import.meta.dirname,
+  "../../../qontoctl/dist/cli.js",
+);
+
+const hasCredentials =
+  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+
+/**
+ * Run the CLI with the given arguments, inheriting sandbox credentials
+ * from the environment.
+ */
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, QONTOCTL_SANDBOX: "1" },
+    timeout: 15_000,
+  });
+}
+
+describe.skipIf(!hasCredentials)("membership commands (e2e)", () => {
+  describe("membership list", () => {
+    it("lists memberships with expected fields", () => {
+      const output = cli("membership", "list");
+      expect(output).toBeTruthy();
+    });
+
+    it("produces valid JSON with --output json", () => {
+      const output = cli("--output", "json", "membership", "list");
+      const parsed = JSON.parse(output) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const item of parsed) {
+        const membership = item as Record<string, unknown>;
+        expect(membership).toHaveProperty("id");
+        expect(membership).toHaveProperty("first_name");
+        expect(membership).toHaveProperty("last_name");
+        expect(membership).toHaveProperty("role");
+        expect(membership).toHaveProperty("team_id");
+        expect(membership).toHaveProperty("status");
+      }
+    });
+
+    it("returns at least one membership", () => {
+      const output = cli("--output", "json", "membership", "list");
+      const parsed = JSON.parse(output) as unknown[];
+      expect(parsed.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(zod@4.3.6)
       '@qontoctl/cli':
         specifier: workspace:^
         version: link:../cli
@@ -148,6 +151,9 @@ importers:
       '@qontoctl/mcp':
         specifier: workspace:^
         version: link:../mcp
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

- Add E2E tests for `label list`, `label show`, and `membership list` CLI commands against the Qonto sandbox
- Add E2E tests for `label_list`, `label_show`, and `membership_list` MCP tools via stdio transport
- All tests skip gracefully when sandbox credentials are not available
- Add `@modelcontextprotocol/sdk` and `zod` dependencies to `@qontoctl/e2e` for MCP client transport

## Test plan

- [ ] CLI: `label list` produces output against sandbox
- [ ] CLI: `label list --output json` returns valid JSON with id, name, parent_id fields
- [ ] CLI: `label show <id>` returns label details including hierarchy fields
- [ ] CLI: `membership list` produces output against sandbox
- [ ] CLI: `membership list --output json` returns valid JSON with id, first_name, last_name, role, team_id, status
- [ ] CLI: `membership list` returns at least one membership
- [ ] MCP: `label_list` tool returns labels with expected structure via stdio
- [ ] MCP: `label_show` tool returns label details for a specific ID via stdio
- [ ] MCP: `membership_list` tool returns memberships with expected structure via stdio
- [ ] Tests skip when `QONTOCTL_ORGANIZATION_SLUG` / `QONTOCTL_SECRET_KEY` are not set

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)