### PR TITLE
(docs) fix debug mode example: transactions → transaction (#129)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ With `--profile <name>`, prefix becomes `QONTOCTL_{NAME}_` (uppercased, hyphens 
 The `--verbose` and `--debug` flags enable wire-level logging to stderr:
 
 ```sh
-qontoctl --verbose transactions list   # request/response summaries
-qontoctl --debug transactions list     # full headers and response bodies
+qontoctl --verbose transaction list   # request/response summaries
+qontoctl --debug transaction list     # full headers and response bodies
 ```
 
 > **Security note:** `--debug` logs full API response bodies. Known sensitive fields


### PR DESCRIPTION
## Summary
- Fix debug mode examples in README.md using `transactions list` (plural) instead of the actual CLI command `transaction list` (singular)

Closes #129

## Test plan
- [x] Verified the CLI command is `transaction` (singular) in `packages/cli/src/commands/transaction/index.ts:12`
- [x] Verified no other instances of `transactions` in command examples across all README files

🤖 Generated with [Claude Code](https://claude.com/claude-code)