### PR TITLE
(test) add e2e tests for transaction commands (#36)

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
     "@qontoctl/mcp": "workspace:^"

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function hasSandboxCredentials(): boolean {
+  return process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined && process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+}
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      QONTOCTL_SANDBOX: "true",
+    },
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface TransactionItem {
+  readonly id: string;
+  readonly amount: number;
+  readonly side: "credit" | "debit";
+  readonly status: "pending" | "declined" | "completed";
+  readonly currency: string;
+  readonly operation_type: string;
+  readonly label: string;
+  readonly settled_at: string | null;
+  readonly bank_account_id: string;
+  readonly attachment_ids?: readonly string[];
+  readonly labels?: readonly { id: string; name: string }[];
+  readonly attachments?: readonly unknown[];
+}
+
+/**
+ * Get the first transaction from a list, or undefined if empty.
+ * Helper to avoid non-null assertions in tests.
+ */
+function firstTransaction(transactions: readonly TransactionItem[]): TransactionItem | undefined {
+  return transactions[0];
+}
+
+describe.skipIf(!hasSandboxCredentials())("transaction CLI commands (e2e)", () => {
+  describe("transaction list", () => {
+    it("lists transactions with default output", () => {
+      const output = cli("transaction", "list", "--no-paginate");
+      expect(output.length).toBeGreaterThan(0);
+    });
+
+    it("lists transactions as JSON", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate");
+      expect(Array.isArray(transactions)).toBe(true);
+      const txn = firstTransaction(transactions);
+      if (txn !== undefined) {
+        expect(txn).toHaveProperty("id");
+        expect(txn).toHaveProperty("amount");
+        expect(txn).toHaveProperty("side");
+        expect(txn).toHaveProperty("status");
+        expect(txn).toHaveProperty("currency");
+      }
+    });
+
+    it("lists transactions with pagination", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--per-page", "2", "--page", "1");
+      expect(Array.isArray(transactions)).toBe(true);
+      expect(transactions.length).toBeLessThanOrEqual(2);
+    });
+
+    it("filters by bank account ID", () => {
+      const all = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
+      const first = firstTransaction(all);
+      if (first === undefined) return;
+
+      const bankAccountId = first.bank_account_id;
+      const filtered = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--bank-account",
+        bankAccountId,
+        "--no-paginate",
+      );
+      expect(Array.isArray(filtered)).toBe(true);
+      for (const txn of filtered) {
+        expect(txn.bank_account_id).toBe(bankAccountId);
+      }
+    });
+
+    it("filters by status", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--status", "completed", "--no-paginate");
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn.status).toBe("completed");
+      }
+    });
+
+    it("filters by side", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--side", "debit", "--no-paginate");
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn.side).toBe("debit");
+      }
+    });
+
+    it("filters by date range", () => {
+      const fromDate = "2020-01-01";
+      const toDate = "2030-12-31";
+      const transactions = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--status",
+        "completed",
+        "--from",
+        fromDate,
+        "--to",
+        toDate,
+        "--no-paginate",
+      );
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        if (txn.settled_at !== null) {
+          expect(txn.settled_at >= fromDate).toBe(true);
+          expect(txn.settled_at <= `${toDate}T23:59:59`).toBe(true);
+        }
+      }
+    });
+
+    it("includes labels with --include labels", () => {
+      const transactions = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--include",
+        "labels",
+        "--no-paginate",
+        "--per-page",
+        "5",
+      );
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn).toHaveProperty("labels");
+        expect(Array.isArray(txn.labels)).toBe(true);
+      }
+    });
+
+    it("includes attachments with --include attachments", () => {
+      const transactions = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--include",
+        "attachments",
+        "--no-paginate",
+        "--per-page",
+        "5",
+      );
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn).toHaveProperty("attachments");
+        expect(Array.isArray(txn.attachments)).toBe(true);
+      }
+    });
+
+    it("includes labels and attachments together", () => {
+      const transactions = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--include",
+        "labels",
+        "attachments",
+        "--no-paginate",
+        "--per-page",
+        "5",
+      );
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn).toHaveProperty("labels");
+        expect(Array.isArray(txn.labels)).toBe(true);
+        expect(txn).toHaveProperty("attachments");
+        expect(Array.isArray(txn.attachments)).toBe(true);
+      }
+    });
+
+    it("filters with --with-attachments", () => {
+      const transactions = cliJson<TransactionItem[]>(
+        "transaction",
+        "list",
+        "--with-attachments",
+        "--include",
+        "attachments",
+        "--no-paginate",
+      );
+      expect(Array.isArray(transactions)).toBe(true);
+      for (const txn of transactions) {
+        expect(txn.attachment_ids?.length ?? 0).toBeGreaterThan(0);
+      }
+    });
+
+    it("outputs CSV format", () => {
+      const output = cli("transaction", "list", "--output", "csv", "--no-paginate", "--per-page", "5");
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const header = lines[0] ?? "";
+      expect(header).toContain("id");
+      expect(header).toContain("amount");
+      expect(header).toContain("side");
+      expect(header).toContain("status");
+    });
+
+    it("outputs YAML format", () => {
+      const output = cli("transaction", "list", "--output", "yaml", "--no-paginate", "--per-page", "2");
+      expect(output).toContain("id:");
+    });
+
+    it("outputs table format", () => {
+      const output = cli("transaction", "list", "--output", "table", "--no-paginate", "--per-page", "2");
+      expect(output.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("transaction show", () => {
+    it("shows a transaction by ID", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
+      const first = firstTransaction(transactions);
+      if (first === undefined) return;
+
+      const txnId = first.id;
+      const transaction = cliJson<TransactionItem>("transaction", "show", txnId);
+      expect(transaction.id).toBe(txnId);
+      expect(transaction).toHaveProperty("amount");
+      expect(transaction).toHaveProperty("side");
+      expect(transaction).toHaveProperty("status");
+      expect(transaction).toHaveProperty("currency");
+    });
+
+    it("shows a transaction with included labels", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
+      const first = firstTransaction(transactions);
+      if (first === undefined) return;
+
+      const txnId = first.id;
+      const transaction = cliJson<TransactionItem>("transaction", "show", txnId, "--include", "labels");
+      expect(transaction.id).toBe(txnId);
+      expect(transaction).toHaveProperty("labels");
+      expect(Array.isArray(transaction.labels)).toBe(true);
+    });
+
+    it("shows a transaction with included attachments", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
+      const first = firstTransaction(transactions);
+      if (first === undefined) return;
+
+      const txnId = first.id;
+      const transaction = cliJson<TransactionItem>("transaction", "show", txnId, "--include", "attachments");
+      expect(transaction.id).toBe(txnId);
+      expect(transaction).toHaveProperty("attachments");
+    });
+
+    it("outputs transaction details as YAML", () => {
+      const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
+      const first = firstTransaction(transactions);
+      if (first === undefined) return;
+
+      const txnId = first.id;
+      const output = cli("transaction", "show", txnId, "--output", "yaml");
+      expect(output).toContain("id:");
+      expect(output).toContain(txnId);
+    });
+  });
+});

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function hasSandboxCredentials(): boolean {
+  return process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined && process.env["QONTOCTL_SECRET_KEY"] !== undefined;
+}
+
+interface TransactionItem {
+  readonly id: string;
+  readonly amount: number;
+  readonly side: "credit" | "debit";
+  readonly status: "pending" | "declined" | "completed";
+  readonly currency: string;
+  readonly bank_account_id: string;
+  readonly labels?: readonly { id: string; name: string }[];
+  readonly attachments?: readonly unknown[];
+}
+
+interface TransactionListResponse {
+  readonly transactions: TransactionItem[];
+  readonly meta: {
+    readonly current_page: number;
+    readonly total_pages: number;
+    readonly total_count: number;
+  };
+}
+
+describe.skipIf(!hasSandboxCredentials())("transaction MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: {
+        ...(process.env as Record<string, string>),
+        QONTOCTL_SANDBOX: "true",
+      },
+      stderr: "pipe",
+    });
+
+    client = new Client({
+      name: "e2e-test-client",
+      version: "0.0.0",
+    });
+
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("transaction_list", () => {
+    it("lists transactions", async () => {
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: {},
+      });
+
+      expect(result.content).toBeDefined();
+      expect(Array.isArray(result.content)).toBe(true);
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      expect(textContent.type).toBe("text");
+
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      expect(parsed).toHaveProperty("transactions");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.transactions)).toBe(true);
+    });
+
+    it("lists transactions with pagination", async () => {
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: { per_page: 2, current_page: 1 },
+      });
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      expect(parsed.transactions.length).toBeLessThanOrEqual(2);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+
+    it("filters by status", async () => {
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: { status: "completed" },
+      });
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      for (const txn of parsed.transactions) {
+        expect(txn.status).toBe("completed");
+      }
+    });
+
+    it("filters by side", async () => {
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: { side: "debit" },
+      });
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      for (const txn of parsed.transactions) {
+        expect(txn.side).toBe("debit");
+      }
+    });
+
+    it("filters by date range", async () => {
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: {
+          settled_at_from: "2020-01-01",
+          settled_at_to: "2030-12-31",
+        },
+      });
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      expect(parsed).toHaveProperty("transactions");
+      expect(Array.isArray(parsed.transactions)).toBe(true);
+    });
+
+    it("filters by bank account ID", async () => {
+      // First get a transaction to extract bank_account_id
+      const listResult = await client.callTool({
+        name: "transaction_list",
+        arguments: { per_page: 1 },
+      });
+      const listText = listResult.content[0] as {
+        type: string;
+        text: string;
+      };
+      const listParsed = JSON.parse(listText.text) as TransactionListResponse;
+      const firstTxn = listParsed.transactions[0];
+      if (firstTxn === undefined) return;
+
+      const bankAccountId = firstTxn.bank_account_id;
+      const result = await client.callTool({
+        name: "transaction_list",
+        arguments: { bank_account_id: bankAccountId },
+      });
+
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      for (const txn of parsed.transactions) {
+        expect(txn.bank_account_id).toBe(bankAccountId);
+      }
+    });
+  });
+
+  describe("transaction_show", () => {
+    it("shows a transaction by ID", async () => {
+      // First get a transaction ID
+      const listResult = await client.callTool({
+        name: "transaction_list",
+        arguments: { per_page: 1 },
+      });
+      const listText = listResult.content[0] as {
+        type: string;
+        text: string;
+      };
+      const listParsed = JSON.parse(listText.text) as TransactionListResponse;
+      const firstTxn = listParsed.transactions[0];
+      if (firstTxn === undefined) return;
+
+      const txnId = firstTxn.id;
+      const result = await client.callTool({
+        name: "transaction_show",
+        arguments: { id: txnId },
+      });
+
+      expect(result.content).toBeDefined();
+      const textContent = result.content[0] as {
+        type: string;
+        text: string;
+      };
+      expect(textContent.type).toBe("text");
+
+      const transaction = JSON.parse(textContent.text) as TransactionItem;
+      expect(transaction.id).toBe(txnId);
+      expect(transaction).toHaveProperty("amount");
+      expect(transaction).toHaveProperty("side");
+      expect(transaction).toHaveProperty("status");
+      expect(transaction).toHaveProperty("currency");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
 
   packages/e2e:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.27.1(zod@4.3.6)
       '@qontoctl/cli':
         specifier: workspace:^
         version: link:../cli


### PR DESCRIPTION
## Summary

- Add end-to-end tests for transaction CLI commands (`transaction list`, `transaction show`) covering filtering, pagination, sideloading, and all output formats (JSON, CSV, YAML, table)
- Add end-to-end tests for MCP transaction tools (`transaction_list`, `transaction_show`) using the MCP SDK `StdioClientTransport` for real server communication
- Tests skip automatically when sandbox credentials (`QONTOCTL_ORGANIZATION_SLUG`, `QONTOCTL_SECRET_KEY`) are not available

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (all 196 unit tests)
- [x] `pnpm lint` passes (all packages)
- [x] `pnpm license-check` passes
- [ ] CI passes on all 3 OS matrix (ubuntu, macos, windows)
- [ ] E2E tests pass with sandbox credentials (`pnpm test:e2e`)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)