### PR TITLE
(chore) add clean scripts and purge stale test files from dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=24"
   },
   "scripts": {
+    "clean": "turbo run clean",
     "build": "turbo run build",
     "test": "turbo run test",
     "test:e2e": "turbo run test:e2e --concurrency=1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "access": "public"
   },
   "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,6 +10,7 @@
   "license": "AGPL-3.0-only",
   "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
   "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "echo 'No unit tests'",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -49,6 +49,7 @@
     "access": "public"
   },
   "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/packages/qontoctl/package.json
+++ b/packages/qontoctl/package.json
@@ -37,6 +37,7 @@
     "dist"
   ],
   "scripts": {
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "cp ../../README.md ../../LICENSE .",
     "build": "tsc",
     "typecheck": "tsc --noEmit",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
+    "clean": {
+      "cache": false
+    },
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]


### PR DESCRIPTION
## Summary

- Add per-package `clean` script (`rm -rf dist tsconfig.tsbuildinfo`) to all 5 packages
- Add Turbo `clean` task with `"cache": false`
- Add root `pnpm clean` script that orchestrates via `turbo run clean`

Running `pnpm clean && pnpm build` eliminates the 152 stale compiled test artifacts that remained in `dist/` after the prior tsconfig exclusion fix.

Closes #125

## Test plan

- [x] `pnpm clean` runs successfully across all packages
- [x] `pnpm build` succeeds after clean
- [x] Zero `*.test.*` files remain in any `dist/` directory after clean + build
- [x] All unit tests pass (363 tests)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)