### PR TITLE
Add debug mode warning and redact sensitive fields in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ oauth:
 
 OAuth takes precedence over API Key when tokens are valid. Expired tokens are refreshed automatically and written back to the source file.
 
+## Debug Mode
+
+The `--verbose` and `--debug` flags enable wire-level logging to stderr:
+
+```sh
+qontoctl --verbose transactions list   # request/response summaries
+qontoctl --debug transactions list     # full headers and response bodies
+```
+
+> **Security note:** `--debug` logs full API response bodies. Known sensitive fields
+> (IBAN, BIC, balance) are automatically redacted, but responses may still contain
+> other financial data. Do not use `--debug` in shared environments or pipe debug
+> output to files accessible by others.
+
 ## Disclaimer
 
 `qontoctl` is an **independent project** not affiliated with, endorsed by, or officially connected to **Qonto** or Qonto SAS.

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -115,6 +115,25 @@ describe("createClient", () => {
     expect(stderrSpy).toHaveBeenCalledWith("debug msg\n");
   });
 
+  it("emits a warning when --debug is set", async () => {
+    const options: GlobalOptions = { output: "table", debug: true };
+    await createClient(options);
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Debug mode logs full API responses"),
+    );
+  });
+
+  it("does not emit debug warning when only --verbose is set", async () => {
+    const options: GlobalOptions = { output: "table", verbose: true };
+    await createClient(options);
+
+    const calls = stderrSpy.mock.calls.map(
+      (call: [string]) => call[0],
+    ) as string[];
+    expect(calls.every((msg) => !msg.includes("Debug mode"))).toBe(true);
+  });
+
   it("creates a verbose-only logger when --verbose is set", async () => {
     const options: GlobalOptions = { output: "table", verbose: true };
     await createClient(options);

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -33,6 +33,10 @@ export async function createClient(
 
   let logger: HttpClientLogger | undefined;
   if (options.debug === true) {
+    process.stderr.write(
+      "Warning: Debug mode logs full API responses which may include financial data (IBANs, balances). " +
+        "Do not use in shared environments.\n",
+    );
     logger = {
       verbose: (msg) => process.stderr.write(`${msg}\n`),
       debug: (msg) => process.stderr.write(`${msg}\n`),

--- a/packages/cli/src/commands/profile/test.ts
+++ b/packages/cli/src/commands/profile/test.ts
@@ -37,6 +37,10 @@ export function registerTestCommand(parent: Command): void {
 async function testProfile(options: GlobalOptions): Promise<void> {
   let logger: HttpClientLogger | undefined;
   if (options.debug === true) {
+    console.error(
+      "Warning: Debug mode logs full API responses which may include financial data (IBANs, balances). " +
+        "Do not use in shared environments.",
+    );
     logger = {
       verbose: (msg: string) => console.error(`[verbose] ${msg}`),
       debug: (msg: string) => console.error(`[debug] ${msg}`),

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -595,6 +595,55 @@ describe("HttpClient", () => {
       expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("content-type"));
     });
 
+    it("redacts sensitive fields in response body debug logs", async () => {
+      const responseData = {
+        organization: {
+          slug: "acme",
+          bank_accounts: [
+            {
+              id: "acc-1",
+              name: "Main",
+              iban: "FR7630001007941234567890185",
+              bic: "BNPAFRPPXXX",
+              balance: 12345.67,
+              balance_cents: 1234567,
+              authorized_balance: 10000.0,
+              authorized_balance_cents: 1000000,
+              currency: "EUR",
+            },
+          ],
+        },
+      };
+      fetchSpy.mockReturnValue(jsonResponse(responseData));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.get("/v2/organization");
+
+      const bodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Response body"),
+      );
+      expect(bodyLogCalls.length).toBeGreaterThan(0);
+      const bodyLog = bodyLogCalls[0]?.[0] as string;
+      expect(bodyLog).not.toContain("FR7630001007941234567890185");
+      expect(bodyLog).not.toContain("BNPAFRPPXXX");
+      expect(bodyLog).not.toContain("12345.67");
+      expect(bodyLog).not.toContain("1234567");
+      expect(bodyLog).toContain('"iban":"[REDACTED]"');
+      expect(bodyLog).toContain('"bic":"[REDACTED]"');
+      expect(bodyLog).toContain('"balance":"[REDACTED]"');
+      expect(bodyLog).toContain('"balance_cents":"[REDACTED]"');
+      expect(bodyLog).toContain('"authorized_balance":"[REDACTED]"');
+      expect(bodyLog).toContain('"authorized_balance_cents":"[REDACTED]"');
+      // Non-sensitive fields are preserved
+      expect(bodyLog).toContain('"slug":"acme"');
+      expect(bodyLog).toContain('"currency":"EUR"');
+    });
+
     it("redacts Authorization header in debug logs", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
       const logger = createMockLogger();

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -62,6 +62,35 @@ export interface HttpClientOptions {
 const DEFAULT_MAX_RETRIES = 5;
 const BASE_BACKOFF_MS = 1000;
 
+/**
+ * Field names redacted from debug log output to avoid leaking financial data.
+ */
+const SENSITIVE_FIELDS: ReadonlySet<string> = new Set([
+  "iban",
+  "bic",
+  "balance",
+  "balance_cents",
+  "authorized_balance",
+  "authorized_balance_cents",
+]);
+
+function redactSensitiveFields(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item: unknown) => redactSensitiveFields(item));
+  }
+  if (typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = SENSITIVE_FIELDS.has(key) ? "[REDACTED]" : redactSensitiveFields(val);
+    }
+    return result;
+  }
+  return value;
+}
+
 function buildUserAgent(): string {
   return `QontoCtl/0.0.0 (Node.js/${process.versions.node}; ${process.platform})`;
 }
@@ -151,7 +180,7 @@ export class HttpClient {
       }
 
       const responseBody: unknown = await response.json();
-      this.logDebug(`Response body: ${JSON.stringify(responseBody)}`);
+      this.logDebug(`Response body: ${JSON.stringify(redactSensitiveFields(responseBody))}`);
       return responseBody as T;
     }
 


### PR DESCRIPTION
## Summary

Closes #69

- Emit a one-time warning to stderr when `--debug` mode is activated, alerting that full API responses (which may include financial data) will be logged
- Redact known sensitive response body fields (`iban`, `bic`, `balance`, `balance_cents`, `authorized_balance`, `authorized_balance_cents`) in debug log output with `[REDACTED]`
- Document debug mode security considerations in README

## Test plan

- [x] New unit test verifies sensitive fields are redacted in response body debug logs (IBAN, BIC, balance values replaced with `[REDACTED]`, non-sensitive fields preserved)
- [x] New unit test verifies debug warning is emitted when `--debug` is set
- [x] New unit test verifies no warning emitted when only `--verbose` is set
- [x] All 348 existing tests pass
- [x] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)