### PR TITLE
(chore) add npm keywords and funding to sub-packages (#79)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,6 +10,7 @@
   "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
   "homepage": "https://github.com/alexey-pelykh/qontoctl/tree/main/packages/cli",
   "bugs": "https://github.com/alexey-pelykh/qontoctl/issues",
+  "funding": "https://github.com/sponsors/alexey-pelykh",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexey-pelykh/qontoctl.git",
@@ -26,6 +27,14 @@
   },
   "files": [
     "dist"
+  ],
+  "keywords": [
+    "qonto",
+    "banking",
+    "fintech",
+    "cli",
+    "command-line",
+    "qonto-api"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
   "homepage": "https://github.com/alexey-pelykh/qontoctl/tree/main/packages/core",
   "bugs": "https://github.com/alexey-pelykh/qontoctl/issues",
+  "funding": "https://github.com/sponsors/alexey-pelykh",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexey-pelykh/qontoctl.git",
@@ -27,6 +28,15 @@
   },
   "files": [
     "dist"
+  ],
+  "keywords": [
+    "qonto",
+    "qonto-api",
+    "banking",
+    "banking-api",
+    "fintech",
+    "api-client",
+    "typescript"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -10,6 +10,7 @@
   "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
   "homepage": "https://github.com/alexey-pelykh/qontoctl/tree/main/packages/mcp",
   "bugs": "https://github.com/alexey-pelykh/qontoctl/issues",
+  "funding": "https://github.com/sponsors/alexey-pelykh",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexey-pelykh/qontoctl.git",
@@ -34,6 +35,15 @@
   },
   "files": [
     "dist"
+  ],
+  "keywords": [
+    "qonto",
+    "banking",
+    "fintech",
+    "mcp",
+    "model-context-protocol",
+    "claude",
+    "ai-tools"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- Add `keywords` to `@qontoctl/core`, `@qontoctl/cli`, and `@qontoctl/mcp` package.json files for npm search discoverability
- Add `funding` field (`https://github.com/sponsors/alexey-pelykh`) to all three sub-packages
- Keywords are package-specific as recommended in #79

Closes #79

## Test plan

- [x] JSON validity verified for all three package.json files
- [ ] CI passes (build, lint, tests unaffected — metadata-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)