### PR TITLE
(fix) include LICENSE file in published npm packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "dist"
   ],
   "scripts": {
+    "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "test": "vitest run",
     "lint": "eslint src/",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "dist"
   ],
   "scripts": {
+    "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src/",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,6 +36,7 @@
     "dist"
   ],
   "scripts": {
+    "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "test": "vitest run --passWithNoTests",
     "lint": "eslint src/",

--- a/packages/qontoctl/package.json
+++ b/packages/qontoctl/package.json
@@ -37,7 +37,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "cp ../../README.md .",
+    "prepack": "cp ../../README.md ../../LICENSE .",
     "build": "tsc",
     "test": "vitest run",
     "lint": "eslint src/",


### PR DESCRIPTION
## Summary

- Add `prepack` scripts to `@qontoctl/core`, `@qontoctl/cli`, and `@qontoctl/mcp` that copy the root LICENSE file into the package directory before packing
- Extend `qontoctl` umbrella's existing `prepack` to also copy LICENSE alongside README.md
- Ensures all 4 published tarballs include the AGPL-3.0-only license text, satisfying section 4 requirements

## Verification

- `npm pack --dry-run` confirms LICENSE (34.5kB) appears in all 4 package tarballs
- All unit tests pass (345 tests)
- Lint clean

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)