### PR TITLE
Enable strictTypeChecked ESLint rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ pnpm test:e2e                       # Full E2E suite
 - Strict mode with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
 - Use `verbatimModuleSyntax` (explicit `type` imports)
 - All packages use `composite: true` with project references
-- ESLint uses `tseslint.configs.strict` (strict type-aware rules)
+- ESLint uses `tseslint.configs.strictTypeChecked` (strict type-aware rules)
 
 ### Package Exports
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,10 +8,25 @@ import headerPlugin from "@tony.ganchev/eslint-plugin-header";
 
 export default tseslint.config(
   eslint.configs.recommended,
-  ...tseslint.configs.strict,
+  ...tseslint.configs.strictTypeChecked,
   eslintConfigPrettier,
   {
     ignores: ["**/dist/"],
+  },
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/restrict-template-expressions": ["error", { allowNumber: true }],
+    },
+  },
+  {
+    files: ["**/*.test.ts", "**/*.e2e.test.ts"],
+    ...tseslint.configs.disableTypeChecked,
   },
   {
     plugins: {

--- a/packages/cli/src/commands/profile/test.ts
+++ b/packages/cli/src/commands/profile/test.ts
@@ -42,12 +42,18 @@ async function testProfile(options: GlobalOptions): Promise<void> {
         "Do not use in shared environments.",
     );
     logger = {
-      verbose: (msg: string) => console.error(`[verbose] ${msg}`),
-      debug: (msg: string) => console.error(`[debug] ${msg}`),
+      verbose: (msg: string) => {
+        console.error(`[verbose] ${msg}`);
+      },
+      debug: (msg: string) => {
+        console.error(`[debug] ${msg}`);
+      },
     };
   } else if (options.verbose === true) {
     logger = {
-      verbose: (msg: string) => console.error(`[verbose] ${msg}`),
+      verbose: (msg: string) => {
+        console.error(`[verbose] ${msg}`);
+      },
       debug: () => {},
     };
   }

--- a/packages/cli/src/commands/statement.ts
+++ b/packages/cli/src/commands/statement.ts
@@ -40,7 +40,7 @@ export function registerStatementCommands(program: Command): void {
     .addOption(new Option("--from <period>", "start period (MM-YYYY)"))
     .addOption(new Option("--to <period>", "end period (MM-YYYY)"))
     .action(async (commandOpts: StatementListOptions) => {
-      const globalOpts = program.opts() as GlobalOptions & PaginationOptions;
+      const globalOpts = program.opts<GlobalOptions & PaginationOptions>();
       const client = await createClient(globalOpts);
 
       const params: Record<string, string> = {};
@@ -68,7 +68,7 @@ export function registerStatementCommands(program: Command): void {
     .description("Show a bank statement")
     .argument("<id>", "statement ID")
     .action(async (id: string) => {
-      const globalOpts = program.opts() as GlobalOptions;
+      const globalOpts = program.opts<GlobalOptions>();
       const client = await createClient(globalOpts);
 
       const response = await client.get<{ statement: Statement }>(`/v2/statements/${encodeURIComponent(id)}`);
@@ -86,7 +86,7 @@ export function registerStatementCommands(program: Command): void {
     .argument("<id>", "statement ID")
     .addOption(new Option("--output-dir <path>", "directory to save the file (default: current directory)"))
     .action(async (id: string, commandOpts: { outputDir?: string }) => {
-      const globalOpts = program.opts() as GlobalOptions;
+      const globalOpts = program.opts<GlobalOptions>();
       const client = await createClient(globalOpts);
 
       const response = await client.get<{ statement: Statement }>(`/v2/statements/${encodeURIComponent(id)}`);

--- a/packages/cli/src/completions/zsh.ts
+++ b/packages/cli/src/completions/zsh.ts
@@ -19,7 +19,7 @@ export function generateZshCompletion(program: Command): string {
   lines.push("  _arguments -s -S \\");
   for (let i = 0; i < rootArgSpecs.length; i++) {
     const trailing = i < rootArgSpecs.length - 1 ? " \\" : "";
-    lines.push(`    ${rootArgSpecs[i]}${trailing}`);
+    lines.push(`    ${rootArgSpecs[i] ?? ""}${trailing}`);
   }
   lines.push("");
 
@@ -49,13 +49,13 @@ export function generateZshCompletion(program: Command): string {
         lines.push("          _arguments -s -S \\");
         for (let i = 0; i < allSpecs.length; i++) {
           const trailing = i < allSpecs.length - 1 ? " \\" : "";
-          lines.push(`            ${allSpecs[i]}${trailing}`);
+          lines.push(`            ${allSpecs[i] ?? ""}${trailing}`);
         }
       } else if (cmdOptSpecs.length > 0) {
         lines.push("          _arguments -s -S \\");
         for (let i = 0; i < cmdOptSpecs.length; i++) {
           const trailing = i < cmdOptSpecs.length - 1 ? " \\" : "";
-          lines.push(`            ${cmdOptSpecs[i]}${trailing}`);
+          lines.push(`            ${cmdOptSpecs[i] ?? ""}${trailing}`);
         }
       }
       lines.push("          ;;");

--- a/packages/cli/src/formatters/csv.ts
+++ b/packages/cli/src/formatters/csv.ts
@@ -12,10 +12,13 @@ function toCsvValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "";
   }
+  if (typeof value === "string") {
+    return escapeCsvField(value);
+  }
   if (typeof value === "object") {
     return escapeCsvField(JSON.stringify(value));
   }
-  return escapeCsvField(String(value));
+  return escapeCsvField(String(value as number | boolean | bigint));
 }
 
 /**

--- a/packages/cli/src/formatters/table.ts
+++ b/packages/cli/src/formatters/table.ts
@@ -5,10 +5,13 @@ function toDisplayValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "";
   }
+  if (typeof value === "string") {
+    return value;
+  }
   if (typeof value === "object") {
     return JSON.stringify(value);
   }
-  return String(value);
+  return String(value as number | boolean | bigint);
 }
 
 /**
@@ -34,7 +37,7 @@ export function formatTable(rows: readonly Record<string, unknown>[]): string {
 
   const header = columns.map((col, i) => col.padEnd(widths[i] ?? 0)).join("  ");
   const separator = widths.map((w) => "-".repeat(w)).join("  ");
-  const body = cells.map((row) => row.map((cell, i) => (cell ?? "").padEnd(widths[i] ?? 0)).join("  "));
+  const body = cells.map((row) => row.map((cell, i) => cell.padEnd(widths[i] ?? 0)).join("  "));
 
   return [header, separator, ...body].join("\n");
 }

--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -7,7 +7,7 @@ import type { HttpClient } from "@qontoctl/core";
 import { withClient } from "../errors.js";
 
 export function registerAccountTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool("account_list", "List all bank accounts for the organization", {}, async () =>
+  server.registerTool("account_list", { description: "List all bank accounts for the organization" }, async () =>
     withClient(getClient, async (client) => {
       const response = await client.get<{ bank_accounts: unknown[] }>("/v2/bank_accounts");
       return {
@@ -16,11 +16,13 @@ export function registerAccountTools(server: McpServer, getClient: () => Promise
     }),
   );
 
-  server.tool(
+  server.registerTool(
     "account_show",
-    "Show details of a specific bank account",
     {
-      id: z.string().describe("Bank account UUID"),
+      description: "Show details of a specific bank account",
+      inputSchema: {
+        id: z.string().describe("Bank account UUID"),
+      },
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {

--- a/packages/mcp/src/tools/label.ts
+++ b/packages/mcp/src/tools/label.ts
@@ -23,12 +23,14 @@ interface SingleLabelResponse {
 }
 
 export function registerLabelTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool(
+  server.registerTool(
     "label_list",
-    "List all labels in the organization",
     {
-      page: z.number().int().positive().optional().describe("Page number"),
-      per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      description: "List all labels in the organization",
+      inputSchema: {
+        page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      },
     },
     async ({ page, per_page }) =>
       withClient(getClient, async (client) => {
@@ -52,11 +54,13 @@ export function registerLabelTools(server: McpServer, getClient: () => Promise<H
       }),
   );
 
-  server.tool(
+  server.registerTool(
     "label_show",
-    "Show details of a specific label",
     {
-      id: z.string().describe("Label ID (UUID)"),
+      description: "Show details of a specific label",
+      inputSchema: {
+        id: z.string().describe("Label ID (UUID)"),
+      },
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {

--- a/packages/mcp/src/tools/membership.ts
+++ b/packages/mcp/src/tools/membership.ts
@@ -19,12 +19,14 @@ interface PaginatedMembershipsResponse {
 }
 
 export function registerMembershipTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool(
+  server.registerTool(
     "membership_list",
-    "List all memberships in the organization",
     {
-      page: z.number().int().positive().optional().describe("Page number"),
-      per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      description: "List all memberships in the organization",
+      inputSchema: {
+        page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      },
     },
     async ({ page, per_page }) =>
       withClient(getClient, async (client) => {

--- a/packages/mcp/src/tools/org.ts
+++ b/packages/mcp/src/tools/org.ts
@@ -6,12 +6,15 @@ import type { HttpClient } from "@qontoctl/core";
 import { withClient } from "../errors.js";
 
 export function registerOrgTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool("org_show", "Show organization details including name, slug, and bank accounts", {}, async () =>
-    withClient(getClient, async (client) => {
-      const response = await client.get<{ organization: unknown }>("/v2/organization");
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify(response.organization, null, 2) }],
-      };
-    }),
+  server.registerTool(
+    "org_show",
+    { description: "Show organization details including name, slug, and bank accounts" },
+    async () =>
+      withClient(getClient, async (client) => {
+        const response = await client.get<{ organization: unknown }>("/v2/organization");
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(response.organization, null, 2) }],
+        };
+      }),
   );
 }

--- a/packages/mcp/src/tools/statement.test.ts
+++ b/packages/mcp/src/tools/statement.test.ts
@@ -43,8 +43,8 @@ describe("statement MCP tools", () => {
     registeredTools = new Map();
 
     server = {
-      tool: vi.fn((name: string, description: string, _schema: unknown, cb: ToolCallback) => {
-        registeredTools.set(name, { description, cb });
+      registerTool: vi.fn((name: string, config: { description: string; inputSchema?: unknown }, cb: ToolCallback) => {
+        registeredTools.set(name, { description: config.description, cb });
       }),
     } as unknown as McpServer;
 

--- a/packages/mcp/src/tools/statement.ts
+++ b/packages/mcp/src/tools/statement.ts
@@ -22,15 +22,17 @@ interface StatementsResponse {
  * Register statement-related MCP tools on the server.
  */
 export function registerStatementTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool(
+  server.registerTool(
     "statement_list",
-    "List bank statements with optional filters",
     {
-      bank_account_id: z.string().optional().describe("Filter by bank account ID"),
-      period_from: z.string().optional().describe("Start period (MM-YYYY)"),
-      period_to: z.string().optional().describe("End period (MM-YYYY)"),
-      page: z.number().int().positive().optional().describe("Page number"),
-      per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      description: "List bank statements with optional filters",
+      inputSchema: {
+        bank_account_id: z.string().optional().describe("Filter by bank account ID"),
+        period_from: z.string().optional().describe("Start period (MM-YYYY)"),
+        period_to: z.string().optional().describe("End period (MM-YYYY)"),
+        page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      },
     },
     async (args) =>
       withClient(getClient, async (client) => {
@@ -68,11 +70,13 @@ export function registerStatementTools(server: McpServer, getClient: () => Promi
       }),
   );
 
-  server.tool(
+  server.registerTool(
     "statement_show",
-    "Show details of a specific bank statement",
     {
-      id: z.string().describe("Statement ID"),
+      description: "Show details of a specific bank statement",
+      inputSchema: {
+        id: z.string().describe("Statement ID"),
+      },
     },
     async (args) =>
       withClient(getClient, async (client) => {

--- a/packages/mcp/src/tools/transactions.ts
+++ b/packages/mcp/src/tools/transactions.ts
@@ -7,23 +7,25 @@ import { type HttpClient, getOrganization } from "@qontoctl/core";
 import { withClient } from "../errors.js";
 
 export function registerTransactionTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
-  server.tool(
+  server.registerTool(
     "transaction_list",
-    "List transactions for a bank account with optional filters",
     {
-      bank_account_id: z.string().optional().describe("Bank account UUID"),
-      iban: z.string().optional().describe("Bank account IBAN (alternative to bank_account_id)"),
-      status: z.enum(["pending", "declined", "completed"]).optional().describe("Filter by status"),
-      settled_at_from: z.string().optional().describe("Start of settlement date range (ISO 8601)"),
-      settled_at_to: z.string().optional().describe("End of settlement date range (ISO 8601)"),
-      side: z.enum(["credit", "debit"]).optional().describe("Filter by side (credit or debit)"),
-      operation_type: z
-        .string()
-        .optional()
-        .describe("Filter by operation type (card, transfer, income, direct_debit, etc.)"),
-      sort_by: z.string().optional().describe("Sort order (e.g. settled_at:desc, created_at:asc)"),
-      current_page: z.number().int().positive().optional().describe("Page number (default: 1)"),
-      per_page: z.number().int().positive().max(100).optional().describe("Results per page (default: 100, max: 100)"),
+      description: "List transactions for a bank account with optional filters",
+      inputSchema: {
+        bank_account_id: z.string().optional().describe("Bank account UUID"),
+        iban: z.string().optional().describe("Bank account IBAN (alternative to bank_account_id)"),
+        status: z.enum(["pending", "declined", "completed"]).optional().describe("Filter by status"),
+        settled_at_from: z.string().optional().describe("Start of settlement date range (ISO 8601)"),
+        settled_at_to: z.string().optional().describe("End of settlement date range (ISO 8601)"),
+        side: z.enum(["credit", "debit"]).optional().describe("Filter by side (credit or debit)"),
+        operation_type: z
+          .string()
+          .optional()
+          .describe("Filter by operation type (card, transfer, income, direct_debit, etc.)"),
+        sort_by: z.string().optional().describe("Sort order (e.g. settled_at:desc, created_at:asc)"),
+        current_page: z.number().int().positive().optional().describe("Page number (default: 1)"),
+        per_page: z.number().int().positive().max(100).optional().describe("Results per page (default: 100, max: 100)"),
+      },
     },
     async (args) =>
       withClient(getClient, async (client) => {
@@ -62,11 +64,13 @@ export function registerTransactionTools(server: McpServer, getClient: () => Pro
       }),
   );
 
-  server.tool(
+  server.registerTool(
     "transaction_show",
-    "Show details of a specific transaction",
     {
-      id: z.string().describe("Transaction UUID"),
+      description: "Show details of a specific transaction",
+      inputSchema: {
+        id: z.string().describe("Transaction UUID"),
+      },
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {


### PR DESCRIPTION
## Summary

- Upgrade ESLint from `tseslint.configs.strict` to `tseslint.configs.strictTypeChecked` with `projectService` for type-aware linting
- Disable type-checked rules for test files (`*.test.ts`, `*.e2e.test.ts`) since they are excluded from build tsconfigs
- Allow `number` in `restrict-template-expressions` (safe, well-defined `toString()`)
- Fix all new violations: `no-confusing-void-expression`, `no-unnecessary-type-assertion`, `no-base-to-string`, `no-unnecessary-condition`, `restrict-template-expressions`
- Migrate MCP `server.tool()` to `server.registerTool()` to resolve `no-deprecated` warnings
- Update CLAUDE.md to reflect accurate config name

Closes #71

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 errors across all 5 packages)
- [x] `pnpm test` passes (327 unit tests)
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)