### PR TITLE
(fix) use resolved endpoint in MCP standalone entry (#60)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -11,13 +11,13 @@ import { runStdioServer } from "./stdio.js";
 
 await runStdioServer({
   getClient: async () => {
-    const { config } = await resolveConfig();
+    const { config, endpoint } = await resolveConfig();
     if (config.apiKey === undefined) {
       throw new Error("No API key credentials found in configuration");
     }
     const authorization = buildApiKeyAuthorization(config.apiKey);
     return new HttpClient({
-      baseUrl: "https://thirdparty.qonto.com",
+      baseUrl: endpoint,
       authorization,
     });
   },


### PR DESCRIPTION
## Summary

- Replace hardcoded `baseUrl: "https://thirdparty.qonto.com"` in the MCP standalone entry point with the `endpoint` returned by `resolveConfig()`
- This ensures the MCP server respects the user's `endpoint` and `sandbox` configuration, matching CLI behavior

Closes #60

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 345 unit tests pass (`pnpm test`)
- [x] All 80 E2E tests pass (`pnpm test:e2e`)
- [x] Default behavior unchanged (resolveEndpoint returns production URL when no custom config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)