### PR TITLE
Return full API fields for json/yaml output in label and membership commands

### DIFF
--- a/packages/cli/src/commands/label.test.ts
+++ b/packages/cli/src/commands/label.test.ts
@@ -76,7 +76,7 @@ describe("label commands", () => {
       expect(output).toContain("Digital");
     });
 
-    it("lists labels in json format", async () => {
+    it("lists labels in json format with full API fields", async () => {
       const labels = [
         { id: "abc-123", name: "Marketing", parent_id: null },
       ];
@@ -103,7 +103,7 @@ describe("label commands", () => {
       expect(parsed[0]).toEqual({
         id: "abc-123",
         name: "Marketing",
-        parent_id: "",
+        parent_id: null,
       });
     });
 
@@ -156,7 +156,7 @@ describe("label commands", () => {
       expect(output).toContain("parent-id");
     });
 
-    it("shows label with null parent_id as empty string", async () => {
+    it("shows label with full API fields in json format", async () => {
       const label = {
         id: "abc-123",
         name: "Root Label",
@@ -176,11 +176,11 @@ describe("label commands", () => {
 
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
-      const parsed = JSON.parse(output) as unknown[];
-      expect(parsed[0]).toEqual({
+      const parsed = JSON.parse(output) as unknown;
+      expect(parsed).toEqual({
         id: "abc-123",
         name: "Root Label",
-        parent_id: "",
+        parent_id: null,
       });
     });
 

--- a/packages/cli/src/commands/label.ts
+++ b/packages/cli/src/commands/label.ts
@@ -25,13 +25,16 @@ export function createLabelCommand(): Command {
         opts,
       );
 
-      const rows = result.items.map((l) => ({
-        id: l.id,
-        name: l.name,
-        parent_id: l.parent_id ?? "",
-      }));
+      const data =
+        opts.output === "json" || opts.output === "yaml"
+          ? result.items
+          : result.items.map((l) => ({
+              id: l.id,
+              name: l.name,
+              parent_id: l.parent_id ?? "",
+            }));
 
-      process.stdout.write(formatOutput(rows, opts.output) + "\n");
+      process.stdout.write(formatOutput(data, opts.output) + "\n");
     });
 
   label
@@ -44,13 +47,18 @@ export function createLabelCommand(): Command {
       const response = await client.get<{ label: Label }>(`/v2/labels/${encodeURIComponent(id)}`);
       const l = response.label;
 
-      const row = {
-        id: l.id,
-        name: l.name,
-        parent_id: l.parent_id ?? "",
-      };
+      const data =
+        opts.output === "json" || opts.output === "yaml"
+          ? l
+          : [
+              {
+                id: l.id,
+                name: l.name,
+                parent_id: l.parent_id ?? "",
+              },
+            ];
 
-      process.stdout.write(formatOutput([row], opts.output) + "\n");
+      process.stdout.write(formatOutput(data, opts.output) + "\n");
     });
 
   return label;

--- a/packages/cli/src/commands/membership.test.ts
+++ b/packages/cli/src/commands/membership.test.ts
@@ -102,7 +102,7 @@ describe("membership commands", () => {
       expect(output).toContain("Bob");
     });
 
-    it("lists memberships in json format", async () => {
+    it("lists memberships in json format with full API fields", async () => {
       const memberships = [
         {
           id: "mem-1",
@@ -144,6 +144,11 @@ describe("membership commands", () => {
         last_name: "Smith",
         role: "admin",
         team_id: "team-1",
+        residence_country: null,
+        birthdate: null,
+        nationality: null,
+        birth_country: null,
+        ubo: null,
         status: "active",
       });
     });

--- a/packages/cli/src/commands/membership.ts
+++ b/packages/cli/src/commands/membership.ts
@@ -28,16 +28,19 @@ export function createMembershipCommand(): Command {
         opts,
       );
 
-      const rows = result.items.map((m) => ({
-        id: m.id,
-        first_name: m.first_name,
-        last_name: m.last_name,
-        role: m.role,
-        team_id: m.team_id,
-        status: m.status,
-      }));
+      const data =
+        opts.output === "json" || opts.output === "yaml"
+          ? result.items
+          : result.items.map((m) => ({
+              id: m.id,
+              first_name: m.first_name,
+              last_name: m.last_name,
+              role: m.role,
+              team_id: m.team_id,
+              status: m.status,
+            }));
 
-      process.stdout.write(formatOutput(rows, opts.output) + "\n");
+      process.stdout.write(formatOutput(data, opts.output) + "\n");
     });
 
   return membership;


### PR DESCRIPTION
## Summary

- **Label list/show** and **membership list** commands now return full API response objects for `--output json` and `--output yaml`, preserving all fields and original types (e.g., `null` instead of `""`)
- Table and CSV output continues to show the curated subset of fields for readability
- Aligns with the existing pattern used by `account` and `org` commands

Closes #73

## Test plan

- [x] Unit tests updated to verify full API fields in JSON output (label list, label show, membership list)
- [x] All 168 CLI tests pass
- [x] All 44 MCP tests pass
- [x] Lint passes clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)