### PR TITLE
Add MCP registry configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 build/
 .tmp/
 
+# MCP Registry publisher tokens
+.mcpregistry_*
+
 # Turbo
 .turbo/
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["alexey-pelykh"]
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.alexey-pelykh/qontoctl",
+  "description": "CLI and MCP server for the Qonto banking API",
+  "repository": {
+    "url": "https://github.com/alexey-pelykh/qontoctl",
+    "source": "github"
+  },
+  "version": "0.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "qontoctl",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "QONTOCTL_ORGANIZATION_SLUG",
+          "description": "Qonto organization slug",
+          "isRequired": true,
+          "isSecret": false,
+          "format": "string"
+        },
+        {
+          "name": "QONTOCTL_SECRET_KEY",
+          "description": "Qonto API secret key",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,24 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+startCommand:
+  type: stdio
+  configSchema:
+    type: object
+    required:
+      - organizationSlug
+      - secretKey
+    properties:
+      organizationSlug:
+        type: string
+        description: Qonto organization slug
+      secretKey:
+        type: string
+        description: Qonto API secret key
+  commandFunction: |-
+    (config) => ({
+      command: 'npx',
+      args: ['-y', 'qontoctl@0.1.0', 'mcp'],
+      env: {
+        QONTOCTL_ORGANIZATION_SLUG: config.organizationSlug,
+        QONTOCTL_SECRET_KEY: config.secretKey
+      }
+    })


### PR DESCRIPTION
## Summary

- Add `server.json` for the [Official MCP Registry](https://registry.modelcontextprotocol.io) (used by `mcp-publisher`)
- Add `smithery.yaml` for [Smithery.ai](https://smithery.ai) server discovery
- Add `glama.json` for [Glama.ai](https://glama.ai) server ownership claiming
- Add `.mcpregistry_*` to `.gitignore` for `mcp-publisher` token files

These files enable QontoCtl to be listed on major MCP server registries for discoverability by AI assistant users.

## Test plan

- [ ] Verify `server.json` schema validates against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [ ] Verify `smithery.yaml` config schema matches actual env var expectations
- [ ] Verify `glama.json` schema validates against `https://glama.ai/mcp/schemas/server.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)