### PR TITLE
(docs) fix core README usage example property names (#128)

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,16 +15,16 @@ npm install @qontoctl/core
 ## Usage
 
 ```ts
-import { resolveConfig, buildApiKeyAuthorization, HttpClient, API_BASE_URL, getOrganization } from "@qontoctl/core";
+import { resolveConfig, buildApiKeyAuthorization, HttpClient, getOrganization } from "@qontoctl/core";
 
 // Resolve configuration from file or environment
-const config = await resolveConfig();
+const { config, endpoint } = await resolveConfig();
 
 // Build authorization headers
-const auth = buildApiKeyAuthorization(config.credentials);
+const authorization = buildApiKeyAuthorization(config.apiKey);
 
 // Create an HTTP client
-const client = new HttpClient({ baseUrl: API_BASE_URL, auth });
+const client = new HttpClient({ baseUrl: endpoint, authorization });
 
 // Fetch organization details
 const org = await getOrganization(client);


### PR DESCRIPTION
## Summary

- Fix `config.credentials` → `config.apiKey` (per `QontoctlConfig` type)
- Fix `auth` → `authorization` (per `HttpClientOptions`)
- Destructure `resolveConfig()` correctly as `{ config, endpoint }`
- Use resolved `endpoint` instead of hardcoded `API_BASE_URL`

Closes #128

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass
- [x] Usage example matches actual type signatures (`QontoctlConfig.apiKey`, `HttpClientOptions.authorization`, `ConfigResult.endpoint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)