### PR TITLE
Add Homebrew post-release step to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ Each package uses conditional exports with `types` + `import`:
 
 - **CI**: Runs on push/PR to `main`; 3-OS matrix (ubuntu, macos, windows); builds, lints, license-checks, tests
 - **Release**: Triggered by GitHub Release publish; validates, stamps version from git tag, publishes to npm with provenance
+- **Homebrew**: After npm publish completes, manually trigger the "Update Formula" workflow in `qontoctl/homebrew-tap` (Actions → Update Formula → Run workflow) to update the Homebrew formula to the latest npm version
 - **Setup**: Composite action at `.github/actions/setup/` (pnpm + Node.js 24 + frozen lockfile + Turbo cache)
 - Coverage uploaded to Codecov on ubuntu only
 


### PR DESCRIPTION
## Summary

- Documents the manual Homebrew formula update step in the CI/CD section of CLAUDE.md
- After npm publish, trigger `gh workflow run update-formula.yml --repo qontoctl/homebrew-tap`

Part of #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)