### PR TITLE
(ci) use npm version range instead of exact pin in release workflow (#139)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
-      # Trusted publishing requires npm 11.5.1+ for OIDC token exchange
+      # Trusted publishing requires npm >=11.5.1 for OIDC token exchange
       - name: Upgrade npm
-        run: npm install -g "npm@11.5.1"
+        run: npm install -g "npm@>=11.5.1"
 
       - name: Stamp version
         env:


### PR DESCRIPTION
## Summary

- Replace exact npm version pin (`npm@11.5.1`) with semver range (`npm@>=11.5.1`) in the release workflow
- Ensures the release workflow always gets the latest compatible npm version while maintaining the minimum version requirement for OIDC trusted publishing

Closes #139

## Test plan

- [ ] CI passes (workflow YAML syntax is valid)
- [ ] Release workflow will install npm >=11.5.1 on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)