### PR TITLE
(refactor) align profile commands with established CLI patterns

### DIFF
--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -8,6 +8,7 @@ import { createInterface } from "node:readline/promises";
 import { stringify as stringifyYaml } from "yaml";
 import type { Command } from "commander";
 import { loadConfigFile } from "@qontoctl/core";
+import { addInheritableOptions } from "../../inherited-options.js";
 
 const CONFIG_DIR = ".qontoctl";
 
@@ -15,12 +16,11 @@ const CONFIG_DIR = ".qontoctl";
  * Register the `profile add <name>` subcommand.
  */
 export function registerAddCommand(parent: Command): void {
-  parent
-    .command("add <name>")
-    .description("create a new profile interactively")
-    .action(async (name: string) => {
-      await addProfile(name);
-    });
+  const add = parent.command("add <name>").description("create a new profile interactively");
+  addInheritableOptions(add);
+  add.action(async (name: string) => {
+    await addProfile(name);
+  });
 }
 
 async function addProfile(name: string): Promise<void> {

--- a/packages/cli/src/commands/profile/list.ts
+++ b/packages/cli/src/commands/profile/list.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { Command } from "commander";
 import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions } from "../../options.js";
 
 const CONFIG_DIR = ".qontoctl";
@@ -15,13 +16,12 @@ const YAML_EXT = ".yaml";
  * Register the `profile list` subcommand.
  */
 export function registerListCommand(parent: Command): void {
-  parent
-    .command("list")
-    .description("list named profiles from ~/.qontoctl/")
-    .action(async (_options: unknown, cmd: Command) => {
-      const globalOpts = cmd.optsWithGlobals<GlobalOptions>();
-      await listProfiles(globalOpts);
-    });
+  const list = parent.command("list").description("list named profiles from ~/.qontoctl/");
+  addInheritableOptions(list);
+  list.action(async (_options: unknown, cmd: Command) => {
+    const globalOpts = resolveGlobalOptions<GlobalOptions>(cmd);
+    await listProfiles(globalOpts);
+  });
 }
 
 async function listProfiles(options: GlobalOptions): Promise<void> {

--- a/packages/cli/src/commands/profile/remove.ts
+++ b/packages/cli/src/commands/profile/remove.ts
@@ -7,6 +7,7 @@ import { homedir } from "node:os";
 import { createInterface } from "node:readline/promises";
 import type { Command } from "commander";
 import { loadConfigFile } from "@qontoctl/core";
+import { addInheritableOptions } from "../../inherited-options.js";
 
 const CONFIG_DIR = ".qontoctl";
 
@@ -14,12 +15,11 @@ const CONFIG_DIR = ".qontoctl";
  * Register the `profile remove <name>` subcommand.
  */
 export function registerRemoveCommand(parent: Command): void {
-  parent
-    .command("remove <name>")
-    .description("delete a named profile (with confirmation)")
-    .action(async (name: string) => {
-      await removeProfile(name);
-    });
+  const remove = parent.command("remove <name>").description("delete a named profile (with confirmation)");
+  addInheritableOptions(remove);
+  remove.action(async (name: string) => {
+    await removeProfile(name);
+  });
 }
 
 async function removeProfile(name: string): Promise<void> {

--- a/packages/cli/src/commands/profile/show.ts
+++ b/packages/cli/src/commands/profile/show.ts
@@ -4,19 +4,19 @@
 import type { Command } from "commander";
 import { loadConfigFile, validateConfig } from "@qontoctl/core";
 import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions } from "../../options.js";
 
 /**
  * Register the `profile show <name>` subcommand.
  */
 export function registerShowCommand(parent: Command): void {
-  parent
-    .command("show <name>")
-    .description("show profile details with secrets redacted")
-    .action(async (name: string, _options: unknown, cmd: Command) => {
-      const globalOpts = cmd.optsWithGlobals<GlobalOptions>();
-      await showProfile(name, globalOpts);
-    });
+  const show = parent.command("show <name>").description("show profile details with secrets redacted");
+  addInheritableOptions(show);
+  show.action(async (name: string, _options: unknown, cmd: Command) => {
+    const globalOpts = resolveGlobalOptions<GlobalOptions>(cmd);
+    await showProfile(name, globalOpts);
+  });
 }
 
 async function showProfile(name: string, options: GlobalOptions): Promise<void> {


### PR DESCRIPTION
## Summary

- Add `addInheritableOptions` to `profile list`, `profile show`, `profile add`, and `profile remove` subcommands so `--profile`, `--verbose`, and `--debug` flags are accepted after the subcommand
- Replace `cmd.optsWithGlobals()` with `resolveGlobalOptions()` in `profile list` and `profile show` for consistent option resolution across the command chain
- Restructure registration to assign command to a variable before adding options and action (matching the pattern used by all other command groups)

Closes #142

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (all 363 unit tests green)
- [x] Profile subcommands now accept `--profile`, `--verbose`, `--debug` after the subcommand name

🤖 Generated with [Claude Code](https://claude.com/claude-code)