### PR TITLE
(fix) remove invalid --sort flag from pnpm publish commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,9 @@ jobs:
 
   # NOTE: The npm-publish environment requires the following protection rules
   # configured in GitHub Settings → Environments → npm-publish:
-  #   1. Required reviewers — at least one reviewer must approve the deployment
-  #   2. Deployment branches — restricted to "main" only
+  #   1. Deployment branches — restricted to "main" branch and "v*" tags
   # npm publishes are permanent (same version cannot be re-published after unpublish),
-  # so human approval and branch restriction prevent accidental or unauthorized releases.
+  # so branch/tag restriction prevents accidental or unauthorized releases.
   publish-npm:
     name: Publish to npm
     timeout-minutes: 10
@@ -74,9 +73,8 @@ jobs:
 
       - run: pnpm build
 
-      # --sort ensures topological publish order: @qontoctl/core → cli, mcp → qontoctl
       - name: Verify packages
-        run: pnpm -r --sort publish --dry-run --access public --no-git-checks
+        run: pnpm -r publish --dry-run --access public --no-git-checks
 
       - name: Publish packages
-        run: pnpm -r --sort publish --access public --no-git-checks --report-summary --provenance
+        run: pnpm -r publish --access public --no-git-checks --report-summary --provenance


### PR DESCRIPTION
## Summary
- Remove non-existent `--sort` flag from `pnpm -r publish` commands in release workflow
- Update environment protection comment to reflect actual tag-based deployment policy (no reviewer requirement, `v*` tag policy added)

## Context
First release (`v0.1.0`) failed at the publish step because pnpm does not recognize `--sort`. The `-r` flag already handles recursive publishing.

## Test plan
- [ ] Re-run release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)