### PR TITLE
(chore) include turbo.json in CI cache key (#137)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,6 +23,6 @@ runs:
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .turbo
-        key: turbo-${{ runner.os }}-node24-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: turbo-${{ runner.os }}-node24-${{ hashFiles('turbo.json', '**/pnpm-lock.yaml') }}
         restore-keys: |
           turbo-${{ runner.os }}-node24-


### PR DESCRIPTION
## Summary

- Add `turbo.json` to the `hashFiles()` call in the CI setup action's Turbo cache key
- Changes to Turbo task definitions (outputs, dependsOn, cache settings) now correctly invalidate the CI cache

Closes #137

## Test plan

- [ ] CI passes on all 3 OS matrix runners (ubuntu, macos, windows)
- [ ] Turbo cache key now includes hash of `turbo.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)