### PR TITLE
(chore) add build/ and .tmp/ to .gitignore (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ## Project-specific
 .qontoctl.yaml
 *.local.*
+build/
+.tmp/
 
 # Turbo
 .turbo/


### PR DESCRIPTION
## Summary
- Add `build/` to `.gitignore` to prevent accidentally committing CI gh-pages output from local docs builds
- Add `.tmp/` to `.gitignore` to prevent leaking audit reports or scratch files from temporary working directory

Closes #65

## Test plan
- [x] Verify `build/` and `.tmp/` entries are in the project-specific section of `.gitignore`
- [x] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)