### PR TITLE
(fix) align @types/node with runtime requirement (#63)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^1.26.0
       version: 1.27.1
     '@types/node':
-      specifier: ^25
-      version: 25.3.2
+      specifier: ^24
+      version: 24.10.15
     '@vitest/coverage-v8':
       specifier: ^4.0.18
       version: 4.0.18
@@ -104,7 +104,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.3.2
+        version: 24.10.15
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -113,7 +113,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.15)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.3.2
+        version: 24.10.15
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -135,7 +135,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.15)(yaml@2.8.2)
 
   packages/e2e:
     dependencies:
@@ -160,7 +160,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.3.2
+        version: 24.10.15
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -169,7 +169,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.15)(yaml@2.8.2)
 
   packages/mcp:
     dependencies:
@@ -185,7 +185,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.3.2
+        version: 24.10.15
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -194,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.15)(yaml@2.8.2)
 
   packages/qontoctl:
     dependencies:
@@ -207,7 +207,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 25.3.2
+        version: 24.10.15
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -216,7 +216,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@25.3.2)(yaml@2.8.2)
+        version: 4.0.18(@types/node@24.10.15)(yaml@2.8.2)
 
 packages:
 
@@ -637,6 +637,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.10.15':
+    resolution: {integrity: sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==}
 
   '@types/node@25.3.2':
     resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
@@ -1548,6 +1551,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
@@ -1977,9 +1983,14 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@24.10.15':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/node@25.3.2':
     dependencies:
       undici-types: 7.18.2
+    optional: true
 
   '@types/unist@3.0.3': {}
 
@@ -2096,6 +2107,14 @@ snapshots:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.15)(yaml@2.8.2)
 
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.2))':
     dependencies:
@@ -2963,7 +2982,10 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.16.0: {}
+
+  undici-types@7.18.2:
+    optional: true
 
   unpipe@1.0.0: {}
 
@@ -2972,6 +2994,19 @@ snapshots:
       punycode: 2.3.1
 
   vary@1.1.2: {}
+
+  vite@7.3.1(@types/node@24.10.15)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.15
+      fsevents: 2.3.3
+      yaml: 2.8.2
 
   vite@7.3.1(@types/node@25.3.2)(yaml@2.8.2):
     dependencies:
@@ -2985,6 +3020,43 @@ snapshots:
       '@types/node': 25.3.2
       fsevents: 2.3.3
       yaml: 2.8.2
+
+  vitest@4.0.18(@types/node@24.10.15)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@24.10.15)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@types/node@25.3.2)(yaml@2.8.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
 
 catalog:
   typescript: "^5.9.3"
-  "@types/node": "^25"
+  "@types/node": "^24"
   vitest: "^4.0.18"
   "@vitest/coverage-v8": "^4.0.18"
   "@eslint/js": "^9.39.2"


### PR DESCRIPTION
## Summary

- Downgrade `@types/node` catalog entry from `^25` to `^24` to match the `"node": ">=24"` engines requirement declared by all packages
- Regenerate lockfile — all workspace packages now resolve `@types/node@24.x`

Closes #63

## Test plan

- [x] All packages build cleanly with `@types/node@24`
- [x] 345 unit tests pass across all packages
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)