### PR TITLE
(fix) ensure topological publish order in release workflow (#64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,9 @@ jobs:
 
       - run: pnpm build
 
+      # --sort ensures topological publish order: @qontoctl/core → cli, mcp → qontoctl
       - name: Verify packages
-        run: pnpm -r publish --dry-run --access public --no-git-checks
+        run: pnpm -r --sort publish --dry-run --access public --no-git-checks
 
       - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --report-summary --provenance
+        run: pnpm -r --sort publish --access public --no-git-checks --report-summary --provenance


### PR DESCRIPTION
## Summary

- Add explicit `--sort` flag to `pnpm -r publish` commands in the release workflow to guarantee topological publish order (`@qontoctl/core` → `cli`, `mcp` → `qontoctl`)
- Add comment documenting the expected publish order

While pnpm defaults to topological sorting, making it explicit prevents regressions if the default changes and documents the intent for maintainers.

Closes #64

## Test plan

- [ ] Verify CI passes (build, lint, license-check, test)
- [ ] Confirm `--sort` flag is recognized by pnpm (documented at [pnpm.io/cli/recursive](https://pnpm.io/cli/recursive))

🤖 Generated with [Claude Code](https://claude.com/claude-code)