### PR TITLE
(docs) add README badges for Codecov and sub-package npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # QontoCtl: The Complete CLI & MCP for Qonto
 
 [![CI](https://github.com/alexey-pelykh/qontoctl/actions/workflows/ci.yml/badge.svg)](https://github.com/alexey-pelykh/qontoctl/actions/workflows/ci.yml)
+[![Codecov](https://img.shields.io/codecov/c/github/alexey-pelykh/qontoctl?logo=codecov)](https://codecov.io/gh/alexey-pelykh/qontoctl)
 [![npm version](https://img.shields.io/npm/v/qontoctl?logo=npm)](https://www.npmjs.com/package/qontoctl)
 [![npm downloads](https://img.shields.io/npm/dm/qontoctl?logo=npm)](https://www.npmjs.com/package/qontoctl)
 [![GitHub Repo stars](https://img.shields.io/github/stars/alexey-pelykh/qontoctl?style=flat&logo=github)](https://github.com/alexey-pelykh/qontoctl)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,5 +1,7 @@
 # @qontoctl/cli
 
+[![npm version](https://img.shields.io/npm/v/@qontoctl/cli?logo=npm)](https://www.npmjs.com/package/@qontoctl/cli)
+
 CLI commands for [Qonto](https://qonto.com) API integration — transaction listing, organization details, labels, memberships, statements, and more.
 
 Part of the [QontoCtl](https://github.com/alexey-pelykh/qontoctl) project.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,7 @@
 # @qontoctl/core
 
+[![npm version](https://img.shields.io/npm/v/@qontoctl/core?logo=npm)](https://www.npmjs.com/package/@qontoctl/core)
+
 Core library for [Qonto](https://qonto.com) API integration — HTTP client, authentication, configuration, and typed service functions.
 
 Part of the [QontoCtl](https://github.com/alexey-pelykh/qontoctl) project.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,5 +1,7 @@
 # @qontoctl/mcp
 
+[![npm version](https://img.shields.io/npm/v/@qontoctl/mcp?logo=npm)](https://www.npmjs.com/package/@qontoctl/mcp)
+
 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for [Qonto](https://qonto.com) API integration — lets AI assistants interact with Qonto banking data.
 
 Part of the [QontoCtl](https://github.com/alexey-pelykh/qontoctl) project.


### PR DESCRIPTION
## Summary

- Add Codecov coverage badge to root README (the only badge from #82 that was missing — CI, npm version, and license badges already existed)
- Add npm version badges to sub-package READMEs (`@qontoctl/core`, `@qontoctl/cli`, `@qontoctl/mcp`)

Closes #82

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 354 tests pass
- [ ] Verify badge URLs render correctly on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)