### PR TITLE
(ci) enable branch protection on main (#127)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,12 @@ Each package uses conditional exports with `types` + `import`:
 - **Release**: Triggered by GitHub Release publish; validates, stamps version from git tag, publishes to npm with provenance
 - **Setup**: Composite action at `.github/actions/setup/` (pnpm + Node.js 24 + frozen lockfile + Turbo cache)
 - Coverage uploaded to Codecov on ubuntu only
+
+### Branch Protection
+
+The `main` branch is protected with the following rules:
+
+- **Require pull request before merging**: At least 1 approval required
+- **Require status checks to pass**: The `CI` job (ci-gate) must pass before merging
+- **Require branches to be up to date**: Feature branches must be rebased on latest `main`
+- **No bypass**: Admin bypass is disabled — all contributors follow the same rules


### PR DESCRIPTION
## Summary

- Enables branch protection on `main` via GitHub API: requires 1 PR approval, `CI` status check must pass, branches must be up to date, no admin bypass
- Documents the branch protection rules in CLAUDE.md under the CI/CD section

Closes #127

## Test plan

- [x] Branch protection applied via GitHub API — verified settings match issue requirements
- [ ] CI passes on this PR (validates the `CI` status check enforcement works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)