### PR TITLE
(fix) add publishConfig to scoped package.json files (#76)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -35,6 +35,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Adds `publishConfig.access: "public"` to `@qontoctl/core`, `@qontoctl/cli`, and `@qontoctl/mcp` package.json files
- Without this, npm defaults scoped packages to `restricted` access, which would cause the first publish to fail or require manual `--access public`
- Unscoped `qontoctl` (already public by default) and private `@qontoctl/e2e` are excluded

Closes #76

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — all 345 unit tests pass
- [x] Verified only the three scoped, publishable packages are modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)