### PR TITLE
(fix) exclude test files from dist/ builds

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     { "path": "../core" }
   ]

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     { "path": "../core" }
   ]

--- a/packages/qontoctl/tsconfig.json
+++ b/packages/qontoctl/tsconfig.json
@@ -6,6 +6,7 @@
     "rootDir": "src"
   },
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "references": [
     { "path": "../cli" },
     { "path": "../mcp" }


### PR DESCRIPTION
## Summary

- Add `"exclude": ["**/*.test.ts"]` to `packages/cli/tsconfig.json`, `packages/mcp/tsconfig.json`, and `packages/qontoctl/tsconfig.json`
- Matches the existing pattern in `packages/core/tsconfig.json` which already excludes test files
- Eliminates 37 unnecessary test artifact files from `dist/` directories that would be published to npm

Closes #57

## Test plan

- [x] `pnpm build` succeeds — zero test files in any `dist/` directory
- [x] `pnpm test` — all 345 unit tests pass
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)