### PR TITLE
(fix) set restrictive file permissions on credential config files (#67)

### DIFF
--- a/packages/cli/src/commands/profile/add.test.ts
+++ b/packages/cli/src/commands/profile/add.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
@@ -120,5 +120,31 @@ describe("profile add", () => {
 
     expect(consoleErrorSpy).toHaveBeenCalledWith("Secret key cannot be empty.");
     expect(process.exitCode).toBe(1);
+  });
+
+  it.skipIf(process.platform === "win32")("creates config directory with 0700 permissions", async () => {
+    mockQuestionResponses = ["my-org", "my-secret"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "secure"], { from: "user" });
+
+    const dirStat = await stat(join(testHome, ".qontoctl"));
+    expect(dirStat.mode & 0o777).toBe(0o700);
+  });
+
+  it.skipIf(process.platform === "win32")("creates profile file with 0600 permissions", async () => {
+    mockQuestionResponses = ["my-org", "my-secret"];
+
+    const program = createProgram();
+    registerProfileCommands(program);
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "add", "secure"], { from: "user" });
+
+    const fileStat = await stat(join(testHome, ".qontoctl", "secure.yaml"));
+    expect(fileStat.mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -64,10 +64,10 @@ async function addProfile(name: string): Promise<void> {
     };
 
     const dir = join(homedir(), CONFIG_DIR);
-    await mkdir(dir, { recursive: true });
+    await mkdir(dir, { recursive: true, mode: 0o700 });
 
     const path = join(dir, `${name}.yaml`);
-    await writeFile(path, stringifyYaml(config), "utf-8");
+    await writeFile(path, stringifyYaml(config), { encoding: "utf-8", mode: 0o600 });
 
     console.log(`Profile "${name}" created at ${path}`);
   } finally {


### PR DESCRIPTION
## Summary

- Set `mode: 0o700` on `~/.qontoctl/` directory creation to restrict access to owner only
- Set `mode: 0o600` on credential YAML files to prevent other local users from reading API keys
- Add unit tests verifying directory and file permissions (skipped on Windows where Unix permissions don't apply)

Closes #67

## Test plan

- [x] Unit tests pass (347 total, including 2 new permission tests)
- [x] Lint passes
- [x] Build succeeds
- [ ] CI passes on all 3 OS matrix (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)