### PR TITLE
(ci) add npm-publish environment protection rules (#126)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
       - run: pnpm publish-check
       - run: pnpm test
 
+  # NOTE: The npm-publish environment requires the following protection rules
+  # configured in GitHub Settings → Environments → npm-publish:
+  #   1. Required reviewers — at least one reviewer must approve the deployment
+  #   2. Deployment branches — restricted to "main" only
+  # npm publishes are permanent (same version cannot be re-published after unpublish),
+  # so human approval and branch restriction prevent accidental or unauthorized releases.
   publish-npm:
     name: Publish to npm
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Configure the `npm-publish` GitHub environment with required reviewer approval (`alexey-pelykh`) and deployment branch restriction (`main` only)
- Document the expected environment protection rules in the release workflow as inline comments

Closes #126

## What was done

The `npm-publish` environment previously had zero protection rules:

```json
{
  "protection_rules": [],
  "deployment_branch_policy": null,
  "can_admins_bypass": true
}
```

Applied via GitHub API:
1. **Required reviewers**: `alexey-pelykh` must approve each deployment
2. **Deployment branch policy**: Restricted to `main` branch only (custom branch policy)

Added inline documentation in `.github/workflows/release.yml` explaining why these protections exist (npm publishes are permanent — same version cannot be re-published after unpublish).

## Test plan

- [x] Verify environment protection rules are applied via `gh api repos/{owner}/{repo}/environments/npm-publish`
- [x] Verify `main` is the only allowed deployment branch via `gh api repos/{owner}/{repo}/environments/npm-publish/deployment-branch-policies`
- [ ] CI passes (build, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)