### PR TITLE
(test) add CLI framework and output formatting tests (#32)

### DIFF
--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { HttpClientOptions } from "@qontoctl/core";
 import { createClient } from "./client.js";
 import type { GlobalOptions } from "./options.js";
 
@@ -10,16 +11,19 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
   return {
     ...actual,
     resolveConfig: vi.fn(),
+    HttpClient: vi.fn(),
   };
 });
 
-const { resolveConfig } = await import("@qontoctl/core");
+const { resolveConfig, HttpClient } = await import("@qontoctl/core");
 const resolveConfigMock = vi.mocked(resolveConfig);
+const HttpClientMock = vi.mocked(HttpClient);
 
 describe("createClient", () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    HttpClientMock.mockClear();
     stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     resolveConfigMock.mockResolvedValue({
       config: {
@@ -37,10 +41,15 @@ describe("createClient", () => {
     vi.restoreAllMocks();
   });
 
-  it("creates a client with production base URL by default", async () => {
+  it("creates a client with resolved endpoint", async () => {
     const options: GlobalOptions = { output: "table" };
-    const client = await createClient(options);
-    expect(client).toBeDefined();
+    await createClient(options);
+
+    expect(HttpClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://thirdparty.qonto.com",
+      }),
+    );
   });
 
   it("passes profile to resolveConfig", async () => {
@@ -77,5 +86,50 @@ describe("createClient", () => {
     await expect(createClient(options)).rejects.toThrow(
       "No API key credentials found in configuration",
     );
+  });
+
+  it("creates client without logger by default", async () => {
+    const options: GlobalOptions = { output: "table" };
+    await createClient(options);
+
+    const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as
+      | HttpClientOptions
+      | undefined;
+    expect(ctorArgs?.logger).toBeUndefined();
+  });
+
+  it("creates a debug logger when --debug is set", async () => {
+    const options: GlobalOptions = { output: "table", debug: true };
+    await createClient(options);
+
+    const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as
+      | HttpClientOptions
+      | undefined;
+    const logger = ctorArgs?.logger;
+    expect(logger).toBeDefined();
+
+    logger?.verbose("verbose msg");
+    expect(stderrSpy).toHaveBeenCalledWith("verbose msg\n");
+
+    logger?.debug("debug msg");
+    expect(stderrSpy).toHaveBeenCalledWith("debug msg\n");
+  });
+
+  it("creates a verbose-only logger when --verbose is set", async () => {
+    const options: GlobalOptions = { output: "table", verbose: true };
+    await createClient(options);
+
+    const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as
+      | HttpClientOptions
+      | undefined;
+    const logger = ctorArgs?.logger;
+    expect(logger).toBeDefined();
+
+    logger?.verbose("verbose msg");
+    expect(stderrSpy).toHaveBeenCalledWith("verbose msg\n");
+
+    stderrSpy.mockClear();
+    logger?.debug("debug msg");
+    expect(stderrSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/pagination.test.ts
+++ b/packages/cli/src/pagination.test.ts
@@ -135,6 +135,28 @@ describe("pagination", () => {
       expect(result.items).toEqual(items);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("stops at MAX_PAGES safety limit", async () => {
+      // Always return a next_page to simulate infinite pagination
+      fetchSpy.mockImplementation(() => {
+        const callCount = fetchSpy.mock.calls.length;
+        return jsonResponse({
+          items: [{ id: String(callCount) }],
+          meta: makeMeta({
+            current_page: callCount,
+            next_page: callCount + 1,
+            total_pages: 9999,
+            total_count: 9999,
+          }),
+        });
+      });
+
+      const result = await fetchAllPages(client, "/v2/items", "items", 1);
+
+      // MAX_PAGES is 1000, so it should stop after 1000 fetches
+      expect(fetchSpy).toHaveBeenCalledTimes(1000);
+      expect(result.items).toHaveLength(1000);
+    });
   });
 
   describe("fetchPaginated", () => {


### PR DESCRIPTION
## Summary

- Add missing unit tests for `createClient` verbose/debug logger creation (`--verbose`, `--debug` flags)
- Improve existing `createClient` test to verify resolved endpoint is passed to `HttpClient`
- Add `fetchAllPages` MAX_PAGES safety limit test covering the 1000-page break condition
- Test coverage for `client.ts` increased from 64% to 100% (statements)
- Test coverage for `pagination.ts` line 92 (MAX_PAGES break) now covered

## Test plan

- [x] All 154 CLI tests pass (`pnpm test`)
- [x] TypeScript build passes (`pnpm build`)
- [x] ESLint passes (`pnpm lint`)
- [x] New tests verify: debug logger writes both verbose+debug to stderr, verbose logger writes verbose only, no logger by default, MAX_PAGES breaks at 1000

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)