### PR TITLE
(fix) auto-resolve bank account and fix E2E test infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,26 @@ ESLint enforces this via `eslint-plugin-header`.
 - E2E tests: `*.e2e.test.ts` (require Qonto sandbox)
 - Coverage thresholds: statements 85%, branches 69%, functions 80%, lines 85%
 
+### E2E Testing
+
+**When to run:** After implementing or modifying code that touches Qonto API interactions, CLI commands, MCP tools, or any behavior covered by E2E tests — run E2E tests locally to validate before completing the task.
+
+**Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with API key credentials. The config resolver picks this up from CWD automatically — no env var overrides needed.
+
+**Sandbox note:** The Qonto sandbox environment (`thirdparty-sandbox.staging.qonto.co`) is only for OAuth-based integrations. API key authentication uses the production endpoint (`thirdparty.qonto.com`) directly — there is no separate sandbox for API key auth. E2E tests run against production.
+
+**Running:**
+
+```sh
+pnpm test:e2e                       # Full E2E suite
+```
+
+- Turbo builds all packages before running tests (declared dependency)
+- Tests run sequentially (`--concurrency=1`) to avoid API race conditions
+- Per-test timeout: 30 seconds
+
+**What's covered:** organization/account listing, transactions (filtering, pagination), bank statements, labels (CRUD), memberships, MCP server initialization, and MCP tool invocations.
+
 ### TypeScript
 
 - Strict mode with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`

--- a/packages/cli/src/commands/transaction/list.test.ts
+++ b/packages/cli/src/commands/transaction/list.test.ts
@@ -25,6 +25,22 @@ function makeMeta(overrides: Record<string, unknown> = {}) {
   };
 }
 
+const ORG_BODY = {
+  organization: {
+    slug: "test-org",
+    legal_name: "Test Org",
+    bank_accounts: [{ id: "auto-acc-1", main: true }],
+  },
+};
+
+function findTransactionCallUrl(spy: ReturnType<typeof vi.fn>): URL {
+  const call = spy.mock.calls.find(
+    (c) => (c[0] as URL).pathname === "/v2/transactions",
+  );
+  expect(call, "expected a fetch call to /v2/transactions").toBeDefined();
+  return (call as unknown[])[0] as URL;
+}
+
 describe("transaction list command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let writtenOutput: string[];
@@ -98,34 +114,49 @@ describe("transaction list command", () => {
   });
 
   it("passes status filter as array param", async () => {
-    fetchSpy.mockReturnValue(
-      jsonResponse({ transactions: [], meta: makeMeta() }),
-    );
+    fetchSpy.mockImplementation((input: URL) => {
+      if (input.pathname === "/v2/organization") return jsonResponse(ORG_BODY);
+      return jsonResponse({ transactions: [], meta: makeMeta() });
+    });
 
     await runCommand("--status", "pending", "completed");
 
-    const [url] = fetchSpy.mock.calls[0] as [URL];
-    expect(url.searchParams.getAll("status[]")).toEqual(["pending", "completed"]);
+    const txnUrl = findTransactionCallUrl(fetchSpy);
+    expect(txnUrl.searchParams.getAll("status[]")).toEqual(["pending", "completed"]);
   });
 
   it("passes with-attachments filter", async () => {
-    fetchSpy.mockReturnValue(
-      jsonResponse({ transactions: [], meta: makeMeta() }),
-    );
+    fetchSpy.mockImplementation((input: URL) => {
+      if (input.pathname === "/v2/organization") return jsonResponse(ORG_BODY);
+      return jsonResponse({ transactions: [], meta: makeMeta() });
+    });
 
     await runCommand("--with-attachments");
 
-    const [url] = fetchSpy.mock.calls[0] as [URL];
-    expect(url.searchParams.get("with_attachments")).toBe("true");
+    const txnUrl = findTransactionCallUrl(fetchSpy);
+    expect(txnUrl.searchParams.get("with_attachments")).toBe("true");
+  });
+
+  it("auto-resolves bank account from organization", async () => {
+    fetchSpy.mockImplementation((input: URL) => {
+      if (input.pathname === "/v2/organization") return jsonResponse(ORG_BODY);
+      return jsonResponse({ transactions: [], meta: makeMeta() });
+    });
+
+    await runCommand();
+
+    const txnUrl = findTransactionCallUrl(fetchSpy);
+    expect(txnUrl.searchParams.get("bank_account_id")).toBe("auto-acc-1");
   });
 
   it("outputs JSON when --output json", async () => {
     const txns = [
       { id: "txn-1", label: "Coffee", amount: 4.5, side: "debit" },
     ];
-    fetchSpy.mockReturnValue(
-      jsonResponse({ transactions: txns, meta: makeMeta({ total_count: 1 }) }),
-    );
+    fetchSpy.mockImplementation((input: URL) => {
+      if (input.pathname === "/v2/organization") return jsonResponse(ORG_BODY);
+      return jsonResponse({ transactions: txns, meta: makeMeta({ total_count: 1 }) });
+    });
 
     await runCommand("--output", "json");
 
@@ -148,12 +179,13 @@ describe("transaction list command", () => {
         extra_field: "should-not-appear",
       },
     ];
-    fetchSpy.mockReturnValue(
-      jsonResponse({
+    fetchSpy.mockImplementation((input: URL) => {
+      if (input.pathname === "/v2/organization") return jsonResponse(ORG_BODY);
+      return jsonResponse({
         transactions: txns,
         meta: makeMeta({ total_count: 1 }),
-      }),
-    );
+      });
+    });
 
     await runCommand("--output", "table");
 

--- a/packages/cli/src/commands/transaction/list.ts
+++ b/packages/cli/src/commands/transaction/list.ts
@@ -5,6 +5,7 @@ import type { Command } from "commander";
 import { Option } from "commander";
 import {
   buildTransactionQueryParams,
+  getOrganization,
   type ListTransactionsParams,
   type Transaction,
 } from "@qontoctl/core";
@@ -104,7 +105,15 @@ export function registerTransactionListCommand(parent: Command): void {
       const opts = cmd.optsWithGlobals<TransactionListOptions>();
       const client = await createClient(opts);
 
-      const queryParams = buildTransactionQueryParams(buildParams(opts));
+      let params = buildParams(opts);
+      if (params.bank_account_id === undefined && params.iban === undefined) {
+        const org = await getOrganization(client);
+        const mainAccount = org.bank_accounts.find((a) => a.main) ?? org.bank_accounts[0];
+        if (mainAccount !== undefined) {
+          params = { ...params, bank_account_id: mainAccount.id };
+        }
+      }
+      const queryParams = buildTransactionQueryParams(params);
 
       const result = await fetchPaginated<Transaction>(
         client,

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -20,6 +20,7 @@
     "@qontoctl/cli": "workspace:^",
     "@qontoctl/core": "workspace:^",
     "@qontoctl/mcp": "workspace:^",
+    "yaml": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -4,29 +4,26 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
   "../../../qontoctl/dist/cli.js",
 );
 
-const hasCredentials =
-  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-
 /**
- * Run the CLI with the given arguments, inheriting sandbox credentials
+ * Run the CLI with the given arguments, inheriting credentials
  * from the environment.
  */
 function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
-    env: { ...process.env, QONTOCTL_SANDBOX: "1" },
+    env: cliEnv(),
     timeout: 15_000,
   });
 }
 
-describe.skipIf(!hasCredentials)("label commands (e2e)", () => {
+describe.skipIf(!hasCredentials())("label commands (e2e)", () => {
   describe("label list", () => {
     it("lists labels with id, name, parent_id", () => {
       const output = cli("label", "list");

--- a/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
@@ -5,15 +5,12 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
   "../../../qontoctl/dist/cli.js",
 );
-
-const hasCredentials =
-  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
 
 /**
  * Extract the text content from a single-entry MCP tool result.
@@ -26,7 +23,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials)("MCP label & membership tools (e2e)", () => {
+describe.skipIf(!hasCredentials())("MCP label & membership tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 
@@ -34,10 +31,7 @@ describe.skipIf(!hasCredentials)("MCP label & membership tools (e2e)", () => {
     transport = new StdioClientTransport({
       command: "node",
       args: [CLI_PATH, "mcp"],
-      env: {
-        ...process.env,
-        QONTOCTL_SANDBOX: "1",
-      } as Record<string, string>,
+      env: cliEnv(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -4,29 +4,26 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
   "../../../qontoctl/dist/cli.js",
 );
 
-const hasCredentials =
-  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-
 /**
- * Run the CLI with the given arguments, inheriting sandbox credentials
+ * Run the CLI with the given arguments, inheriting credentials
  * from the environment.
  */
 function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
-    env: { ...process.env, QONTOCTL_SANDBOX: "1" },
+    env: cliEnv(),
     timeout: 15_000,
   });
 }
 
-describe.skipIf(!hasCredentials)("membership commands (e2e)", () => {
+describe.skipIf(!hasCredentials())("membership commands (e2e)", () => {
   describe("membership list", () => {
     it("lists memberships with expected fields", () => {
       const output = cli("membership", "list");

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -7,6 +7,7 @@ import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -23,13 +24,6 @@ const EXPECTED_TOOLS = [
   "membership_list",
 ] as const;
 
-function hasSandboxCredentials(): boolean {
-  return (
-    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-    process.env["QONTOCTL_SECRET_KEY"] !== undefined
-  );
-}
-
 describe("MCP server via stdio (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
@@ -38,6 +32,7 @@ describe("MCP server via stdio (e2e)", () => {
     transport = new StdioClientTransport({
       command: "node",
       args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
       stderr: "pipe",
     });
     client = new Client({ name: "e2e-test", version: "0.0.0" });
@@ -83,7 +78,7 @@ describe("MCP server via stdio (e2e)", () => {
     });
   });
 
-  describe.skipIf(!hasSandboxCredentials())("tool call with valid credentials", () => {
+  describe.skipIf(!hasCredentials())("tool call with valid credentials", () => {
     it("org_show returns organization data in MCP content format", async () => {
       const result = await client.callTool({ name: "org_show", arguments: {} });
 

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -4,30 +4,21 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
   "../../../qontoctl/dist/cli.js",
 );
 
-function hasSandboxCredentials(): boolean {
-  return (
-    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-    process.env["QONTOCTL_SECRET_KEY"] !== undefined
-  );
-}
-
 function cli(args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
-    env: {
-      ...process.env,
-      QONTOCTL_SANDBOX: "1",
-    },
+    env: cliEnv(),
   });
 }
 
-describe.skipIf(!hasSandboxCredentials())(
+describe.skipIf(!hasCredentials())(
   "organization & accounts CLI (e2e)",
   () => {
     let knownAccountId: string;

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -5,20 +5,14 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
   "../../../qontoctl/dist/cli.js",
 );
 
-function hasSandboxCredentials(): boolean {
-  return (
-    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-    process.env["QONTOCTL_SECRET_KEY"] !== undefined
-  );
-}
-
-describe.skipIf(!hasSandboxCredentials())(
+describe.skipIf(!hasCredentials())(
   "organization & accounts MCP (e2e)",
   () => {
     let client: Client;
@@ -28,10 +22,7 @@ describe.skipIf(!hasSandboxCredentials())(
       transport = new StdioClientTransport({
         command: "node",
         args: [CLI_PATH, "mcp"],
-        env: {
-          ...(process.env as Record<string, string>),
-          QONTOCTL_SANDBOX: "1",
-        },
+        env: cliEnv(),
         stderr: "pipe",
       });
 

--- a/packages/e2e/src/profile/profile.e2e.test.ts
+++ b/packages/e2e/src/profile/profile.e2e.test.ts
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getCredentials, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(
   import.meta.dirname,
@@ -306,15 +307,8 @@ describe("profile commands (e2e)", () => {
 // profile test — requires sandbox API access
 // ---------------------------------------------------------------------------
 
-function hasSandboxCredentials(): boolean {
-  return (
-    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-    process.env["QONTOCTL_SECRET_KEY"] !== undefined
-  );
-}
-
-describe.skipIf(!hasSandboxCredentials())(
-  "profile test (e2e, sandbox)",
+describe.skipIf(!hasCredentials())(
+  "profile test (e2e)",
   () => {
     let tempDir: string;
 
@@ -330,15 +324,11 @@ describe.skipIf(!hasSandboxCredentials())(
     //     When `profile test` is run,
     //     Then it calls GET /v2/organization and reports success with org name
     it("reports success with organization name for valid credentials", () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by hasSandboxCredentials()
-      const orgSlug = process.env["QONTOCTL_ORGANIZATION_SLUG"]!;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by hasSandboxCredentials()
-      const secretKey = process.env["QONTOCTL_SECRET_KEY"]!;
+      const creds = getCredentials();
       const { stdout, exitCode } = cli(["profile", "test"], {
         env: homeEnv(tempDir, {
-          QONTOCTL_ORGANIZATION_SLUG: orgSlug,
-          QONTOCTL_SECRET_KEY: secretKey,
-          QONTOCTL_SANDBOX: "true",
+          QONTOCTL_ORGANIZATION_SLUG: creds.organizationSlug,
+          QONTOCTL_SECRET_KEY: creds.secretKey,
         }),
       });
       expect(exitCode).toBe(0);
@@ -353,7 +343,6 @@ describe.skipIf(!hasSandboxCredentials())(
         env: homeEnv(tempDir, {
           QONTOCTL_ORGANIZATION_SLUG: "invalid-org-slug",
           QONTOCTL_SECRET_KEY: "invalid-secret-key",
-          QONTOCTL_SANDBOX: "true",
         }),
       });
       expect(exitCode).not.toBe(0);

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+interface ApiKeyCredentials {
+  readonly organizationSlug: string;
+  readonly secretKey: string;
+}
+
+/**
+ * Read API key credentials from `.qontoctl.yaml`, searching from the
+ * working directory up to the filesystem root. Returns `undefined` if
+ * no config file with credentials is found.
+ */
+function readConfigFileCredentials(): ApiKeyCredentials | undefined {
+  let dir = process.cwd();
+  for (;;) {
+    const result = tryReadConfigFile(join(dir, ".qontoctl.yaml"));
+    if (result !== undefined) {
+      return result;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+function tryReadConfigFile(path: string): ApiKeyCredentials | undefined {
+  try {
+    const content = readFileSync(path, "utf-8");
+    const parsed: unknown = parseYaml(content);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "api-key" in parsed
+    ) {
+      const apiKey = (parsed as Record<string, unknown>)["api-key"];
+      if (
+        typeof apiKey === "object" &&
+        apiKey !== null &&
+        "organization_slug" in apiKey &&
+        "secret_key" in apiKey
+      ) {
+        const record = apiKey as Record<string, unknown>;
+        const slug = record["organization_slug"];
+        const key = record["secret_key"];
+        if (typeof slug === "string" && typeof key === "string") {
+          return { organizationSlug: slug, secretKey: key };
+        }
+      }
+    }
+  } catch {
+    // File not found or unreadable
+  }
+  return undefined;
+}
+
+/**
+ * Check whether Qonto API credentials are available — either via
+ * environment variables or via `.qontoctl.yaml` in the working directory.
+ *
+ * Used by `describe.skipIf(!hasCredentials())` guards in E2E tests so
+ * that API-dependent suites are skipped when no credentials are present.
+ */
+export function hasCredentials(): boolean {
+  if (
+    process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
+    process.env["QONTOCTL_SECRET_KEY"] !== undefined
+  ) {
+    return true;
+  }
+  return readConfigFileCredentials() !== undefined;
+}
+
+/**
+ * Retrieve the API key credentials from environment variables or
+ * `.qontoctl.yaml`. Throws if no credentials are available (callers
+ * should be guarded by `hasCredentials()`).
+ */
+export function getCredentials(): ApiKeyCredentials {
+  const envSlug = process.env["QONTOCTL_ORGANIZATION_SLUG"];
+  const envKey = process.env["QONTOCTL_SECRET_KEY"];
+  if (envSlug !== undefined && envKey !== undefined) {
+    return { organizationSlug: envSlug, secretKey: envKey };
+  }
+
+  const fileCreds = readConfigFileCredentials();
+  if (fileCreds !== undefined) {
+    return fileCreds;
+  }
+
+  throw new Error("No Qonto credentials available (checked env vars and .qontoctl.yaml)");
+}
+
+/**
+ * Build an environment for spawning CLI child processes, ensuring
+ * credentials are available via env vars. When credentials come from
+ * `.qontoctl.yaml` (not env vars), this injects them so child
+ * processes running from a different CWD can resolve them.
+ */
+export function cliEnv(): Record<string, string> {
+  const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+
+  if (env["QONTOCTL_ORGANIZATION_SLUG"] === undefined || env["QONTOCTL_SECRET_KEY"] === undefined) {
+    const creds = getCredentials();
+    env["QONTOCTL_ORGANIZATION_SLUG"] = creds.organizationSlug;
+    env["QONTOCTL_SECRET_KEY"] = creds.secretKey;
+  }
+
+  return env;
+}

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -6,34 +6,20 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-const hasSandboxCreds =
-  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-
-/**
- * Build environment with sandbox credentials for CLI invocations.
- * Inherits the current process environment and ensures sandbox mode is on.
- */
-function sandboxEnv(): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    QONTOCTL_SANDBOX: "true",
-  };
-}
 
 function listStatements(): Record<string, unknown>[] {
   const output = execFileSync(
     "node",
     [CLI_PATH, "statement", "list", "--no-paginate", "-o", "json"],
-    { encoding: "utf-8", env: sandboxEnv() },
+    { encoding: "utf-8", env: cliEnv() },
   );
   return JSON.parse(output) as Record<string, unknown>[];
 }
 
-describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
+describe.skipIf(!hasCredentials())("statement CLI commands (e2e)", () => {
   // -- statement list --
 
   describe("statement list", () => {
@@ -68,7 +54,7 @@ describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
           "-o",
           "json",
         ],
-        { encoding: "utf-8", env: sandboxEnv() },
+        { encoding: "utf-8", env: cliEnv() },
       );
       const filteredRows = JSON.parse(filteredOutput) as Record<string, unknown>[];
 
@@ -92,7 +78,7 @@ describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
           "-o",
           "json",
         ],
-        { encoding: "utf-8", env: sandboxEnv() },
+        { encoding: "utf-8", env: cliEnv() },
       );
 
       // The command should succeed; results may be empty if no statements in range
@@ -113,7 +99,7 @@ describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
       const showOutput = execFileSync(
         "node",
         [CLI_PATH, "statement", "show", statementId, "-o", "json"],
-        { encoding: "utf-8", env: sandboxEnv() },
+        { encoding: "utf-8", env: cliEnv() },
       );
       const showRows = JSON.parse(showOutput) as Record<string, unknown>[];
       expect(showRows).toHaveLength(1);
@@ -153,7 +139,7 @@ describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
       execFileSync(
         "node",
         [CLI_PATH, "statement", "download", statementId],
-        { encoding: "utf-8", env: sandboxEnv(), cwd: downloadDir },
+        { encoding: "utf-8", env: cliEnv(), cwd: downloadDir },
       );
 
       const downloadedFile = join(downloadDir, expectedFileName);
@@ -172,7 +158,7 @@ describe.skipIf(!hasSandboxCreds)("statement CLI commands (e2e)", () => {
       execFileSync(
         "node",
         [CLI_PATH, "statement", "download", statementId, "--output-dir", outputDir],
-        { encoding: "utf-8", env: sandboxEnv() },
+        { encoding: "utf-8", env: cliEnv() },
       );
 
       const downloadedFile = join(outputDir, expectedFileName);

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -5,14 +5,11 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-const hasSandboxCreds =
-  process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined &&
-  process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-
-describe.skipIf(!hasSandboxCreds)("statement MCP tools (e2e)", () => {
+describe.skipIf(!hasCredentials())("statement MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 
@@ -20,10 +17,7 @@ describe.skipIf(!hasSandboxCreds)("statement MCP tools (e2e)", () => {
     transport = new StdioClientTransport({
       command: "node",
       args: [CLI_PATH, "mcp"],
-      env: {
-        ...(process.env as Record<string, string>),
-        QONTOCTL_SANDBOX: "true",
-      },
+      env: cliEnv(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -4,20 +4,14 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function hasSandboxCredentials(): boolean {
-  return process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined && process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-}
 
 function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
-    env: {
-      ...process.env,
-      QONTOCTL_SANDBOX: "true",
-    },
+    env: cliEnv(),
   });
 }
 
@@ -49,7 +43,7 @@ function firstTransaction(transactions: readonly TransactionItem[]): Transaction
   return transactions[0];
 }
 
-describe.skipIf(!hasSandboxCredentials())("transaction CLI commands (e2e)", () => {
+describe.skipIf(!hasCredentials())("transaction CLI commands (e2e)", () => {
   describe("transaction list", () => {
     it("lists transactions with default output", () => {
       const output = cli("transaction", "list", "--no-paginate");
@@ -112,7 +106,7 @@ describe.skipIf(!hasSandboxCredentials())("transaction CLI commands (e2e)", () =
 
     it("filters by date range", () => {
       const fromDate = "2020-01-01";
-      const toDate = "2030-12-31";
+      const toDate = "2026-12-31";
       const transactions = cliJson<TransactionItem[]>(
         "transaction",
         "list",

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -5,12 +5,9 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function hasSandboxCredentials(): boolean {
-  return process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined && process.env["QONTOCTL_SECRET_KEY"] !== undefined;
-}
 
 interface TransactionItem {
   readonly id: string;
@@ -32,7 +29,7 @@ interface TransactionListResponse {
   };
 }
 
-describe.skipIf(!hasSandboxCredentials())("transaction MCP tools (e2e)", () => {
+describe.skipIf(!hasCredentials())("transaction MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 
@@ -40,10 +37,7 @@ describe.skipIf(!hasSandboxCredentials())("transaction MCP tools (e2e)", () => {
     transport = new StdioClientTransport({
       command: "node",
       args: [CLI_PATH, "mcp"],
-      env: {
-        ...(process.env as Record<string, string>),
-        QONTOCTL_SANDBOX: "true",
-      },
+      env: cliEnv(),
       stderr: "pipe",
     });
 
@@ -133,7 +127,7 @@ describe.skipIf(!hasSandboxCredentials())("transaction MCP tools (e2e)", () => {
         name: "transaction_list",
         arguments: {
           settled_at_from: "2020-01-01",
-          settled_at_to: "2030-12-31",
+          settled_at_to: "2026-12-31",
         },
       });
 

--- a/packages/mcp/src/tools/transactions.test.ts
+++ b/packages/mcp/src/tools/transactions.test.ts
@@ -10,6 +10,14 @@ function createMockClient() {
   return { get: vi.fn() } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };
 }
 
+const ORG_BODY = {
+  organization: {
+    slug: "test-org",
+    legal_name: "Test Org",
+    bank_accounts: [{ id: "auto-acc-1", main: true }],
+  },
+};
+
 describe("registerTransactionTools", () => {
   it("registers transaction_list and transaction_show tools", () => {
     const server = new McpServer({ name: "test", version: "0.0.0" });
@@ -58,7 +66,10 @@ describe("registerTransactionTools", () => {
   it("transaction_list passes pagination params as strings", async () => {
     const server = new McpServer({ name: "test", version: "0.0.0" });
     const mockClient = createMockClient();
-    mockClient.get.mockResolvedValue({ transactions: [], meta: {} });
+    mockClient.get.mockImplementation((path: string) => {
+      if (path === "/v2/organization") return Promise.resolve(ORG_BODY);
+      return Promise.resolve({ transactions: [], meta: {} });
+    });
     registerTransactionTools(server, () => Promise.resolve(mockClient));
 
     const tool = (
@@ -72,8 +83,34 @@ describe("registerTransactionTools", () => {
     } as never);
 
     expect(mockClient.get).toHaveBeenCalledWith("/v2/transactions", {
+      bank_account_id: "auto-acc-1",
       current_page: "2",
       per_page: "50",
+    });
+  });
+
+  it("transaction_list auto-resolves bank account from organization", async () => {
+    const server = new McpServer({ name: "test", version: "0.0.0" });
+    const mockClient = createMockClient();
+    mockClient.get.mockImplementation((path: string) => {
+      if (path === "/v2/organization") return Promise.resolve(ORG_BODY);
+      return Promise.resolve({
+        transactions: [{ id: "txn-1", amount: 42.0, side: "debit" }],
+        meta: { current_page: 1, total_pages: 1, total_count: 1 },
+      });
+    });
+    registerTransactionTools(server, () => Promise.resolve(mockClient));
+
+    const tool = (
+      server as unknown as {
+        _registeredTools: Record<string, { handler: (...args: unknown[]) => Promise<unknown> }>;
+      }
+    )._registeredTools["transaction_list"] as { handler: (...args: unknown[]) => Promise<unknown> };
+    await tool.handler({} as never);
+
+    expect(mockClient.get).toHaveBeenCalledWith("/v2/organization");
+    expect(mockClient.get).toHaveBeenCalledWith("/v2/transactions", {
+      bank_account_id: "auto-acc-1",
     });
   });
 

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -3,7 +3,7 @@
 
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { HttpClient } from "@qontoctl/core";
+import { type HttpClient, getOrganization } from "@qontoctl/core";
 import { withClient } from "../errors.js";
 
 export function registerTransactionTools(
@@ -47,7 +47,16 @@ export function registerTransactionTools(
       withClient(getClient, async (client) => {
         const params: Record<string, string> = {};
 
-        if (args.bank_account_id !== undefined) params["bank_account_id"] = args.bank_account_id;
+        let bankAccountId = args.bank_account_id;
+        if (bankAccountId === undefined && args.iban === undefined) {
+          const org = await getOrganization(client);
+          const mainAccount = org.bank_accounts.find((a) => a.main) ?? org.bank_accounts[0];
+          if (mainAccount !== undefined) {
+            bankAccountId = mainAccount.id;
+          }
+        }
+
+        if (bankAccountId !== undefined) params["bank_account_id"] = bankAccountId;
         if (args.iban !== undefined) params["iban"] = args.iban;
         if (args.settled_at_from !== undefined) params["settled_at_from"] = args.settled_at_from;
         if (args.settled_at_to !== undefined) params["settled_at_to"] = args.settled_at_to;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@qontoctl/mcp':
         specifier: workspace:^
         version: link:../mcp
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.2
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## Summary

- **Auto-resolve bank account**: Transaction list commands (CLI `transaction list` and MCP `transaction_list`) now automatically resolve the main bank account from the organization when neither `--bank-account`/`bank_account_id` nor `--iban` is provided. This fixes 422 errors from the Qonto API which requires one of these parameters.
- **Centralize E2E credentials**: Extracted shared `sandbox.ts` module (`hasCredentials()`, `getCredentials()`, `cliEnv()`) that discovers `.qontoctl.yaml` by walking up from CWD, replacing duplicated credential helpers across 11 test files.
- **Remove sandbox references**: Removed `QONTOCTL_SANDBOX` env var usage from E2E tests since API key auth uses the production endpoint directly (sandbox is OAuth-only).
- **Fix date range tests**: Changed future date from `2030-12-31` to `2026-12-31` to avoid API rejection of out-of-range dates.

## Test plan

- [x] All 345 unit tests pass
- [x] All 80 E2E tests pass (5 skipped — fish completions)
- [x] Build clean across all packages
- [x] Lint clean across all packages
- [ ] CI passes on all 3 OS matrix (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)