### PR TITLE
(feat) add global CLI error handler for user-friendly error messages (#68)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,5 +3,12 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { createProgram } from "./program.js";
+import { handleCliError } from "./error-handler.js";
 
-createProgram().parse();
+const program = createProgram();
+
+try {
+  await program.parseAsync();
+} catch (error: unknown) {
+  handleCliError(error, program.opts()["debug"] === true);
+}

--- a/packages/cli/src/error-handler.test.ts
+++ b/packages/cli/src/error-handler.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  ConfigError,
+  AuthError,
+  QontoApiError,
+  QontoRateLimitError,
+} from "@qontoctl/core";
+import { handleCliError } from "./error-handler.js";
+
+describe("handleCliError", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  describe("ConfigError", () => {
+    it("shows configuration guidance", () => {
+      const error = new ConfigError("No credentials found.");
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Configuration error: No credentials found.");
+      expect(output).toContain("~/.qontoctl.yaml");
+      expect(output).toContain("organization_slug");
+      expect(output).toContain("QONTOCTL_ORGANIZATION_SLUG");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe("AuthError", () => {
+    it("suggests checking credentials", () => {
+      const error = new AuthError(
+        "Missing organization slug in API key credentials",
+      );
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Authentication error:");
+      expect(output).toContain("Missing organization slug");
+      expect(output).toContain("Verify your API key credentials");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe("QontoApiError", () => {
+    it("shows HTTP status and error details", () => {
+      const error = new QontoApiError(401, [
+        { code: "unauthorized", detail: "Invalid credentials" },
+      ]);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Qonto API error (HTTP 401):");
+      expect(output).toContain("unauthorized: Invalid credentials");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("formats multiple error entries", () => {
+      const error = new QontoApiError(422, [
+        { code: "invalid", detail: "Field A is required" },
+        { code: "invalid", detail: "Field B is too long" },
+      ]);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("  - invalid: Field A is required");
+      expect(output).toContain("  - invalid: Field B is too long");
+    });
+  });
+
+  describe("QontoRateLimitError", () => {
+    it("shows retry-after when available", () => {
+      const error = new QontoRateLimitError(30);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Rate limit exceeded.");
+      expect(output).toContain("Retry after 30 seconds.");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("omits retry-after when unavailable", () => {
+      const error = new QontoRateLimitError(undefined);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Rate limit exceeded.");
+      expect(output).toContain("Please wait before retrying.");
+      expect(output).not.toContain("Retry after");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe("unknown errors", () => {
+    it("shows message only without debug", () => {
+      const error = new Error("Something went wrong");
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toBe("Error: Something went wrong\n");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("shows stack trace with debug", () => {
+      const error = new Error("Something went wrong");
+
+      handleCliError(error, true);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Error: Something went wrong");
+      expect(output).toContain("at ");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("handles non-Error values", () => {
+      handleCliError("string error", false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toBe("Error: string error\n");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/cli/src/error-handler.ts
+++ b/packages/cli/src/error-handler.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  ConfigError,
+  AuthError,
+  QontoApiError,
+  QontoRateLimitError,
+} from "@qontoctl/core";
+
+/**
+ * Global CLI error handler that formats known error types into
+ * user-friendly messages written to stderr.
+ *
+ * Stack traces are only shown for unknown errors in debug mode.
+ */
+export function handleCliError(error: unknown, debug: boolean): void {
+  if (error instanceof ConfigError) {
+    process.stderr.write(
+      [
+        `Configuration error: ${error.message}`,
+        "",
+        "To configure credentials, create ~/.qontoctl.yaml:",
+        "",
+        "  api-key:",
+        "    organization_slug: <your-org-slug>",
+        "    secret_key: <your-secret-key>",
+        "",
+        "Or set environment variables:",
+        "  QONTOCTL_ORGANIZATION_SLUG=<your-org-slug>",
+        "  QONTOCTL_SECRET_KEY=<your-secret-key>",
+      ].join("\n") + "\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (error instanceof AuthError) {
+    process.stderr.write(
+      [
+        `Authentication error: ${error.message}`,
+        "",
+        "Verify your API key credentials in ~/.qontoctl.yaml or environment variables.",
+      ].join("\n") + "\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (error instanceof QontoApiError) {
+    const details = error.errors
+      .map((e) => `  - ${e.code}: ${e.detail}`)
+      .join("\n");
+    process.stderr.write(
+      `Qonto API error (HTTP ${error.status}):\n${details}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (error instanceof QontoRateLimitError) {
+    const retryHint =
+      error.retryAfter !== undefined
+        ? ` Retry after ${error.retryAfter} seconds.`
+        : "";
+    process.stderr.write(
+      `Rate limit exceeded.${retryHint} Please wait before retrying.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Unknown errors: show stack trace in debug mode, message only otherwise
+  if (debug && error instanceof Error && error.stack !== undefined) {
+    process.stderr.write(`${error.stack}\n`);
+  } else {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`Error: ${message}\n`);
+  }
+  process.exitCode = 1;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,8 @@ export {
 
 export { createClient } from "./client.js";
 
+export { handleCliError } from "./error-handler.js";
+
 export {
   createLabelCommand,
   createMembershipCommand,

--- a/packages/qontoctl/src/cli.ts
+++ b/packages/qontoctl/src/cli.ts
@@ -7,6 +7,7 @@ import {
   createProgram,
   createLabelCommand,
   createMembershipCommand,
+  handleCliError,
   registerProfileCommands,
   registerStatementCommands,
 } from "@qontoctl/cli";
@@ -28,4 +29,8 @@ program
     });
   });
 
-program.parse();
+try {
+  await program.parseAsync();
+} catch (error: unknown) {
+  handleCliError(error, program.opts()["debug"] === true);
+}


### PR DESCRIPTION
## Summary

- Add `handleCliError` function in `@qontoctl/cli` that catches known error types (`ConfigError`, `AuthError`, `QontoApiError`, `QontoRateLimitError`) and formats them as user-friendly messages with actionable guidance
- Wrap both CLI entry points (`packages/cli/src/cli.ts` and `packages/qontoctl/src/cli.ts`) with top-level try/catch using `parseAsync()` instead of `parse()`
- Show stack traces only for unknown errors in debug mode; known errors get clean formatted output to stderr

## Test plan

- [x] New unit tests for all error type formatting (9 tests in `error-handler.test.ts`)
- [x] Existing test suite passes (168 CLI tests, 139 core tests, 50 MCP tests)
- [x] Build and lint pass across all packages

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)