### PR TITLE
(docs) add README to each publishable package

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -14,32 +14,32 @@ npm install @qontoctl/cli
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `org show` | Show organization details |
-| `account list` | List bank accounts |
-| `account show <id>` | Show account details |
-| `transaction list` | List transactions with filters |
-| `transaction show <id>` | Show transaction details |
-| `label list` | List all labels |
-| `label show <id>` | Show label details |
-| `membership list` | List organization memberships |
-| `statement list` | List bank statements |
-| `statement show <id>` | Show statement details |
-| `statement download <id>` | Download statement PDF |
-| `completion` | Generate shell completion scripts |
+| Command                   | Description                       |
+| ------------------------- | --------------------------------- |
+| `org show`                | Show organization details         |
+| `account list`            | List bank accounts                |
+| `account show <id>`       | Show account details              |
+| `transaction list`        | List transactions with filters    |
+| `transaction show <id>`   | Show transaction details          |
+| `label list`              | List all labels                   |
+| `label show <id>`         | Show label details                |
+| `membership list`         | List organization memberships     |
+| `statement list`          | List bank statements              |
+| `statement show <id>`     | Show statement details            |
+| `statement download <id>` | Download statement PDF            |
+| `completion`              | Generate shell completion scripts |
 
 ### Global Options
 
-| Option | Description |
-|--------|-------------|
-| `-p, --profile <name>` | Configuration profile to use |
+| Option                  | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| `-p, --profile <name>`  | Configuration profile to use                  |
 | `-o, --output <format>` | Output format: `table`, `json`, `yaml`, `csv` |
-| `--verbose` | Enable verbose logging |
-| `--debug` | Enable debug logging |
-| `--page <number>` | Page number for paginated results |
-| `--per-page <number>` | Items per page |
-| `--no-paginate` | Disable auto-pagination |
+| `--verbose`             | Enable verbose logging                        |
+| `--debug`               | Enable debug logging                          |
+| `--page <number>`       | Page number for paginated results             |
+| `--per-page <number>`   | Items per page                                |
+| `--no-paginate`         | Disable auto-pagination                       |
 
 ## Programmatic Usage
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,13 +13,7 @@ npm install @qontoctl/core
 ## Usage
 
 ```ts
-import {
-  resolveConfig,
-  buildApiKeyAuthorization,
-  HttpClient,
-  API_BASE_URL,
-  getOrganization,
-} from "@qontoctl/core";
+import { resolveConfig, buildApiKeyAuthorization, HttpClient, API_BASE_URL, getOrganization } from "@qontoctl/core";
 
 // Resolve configuration from file or environment
 const config = await resolveConfig();

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,29 +18,29 @@ Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 ```json
 {
-  "mcpServers": {
-    "qontoctl": {
-      "command": "npx",
-      "args": ["qontoctl", "mcp"]
+    "mcpServers": {
+        "qontoctl": {
+            "command": "npx",
+            "args": ["qontoctl", "mcp"]
+        }
     }
-  }
 }
 ```
 
 ## Available Tools
 
-| Tool | Description |
-|------|-------------|
-| `org_show` | Show organization details |
-| `account_list` | List all bank accounts |
-| `account_show` | Show account details by ID |
+| Tool               | Description                                     |
+| ------------------ | ----------------------------------------------- |
+| `org_show`         | Show organization details                       |
+| `account_list`     | List all bank accounts                          |
+| `account_show`     | Show account details by ID                      |
 | `transaction_list` | List transactions with filtering and pagination |
-| `transaction_show` | Show transaction details by ID |
-| `label_list` | List labels with pagination |
-| `label_show` | Show label details by ID |
-| `membership_list` | List memberships with pagination |
-| `statement_list` | List bank statements with filtering |
-| `statement_show` | Show statement details by ID |
+| `transaction_show` | Show transaction details by ID                  |
+| `label_list`       | List labels with pagination                     |
+| `label_show`       | Show label details by ID                        |
+| `membership_list`  | List memberships with pagination                |
+| `statement_list`   | List bank statements with filtering             |
+| `statement_show`   | Show statement details by ID                    |
 
 ## Programmatic Usage
 
@@ -49,9 +49,9 @@ import { createServer } from "@qontoctl/mcp";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
 const server = createServer({
-  getClient: async () => {
-    // Return a configured HttpClient instance
-  },
+    getClient: async () => {
+        // Return a configured HttpClient instance
+    },
 });
 
 const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary

- Add README.md to `@qontoctl/core` with API client usage, authentication, available services, and type exports
- Add README.md to `@qontoctl/cli` with command reference table, global options, and programmatic usage
- Add README.md to `@qontoctl/mcp` with MCP tool reference, Claude Desktop setup, and programmatic usage
- Each README links back to the main repo for comprehensive documentation

Closes #62

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (168 tests)
- [ ] Verify READMEs render correctly on npm after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)