### PR TITLE
(ci) add format:check and typecheck to release validation (#131)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
+      - run: pnpm format:check
       - run: pnpm build
+      - run: pnpm typecheck
       - run: pnpm lint
       - run: pnpm license-check
       - run: pnpm publish-check


### PR DESCRIPTION
## Summary

- Add `pnpm format:check` step before `pnpm build` in release validate job
- Add `pnpm typecheck` step after `pnpm build` in release validate job
- Release validation now runs all 7 checks matching CI, closing the gap identified in audit finding CROSS-003 / CICD-003 / INFRA-002

Closes #131

## Test plan

- [ ] CI passes on all 3 OS matrix entries (ubuntu, macos, windows)
- [ ] Verify release validate job step order matches CI: format:check → build → typecheck → lint → license-check → publish-check → test

🤖 Generated with [Claude Code](https://claude.com/claude-code)