### PR TITLE
(fix) replace eslint-plugin-header with maintained fork

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,13 +4,7 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
-import headerPlugin from "eslint-plugin-header";
-
-// Workaround: eslint-plugin-header lacks meta.schema, which ESLint >=9.4
-// treats as "no options allowed". Setting schema to false disables validation.
-// See https://github.com/Stuk/eslint-plugin-header/issues/57
-headerPlugin.rules.header.meta ??= {};
-headerPlugin.rules.header.meta.schema = false;
+import headerPlugin from "@tony.ganchev/eslint-plugin-header";
 
 export default tseslint.config(
   eslint.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
-    "eslint-plugin-header": "catalog:",
+    "@tony.ganchev/eslint-plugin-header": "catalog:",
     "prettier": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@modelcontextprotocol/sdk':
       specifier: ^1.26.0
       version: 1.27.1
+    '@tony.ganchev/eslint-plugin-header':
+      specifier: ^3.2.4
+      version: 3.2.4
     '@types/node':
       specifier: ^25
       version: 25.3.2
@@ -27,9 +30,6 @@ catalogs:
     eslint-config-prettier:
       specifier: ^10.1.8
       version: 10.1.8
-    eslint-plugin-header:
-      specifier: ^3.1.1
-      version: 3.1.1
     prettier:
       specifier: ^3.8.1
       version: 3.8.1
@@ -62,6 +62,9 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.3
+      '@tony.ganchev/eslint-plugin-header':
+        specifier: 'catalog:'
+        version: 3.2.4(eslint@9.39.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@25.3.2)(yaml@2.8.2))
@@ -71,9 +74,6 @@ importers:
       eslint-config-prettier:
         specifier: 'catalog:'
         version: 10.1.8(eslint@9.39.3)
-      eslint-plugin-header:
-        specifier: 'catalog:'
-        version: 3.1.1(eslint@9.39.3)
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
@@ -623,6 +623,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tony.ganchev/eslint-plugin-header@3.2.4':
+    resolution: {integrity: sha512-zqMKTW/KQmqKGINkhwEPoJFcJ0ewUkUAmvzHLB5N+n/6bsk7D/xkQ50VhUakG2P4JHHtqsncaXrPxgSeuBPmOw==}
+    peerDependencies:
+      eslint: '>=7.7.0'
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -929,11 +934,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-
-  eslint-plugin-header@3.1.1:
-    resolution: {integrity: sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==}
-    peerDependencies:
-      eslint: '>=7.7.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -1962,6 +1962,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tony.ganchev/eslint-plugin-header@3.2.4(eslint@9.39.3)':
+    dependencies:
+      eslint: 9.39.3
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -2315,10 +2319,6 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   eslint-config-prettier@10.1.8(eslint@9.39.3):
-    dependencies:
-      eslint: 9.39.3
-
-  eslint-plugin-header@3.1.1(eslint@9.39.3):
     dependencies:
       eslint: 9.39.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ catalog:
   prettier: "^3.8.1"
   typescript-eslint: "^8.54.0"
   eslint-config-prettier: "^10.1.8"
-  eslint-plugin-header: "^3.1.1"
+  "@tony.ganchev/eslint-plugin-header": "^3.2.4"
   "@modelcontextprotocol/sdk": "^1.26.0"
   zod: "^4.3.6"
   commander: "^14.0.3"


### PR DESCRIPTION
## Summary

- Replace `eslint-plugin-header@3.1.1` with `@tony.ganchev/eslint-plugin-header@3.2.4` which provides native ESLint 9/10 flat config support with proper `meta.schema`
- Remove the monkey-patch workaround in `eslint.config.js` (lines 9-13) that set `meta.schema = false` to work around the original plugin's missing schema
- Update catalog entry in `pnpm-workspace.yaml` and root `package.json`

Closes #74

## Test plan

- [x] `pnpm lint` passes across all packages (header rule still enforced)
- [x] `pnpm test` passes across all packages
- [x] `pnpm license-check` passes (MIT license compatible with AGPL-3.0-only)
- [x] Verified new plugin exports proper `meta.schema` (no monkey-patch needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)