### PR TITLE
(test) add e2e tests for MCP server and tools (#39)

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
     "@qontoctl/mcp": "workspace:^"

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+const EXPECTED_TOOLS = [
+  "org_show",
+  "account_list",
+  "account_show",
+  "transaction_list",
+  "transaction_show",
+  "statement_list",
+  "statement_show",
+  "label_list",
+  "label_show",
+  "membership_list",
+] as const;
+
+function hasSandboxCredentials(): boolean {
+  return (
+    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+    process.env["QONTOCTL_SECRET_KEY"] !== undefined
+  );
+}
+
+describe("MCP server via stdio (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      stderr: "pipe",
+    });
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it("responds to initialize and connects successfully", () => {
+    // client.connect() already performed the initialize handshake;
+    // reaching this point means the server responded correctly
+    expect(client).toBeDefined();
+  });
+
+  describe("tools/list", () => {
+    it("lists all 10 expected tools", async () => {
+      const { tools } = await client.listTools();
+      const names = tools.map((t) => t.name);
+
+      for (const expected of EXPECTED_TOOLS) {
+        expect(names, `missing tool: ${expected}`).toContain(expected);
+      }
+      expect(tools).toHaveLength(EXPECTED_TOOLS.length);
+    });
+
+    it("each tool has a description", async () => {
+      const { tools } = await client.listTools();
+
+      for (const tool of tools) {
+        expect(tool.description, `${tool.name} should have a description`).toBeTruthy();
+      }
+    });
+
+    it("each tool has an input schema", async () => {
+      const { tools } = await client.listTools();
+
+      for (const tool of tools) {
+        expect(tool.inputSchema, `${tool.name} should have an inputSchema`).toBeDefined();
+        expect(tool.inputSchema.type).toBe("object");
+      }
+    });
+  });
+
+  describe.skipIf(!hasSandboxCredentials())("tool call with valid credentials", () => {
+    it("org_show returns organization data in MCP content format", async () => {
+      const result = await client.callTool({ name: "org_show", arguments: {} });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      expect(first.type).toBe("text");
+
+      const parsed: unknown = JSON.parse(first.text);
+      expect(parsed).toBeDefined();
+      expect(typeof parsed).toBe("object");
+    });
+  });
+});
+
+describe("MCP server with no credentials (e2e)", () => {
+  let tempHome: string;
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    tempHome = mkdtempSync(join(tmpdir(), "qontoctl-mcp-e2e-"));
+
+    // Strip all QONTOCTL_* env vars and point HOME to an empty temp dir
+    // so resolveConfig finds no config file and no env credentials.
+    const cleanEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!key.startsWith("QONTOCTL_") && value !== undefined) {
+        cleanEnv[key] = value;
+      }
+    }
+    cleanEnv["HOME"] = tempHome;
+
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cleanEnv,
+      stderr: "pipe",
+    });
+    client = new Client({ name: "e2e-no-creds", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("returns isError with guidance when calling a tool without credentials", async () => {
+    const result = await client.callTool({ name: "org_show", arguments: {} });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as { type: string; text: string }[];
+    expect(content).toHaveLength(1);
+    const first = content[0] as { type: string; text: string };
+    expect(first.type).toBe("text");
+    expect(first.text.toLowerCase()).toContain("error");
+  });
+});

--- a/packages/mcp/src/rate-limit.test.ts
+++ b/packages/mcp/src/rate-limit.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { HttpClient } from "@qontoctl/core";
+import { createServer } from "./server.js";
+
+describe("rate limit error handling (integration)", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const httpClient = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+      maxRetries: 0, // No retries — trigger QontoRateLimitError immediately
+    });
+
+    const server = createServer({ getClient: () => Promise.resolve(httpClient) });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    mcpClient = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([mcpClient.connect(clientTransport), server.connect(serverTransport)]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns isError with retry-after when API responds with 429", async () => {
+    fetchSpy.mockReturnValue(
+      Promise.resolve(
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+          headers: { "Retry-After": "30" },
+        }),
+      ),
+    );
+
+    const result = await mcpClient.callTool({
+      name: "org_show",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as { type: string; text: string }[];
+    const first = content[0] as { type: string; text: string };
+    expect(first.text).toContain("Rate limit exceeded");
+    expect(first.text).toContain("30 seconds");
+  });
+
+  it("returns isError without retry-after when 429 has no Retry-After header", async () => {
+    fetchSpy.mockReturnValue(
+      Promise.resolve(
+        new Response(JSON.stringify({ message: "rate limited" }), {
+          status: 429,
+        }),
+      ),
+    );
+
+    const result = await mcpClient.callTool({
+      name: "org_show",
+      arguments: {},
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as { type: string; text: string }[];
+    const first = content[0] as { type: string; text: string };
+    expect(first.text).toContain("Rate limit exceeded");
+    expect(first.text).toContain("Please wait before retrying");
+  });
+});

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -56,4 +56,17 @@ describe("createServer", () => {
       expect(tool.description, `Tool ${name} should have a description`).toBeTruthy();
     }
   });
+
+  it("tool names follow entity_operation underscore convention", () => {
+    const server = createServer();
+    const registeredTools = (
+      server as unknown as { _registeredTools: Record<string, unknown> }
+    )._registeredTools;
+    const toolNames = Object.keys(registeredTools);
+
+    const pattern = /^[a-z]+_[a-z]+$/;
+    for (const name of toolNames) {
+      expect(name, `Tool "${name}" should match {entity}_{operation} pattern`).toMatch(pattern);
+    }
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(zod@4.3.6)
       '@qontoctl/cli':
         specifier: workspace:^
         version: link:../cli


### PR DESCRIPTION
## Summary

- Add E2E tests for MCP server startup via stdio, tool listing with schemas, tool execution with valid credentials, and error handling for missing credentials
- Add integration test for rate limit (429) error handling through the full MCP tool call flow with mocked HTTP responses
- Add unit test asserting tool names follow the `{entity}_{operation}` underscore naming convention

## Test plan

- [x] `pnpm test` — all unit/integration tests pass (51 total in MCP package)
- [x] `pnpm test:e2e` — all E2E tests pass (sandbox credential test skipped without creds)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] `pnpm license-check` — clean

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)