### PR TITLE
(chore) add Dependabot commit-message prefix (#138)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "(chore)"
     groups:
       actions-minor-patch:
         update-types:
@@ -20,6 +22,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "(chore)"
     groups:
       npm-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

- Adds `commit-message: prefix: "(chore)"` to both `github-actions` and `npm` ecosystems in `.github/dependabot.yml`
- Ensures Dependabot PRs follow the project's `(type) message` commit convention

Closes #138

## Test plan

- [x] Verify YAML syntax is valid
- [x] Confirm both ecosystems have the `commit-message` block
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)