### PR TITLE
(chore) standardize MCP pagination parameter to current_page (#141)

### DIFF
--- a/packages/mcp/src/tools/label.test.ts
+++ b/packages/mcp/src/tools/label.test.ts
@@ -69,7 +69,7 @@ describe("label MCP tools", () => {
 
       await mcpClient.callTool({
         name: "label_list",
-        arguments: { page: 2, per_page: 10 },
+        arguments: { current_page: 2, per_page: 10 },
       });
 
       const [url] = fetchSpy.mock.calls[0] as [URL];

--- a/packages/mcp/src/tools/label.ts
+++ b/packages/mcp/src/tools/label.ts
@@ -28,14 +28,14 @@ export function registerLabelTools(server: McpServer, getClient: () => Promise<H
     {
       description: "List all labels in the organization",
       inputSchema: {
-        page: z.number().int().positive().optional().describe("Page number"),
+        current_page: z.number().int().positive().optional().describe("Page number"),
         per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
       },
     },
-    async ({ page, per_page }) =>
+    async ({ current_page, per_page }) =>
       withClient(getClient, async (client) => {
         const params: Record<string, string> = {};
-        if (page !== undefined) params["current_page"] = String(page);
+        if (current_page !== undefined) params["current_page"] = String(current_page);
         if (per_page !== undefined) params["per_page"] = String(per_page);
 
         const response = await client.get<PaginatedLabelsResponse>(

--- a/packages/mcp/src/tools/membership.test.ts
+++ b/packages/mcp/src/tools/membership.test.ts
@@ -80,7 +80,7 @@ describe("membership MCP tools", () => {
 
       await mcpClient.callTool({
         name: "membership_list",
-        arguments: { page: 3, per_page: 25 },
+        arguments: { current_page: 3, per_page: 25 },
       });
 
       const [url] = fetchSpy.mock.calls[0] as [URL];

--- a/packages/mcp/src/tools/membership.ts
+++ b/packages/mcp/src/tools/membership.ts
@@ -24,14 +24,14 @@ export function registerMembershipTools(server: McpServer, getClient: () => Prom
     {
       description: "List all memberships in the organization",
       inputSchema: {
-        page: z.number().int().positive().optional().describe("Page number"),
+        current_page: z.number().int().positive().optional().describe("Page number"),
         per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
       },
     },
-    async ({ page, per_page }) =>
+    async ({ current_page, per_page }) =>
       withClient(getClient, async (client) => {
         const params: Record<string, string> = {};
-        if (page !== undefined) params["current_page"] = String(page);
+        if (current_page !== undefined) params["current_page"] = String(current_page);
         if (per_page !== undefined) params["per_page"] = String(per_page);
 
         const response = await client.get<PaginatedMembershipsResponse>(

--- a/packages/mcp/src/tools/statement.test.ts
+++ b/packages/mcp/src/tools/statement.test.ts
@@ -98,7 +98,7 @@ describe("statement MCP tools", () => {
         bank_account_id: "acct-1",
         period_from: "01-2025",
         period_to: "06-2025",
-        page: 2,
+        current_page: 2,
         per_page: 50,
       });
 

--- a/packages/mcp/src/tools/statement.ts
+++ b/packages/mcp/src/tools/statement.ts
@@ -30,7 +30,7 @@ export function registerStatementTools(server: McpServer, getClient: () => Promi
         bank_account_id: z.string().optional().describe("Filter by bank account ID"),
         period_from: z.string().optional().describe("Start period (MM-YYYY)"),
         period_to: z.string().optional().describe("End period (MM-YYYY)"),
-        page: z.number().int().positive().optional().describe("Page number"),
+        current_page: z.number().int().positive().optional().describe("Page number"),
         per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
       },
     },
@@ -47,8 +47,8 @@ export function registerStatementTools(server: McpServer, getClient: () => Promi
         if (args.period_to !== undefined) {
           params["period_to"] = args.period_to;
         }
-        if (args.page !== undefined) {
-          params["current_page"] = String(args.page);
+        if (args.current_page !== undefined) {
+          params["current_page"] = String(args.current_page);
         }
         if (args.per_page !== undefined) {
           params["per_page"] = String(args.per_page);


### PR DESCRIPTION
## Summary

- Rename `page` parameter to `current_page` in `label_list`, `membership_list`, and `statement_list` MCP tools
- Aligns all 4 paginated MCP tools with the Qonto API convention (`current_page`)
- Removes the unnecessary parameter name conversion (`page` → `current_page`) in the request building logic

Closes #141

## Test plan

- [x] Unit tests updated and passing (44 MCP tests, 363 total)
- [x] E2E tests passing (80 passed, 5 skipped)
- [x] Build and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)