### PR TITLE
(docs) fix CHANGELOG 0.0.0 umbrella package description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ All notable changes to this project will be documented in this file.
 - Monorepo scaffolding with pnpm workspace and Turbo build orchestration
 - `@qontoctl/core` package for Qonto API client and service layer
 - `@qontoctl/mcp` package with MCP server (stdio transport)
-- `@qontoctl/cli` umbrella package with `qontoctl` CLI and `mcp` subcommand
+- `@qontoctl/cli` package with CLI command definitions
 - CI pipeline (GitHub Actions) with multi-platform testing
 - Release pipeline with npm provenance attestation
 - SPDX license headers on all source files


### PR DESCRIPTION
## Summary

- Fix `@qontoctl/cli` description in CHANGELOG 0.0.0 section: it's the CLI commands package, not the umbrella package

Closes #130

## Test plan

- [x] Verify CHANGELOG.md line 66 now reads "`@qontoctl/cli` package with CLI command definitions"
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)