### PR TITLE
(fix) read version from package.json at runtime (#66)

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { createRequire } from "node:module";
 import { Command, Option } from "commander";
 import { registerCompletionCommand } from "./completions/index.js";
 import { registerTransactionCommands } from "./commands/transaction/index.js";
@@ -8,13 +9,16 @@ import { registerOrgCommands } from "./commands/org.js";
 import { registerAccountCommands } from "./commands/account.js";
 import { OUTPUT_FORMATS } from "./options.js";
 
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
 export function createProgram(): Command {
   const program = new Command();
 
   program
     .name("qontoctl")
     .description("The complete CLI & MCP for Qonto")
-    .version("0.0.0");
+    .version(packageJson.version);
 
   program
     .addOption(

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
 /**
  * Logger interface for HTTP client wire logging.
  */
@@ -92,7 +97,7 @@ function redactSensitiveFields(value: unknown): unknown {
 }
 
 function buildUserAgent(): string {
-  return `QontoCtl/0.0.0 (Node.js/${process.versions.node}; ${process.platform})`;
+  return `QontoCtl/${packageJson.version} (Node.js/${process.versions.node}; ${process.platform})`;
 }
 
 /**

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { HttpClient } from "@qontoctl/core";
 import {
@@ -12,6 +13,9 @@ import {
   registerTransactionTools,
 } from "./tools/index.js";
 
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
+
 export interface CreateServerOptions {
   readonly getClient: () => Promise<HttpClient>;
 }
@@ -19,7 +23,7 @@ export interface CreateServerOptions {
 export function createServer(options?: CreateServerOptions): McpServer {
   const server = new McpServer({
     name: "qontoctl",
-    version: "0.0.0",
+    version: packageJson.version,
   });
 
   const getClient =


### PR DESCRIPTION
## Summary

- Replace hardcoded `"0.0.0"` version strings with dynamic reads from each package's `package.json` using `createRequire(import.meta.url)`
- Fixes User-Agent header (`packages/core/src/http-client.ts`), CLI `--version` output (`packages/cli/src/program.ts`), and MCP server identification (`packages/mcp/src/server.ts`)
- The release workflow already stamps `package.json` versions from git tags — this change ensures the source code reads those stamped values at runtime

Closes #66

## Test plan

- [x] Build succeeds (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 350 unit tests pass (`pnpm test`)
- [x] All 80 E2E tests pass (`pnpm test:e2e`)
- [x] Existing User-Agent test (`http-client.test.ts:193`) validates version format via regex pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)