### PR TITLE
(fix) remove unsafe type assertions in HTTP client

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -142,16 +142,28 @@ describe("HttpClient", () => {
       expect(result).toEqual(responseData);
     });
 
-    it("returns undefined for 204 No Content responses", async () => {
+    it("resolves void for 204 No Content via requestVoid", async () => {
       fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
       const client = new TestableHttpClient({
         baseUrl: "https://thirdparty.qonto.com",
         authorization: "slug:secret",
       });
 
-      const result = await client.request("DELETE", "/v2/something");
+      await expect(client.requestVoid("DELETE", "/v2/something")).resolves.toBeUndefined();
+    });
 
-      expect(result).toBeUndefined();
+    it("sends DELETE request via delete convenience method", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await expect(client.delete("/v2/something")).resolves.toBeUndefined();
+
+      const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.toString()).toBe("https://thirdparty.qonto.com/v2/something");
+      expect(init.method).toBe("DELETE");
     });
   });
 

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -136,6 +136,12 @@ export class HttpClient {
     this.userAgent = buildUserAgent();
   }
 
+  /**
+   * Sends an HTTP request and parses the response as JSON.
+   *
+   * **Trust boundary**: The parsed JSON is cast to `T` without runtime validation.
+   * Callers trust the Qonto API contract for response shapes.
+   */
   async request<T>(
     method: string,
     path: string,
@@ -144,6 +150,46 @@ export class HttpClient {
       readonly params?: QueryParams;
     },
   ): Promise<T> {
+    const response = await this.fetchWithRetry(method, path, options);
+    const responseBody: unknown = await response.json();
+    this.logDebug(`Response body: ${JSON.stringify(redactSensitiveFields(responseBody))}`);
+    return responseBody as T;
+  }
+
+  /**
+   * Sends an HTTP request expecting no response body (e.g. 204 No Content).
+   */
+  async requestVoid(
+    method: string,
+    path: string,
+    options?: {
+      readonly body?: unknown;
+      readonly params?: QueryParams;
+    },
+  ): Promise<void> {
+    await this.fetchWithRetry(method, path, options);
+  }
+
+  async get<T>(path: string, params?: QueryParams): Promise<T> {
+    return this.request<T>("GET", path, params !== undefined ? { params } : undefined);
+  }
+
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, body !== undefined ? { body } : undefined);
+  }
+
+  async delete(path: string): Promise<void> {
+    return this.requestVoid("DELETE", path);
+  }
+
+  private async fetchWithRetry(
+    method: string,
+    path: string,
+    options?: {
+      readonly body?: unknown;
+      readonly params?: QueryParams;
+    },
+  ): Promise<Response> {
     const url = this.buildUrl(path, options?.params);
     const headers = this.buildHeaders(options?.body !== undefined);
     const body = options?.body !== undefined ? JSON.stringify(options.body) : undefined;
@@ -180,25 +226,11 @@ export class HttpClient {
         throw new QontoApiError(response.status, errors);
       }
 
-      if (response.status === 204) {
-        return undefined as T;
-      }
-
-      const responseBody: unknown = await response.json();
-      this.logDebug(`Response body: ${JSON.stringify(redactSensitiveFields(responseBody))}`);
-      return responseBody as T;
+      return response;
     }
 
     // Unreachable in practice: the loop always returns or throws
     throw new QontoRateLimitError(undefined);
-  }
-
-  async get<T>(path: string, params?: QueryParams): Promise<T> {
-    return this.request<T>("GET", path, params !== undefined ? { params } : undefined);
-  }
-
-  async post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>("POST", path, body !== undefined ? { body } : undefined);
   }
 
   private buildUrl(path: string, params?: QueryParams): URL {


### PR DESCRIPTION
## Summary

- Extract `fetchWithRetry` private method to separate transport/retry logic from response parsing
- Add type-safe `requestVoid()` method for endpoints returning no body (e.g. 204 No Content)
- Add `delete()` convenience method delegating to `requestVoid()`
- Remove unsound `undefined as T` cast from `request<T>()` (CODE-006)
- Document the JSON parsing trust boundary on `request<T>()` via JSDoc (CODE-007)

Closes #77

## Test plan

- [x] Existing unit tests pass (all 10 test suites green)
- [x] Updated 204 test to use `requestVoid()` instead of `request()`
- [x] Added new test for `delete()` convenience method
- [x] Build, lint, and license-check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)