### PR TITLE
(docs) update CLAUDE.md branches coverage threshold to 75%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ ESLint enforces this via `eslint-plugin-header`.
 
 - Unit tests: `*.test.ts` (co-located with source)
 - E2E tests: `*.e2e.test.ts` (require Qonto sandbox)
-- Coverage thresholds: statements 85%, branches 69%, functions 80%, lines 85%
+- Coverage thresholds: statements 85%, branches 75%, functions 80%, lines 85%
 
 ### E2E Testing
 


### PR DESCRIPTION
## Summary

- Aligns `CLAUDE.md` branches coverage threshold with the actual `vitest.config.ts` value: `69%` → `75%`

Closes #132

## Test plan

- [x] Verified `vitest.config.ts:18` enforces `branches: 75`
- [x] Updated `CLAUDE.md:91` to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)