### PR TITLE
Add Homebrew tap update to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,3 +78,21 @@ jobs:
 
       - name: Publish packages
         run: pnpm -r publish --access public --no-git-checks --report-summary --provenance
+
+  # NOTE: GITHUB_TOKEN cannot trigger cross-repo workflows, so this job requires
+  # a PAT (HOMEBREW_TAP_TOKEN) with repo scope for the qontoctl org.
+  update-homebrew:
+    name: Update Homebrew formula
+    timeout-minutes: 5
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch formula update
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          RAW_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${RAW_TAG#v}"
+          gh api repos/qontoctl/homebrew-tap/dispatches \
+            -f event_type=update-formula \
+            -f "client_payload[version]=$VERSION"


### PR DESCRIPTION
## Summary

- Adds `update-homebrew` job to release workflow that fires `repository_dispatch` to `qontoctl/homebrew-tap` after successful npm publish
- The tap repo auto-updates the formula URL and SHA256 for the new version

## Setup required

- Create `HOMEBREW_TAP_TOKEN` secret on `alexey-pelykh/qontoctl` — a PAT with `repo` scope for the `qontoctl` org (needed because `GITHUB_TOKEN` cannot trigger cross-repo workflows)

## Test plan

- [ ] Add `HOMEBREW_TAP_TOKEN` secret to repo settings
- [ ] Verify on next release that the dispatch triggers formula update in `qontoctl/homebrew-tap`
- [ ] `brew tap qontoctl/tap && brew install qontoctl` installs successfully

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)