### PR TITLE
(ci) run release validation on full OS matrix (#75)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,13 @@ jobs:
   # affects build output. If version-dependent behavior is introduced, consider
   # moving version stamping before validation.
   validate:
-    name: Validate
+    name: Validate (${{ matrix.os }})
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

- Adds 3-OS matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`) to the release workflow's `validate` job, matching the CI workflow's coverage
- `publish-npm` already depends on `validate` via `needs`, so it naturally waits for all matrix jobs to pass before publishing

Closes #75

## Test plan

- [ ] CI passes on all 3 OS runners for this PR
- [ ] Verify `publish-npm` job still correctly depends on the matrix `validate` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)