### PR TITLE
(fix) add encodeURIComponent to all URL path parameters (#59)

### DIFF
--- a/packages/cli/src/commands/label.ts
+++ b/packages/cli/src/commands/label.ts
@@ -41,7 +41,7 @@ export function createLabelCommand(): Command {
       const opts = label.optsWithGlobals<GlobalOptions>();
       const client = await createClient(opts);
 
-      const response = await client.get<{ label: Label }>(`/v2/labels/${id}`);
+      const response = await client.get<{ label: Label }>(`/v2/labels/${encodeURIComponent(id)}`);
       const l = response.label;
 
       const row = {

--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -33,7 +33,7 @@ export function registerAccountTools(
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {
-        const response = await client.get<{ bank_account: unknown }>(`/v2/bank_accounts/${id}`);
+        const response = await client.get<{ bank_account: unknown }>(`/v2/bank_accounts/${encodeURIComponent(id)}`);
         return {
           content: [
             { type: "text" as const, text: JSON.stringify(response.bank_account, null, 2) },

--- a/packages/mcp/src/tools/label.ts
+++ b/packages/mcp/src/tools/label.ts
@@ -73,7 +73,7 @@ export function registerLabelTools(
     async ({ id }) => {
       const client = await getClient();
       const response = await client.get<SingleLabelResponse>(
-        `/v2/labels/${id}`,
+        `/v2/labels/${encodeURIComponent(id)}`,
       );
 
       return {

--- a/packages/mcp/src/tools/labels.ts
+++ b/packages/mcp/src/tools/labels.ts
@@ -31,7 +31,7 @@ export function registerLabelTools(
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {
-        const response = await client.get<{ label: unknown }>(`/v2/labels/${id}`);
+        const response = await client.get<{ label: unknown }>(`/v2/labels/${encodeURIComponent(id)}`);
         return {
           content: [{ type: "text" as const, text: JSON.stringify(response.label, null, 2) }],
         };

--- a/packages/mcp/src/tools/statements.ts
+++ b/packages/mcp/src/tools/statements.ts
@@ -75,7 +75,7 @@ export function registerStatementTools(
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {
-        const response = await client.get<{ statement: unknown }>(`/v2/statements/${id}`);
+        const response = await client.get<{ statement: unknown }>(`/v2/statements/${encodeURIComponent(id)}`);
         return {
           content: [
             { type: "text" as const, text: JSON.stringify(response.statement, null, 2) },

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -95,7 +95,7 @@ export function registerTransactionTools(
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {
-        const response = await client.get<{ transaction: unknown }>(`/v2/transactions/${id}`);
+        const response = await client.get<{ transaction: unknown }>(`/v2/transactions/${encodeURIComponent(id)}`);
         return {
           content: [
             { type: "text" as const, text: JSON.stringify(response.transaction, null, 2) },


### PR DESCRIPTION
## Summary

- Apply `encodeURIComponent()` to all 6 user-supplied URL path parameters that were missing encoding in CLI and MCP tool handlers
- Fixes inconsistency where `core` services encoded IDs but `cli` and `mcp` layers did not
- Prevents potential path injection if ID formats ever change or untrusted input is passed through

**Files changed:**
- `packages/mcp/src/tools/labels.ts` — `label_show` tool
- `packages/mcp/src/tools/label.ts` — `label_show` tool
- `packages/mcp/src/tools/accounts.ts` — `account_show` tool
- `packages/mcp/src/tools/transactions.ts` — `transaction_show` tool
- `packages/mcp/src/tools/statements.ts` — `statement_show` tool
- `packages/cli/src/commands/label.ts` — `label show` command

Closes #59

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All 350 unit tests pass (`pnpm test`)
- [x] All 80 E2E tests pass (`pnpm test:e2e`)
- [x] Lint passes (`pnpm lint`)
- [x] Verified zero unencoded URL path interpolations remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)