### PR TITLE
(docs) fix README config keys: snake_case → kebab-case (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,15 +199,15 @@ All configuration files use the same YAML format:
 
 ```yaml
 api-key:
-    organization_slug: acme-corp-4821
-    secret_key: your-secret-key
+    organization-slug: acme-corp-4821
+    secret-key: your-secret-key
 
 oauth:
-    client_id: app-id
-    client_secret: app-secret
-    access_token: eyJ... # auto-managed
-    refresh_token: dGhp... # auto-managed
-    expires_at: 2026-02-26T18:30:00Z # auto-managed
+    client-id: app-id
+    client-secret: app-secret
+    access-token: eyJ... # auto-managed
+    refresh-token: dGhp... # auto-managed
+    expires-at: 2026-02-26T18:30:00Z # auto-managed
 ```
 
 ### Resolution Order


### PR DESCRIPTION
## Summary

- Fix snake_case → kebab-case for config keys in README Profile Format example
- `organization_slug` → `organization-slug`, `secret_key` → `secret-key` (matches `validate.ts` expectations)
- Also fix OAuth section keys (`client_id`, `client_secret`, `access_token`, `refresh_token`, `expires_at`) for consistency

Closes #122

## Test plan

- [x] Verified no remaining snake_case config keys in README
- [x] Confirmed `packages/qontoctl/README.md` has no stale keys (issue mentioned it but it was clean)
- [ ] CI passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)