### PR TITLE
Add supplier invoice commands

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -11,3 +11,4 @@ export { registerStatementCommands } from "./statement.js";
 export { registerOrgCommands } from "./org.js";
 export { registerAccountCommands } from "./account.js";
 export { registerTransferCommands } from "./transfer/index.js";
+export { registerSupplierInvoiceCommands } from "./supplier-invoice/index.js";

--- a/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockResolvedValue(Buffer.from("fake-pdf-content")),
+}));
+
+import { createClient } from "../../client.js";
+import { HttpClient } from "@qontoctl/core";
+
+describe("supplier-invoice bulk-create command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("creates supplier invoices from files", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [
+          {
+            id: "new-inv-1",
+            supplier_name: null,
+            invoice_number: null,
+            status: "to_review",
+            total_amount: null,
+            due_date: null,
+            issue_date: null,
+            payment_date: null,
+            file_name: "invoice.pdf",
+            is_einvoice: false,
+            created_at: "2026-03-01T00:00:00.000Z",
+            self: "https://example.com/new-inv-1",
+          },
+        ],
+        errors: [],
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("new-inv-1");
+  });
+
+  it("outputs json format for created invoices", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [
+          {
+            id: "new-inv-1",
+            supplier_name: null,
+            invoice_number: null,
+            status: "to_review",
+            total_amount: null,
+            due_date: null,
+            issue_date: null,
+            payment_date: null,
+            file_name: "invoice.pdf",
+            is_einvoice: false,
+            created_at: "2026-03-01T00:00:00.000Z",
+            self: "https://example.com/new-inv-1",
+          },
+        ],
+        errors: [],
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], {
+      from: "user",
+    });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as unknown[];
+    expect(parsed).toHaveLength(1);
+  });
+
+  it("writes errors to stderr and sets exit code", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [],
+        errors: [
+          {
+            code: "invalid_file_type",
+            detail: "File type not supported",
+          },
+        ],
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/bad.txt"], { from: "user" });
+
+    expect(stderrSpy).toHaveBeenCalled();
+    const errorOutput = stderrSpy.mock.calls[0]?.[0] as string;
+    expect(errorOutput).toContain("invalid_file_type");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("sends FormData to the bulk endpoint", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [],
+        errors: [],
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], { from: "user" });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/supplier_invoices/bulk");
+  });
+});

--- a/packages/cli/src/commands/supplier-invoice/bulk-create.ts
+++ b/packages/cli/src/commands/supplier-invoice/bulk-create.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { randomUUID } from "node:crypto";
+import type { Command } from "commander";
+import { bulkCreateSupplierInvoices, type BulkCreateSupplierInvoiceEntry } from "@qontoctl/core";
+import { createClient } from "../../client.js";
+import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import type { GlobalOptions } from "../../options.js";
+
+export function registerSupplierInvoiceBulkCreateCommand(parent: Command): void {
+  const bulkCreate = parent
+    .command("bulk-create")
+    .description("Create supplier invoices from files")
+    .argument("<files...>", "invoice file paths (PDF, PNG, JPG)");
+  addInheritableOptions(bulkCreate);
+  bulkCreate.action(async (files: string[], _opts: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions>(cmd);
+    const client = await createClient(opts);
+
+    const entries: BulkCreateSupplierInvoiceEntry[] = [];
+    for (const filePath of files) {
+      const buffer = await readFile(filePath);
+      const fileName = basename(filePath);
+      entries.push({
+        file: new Blob([buffer]),
+        fileName,
+        idempotencyKey: randomUUID(),
+      });
+    }
+
+    const result = await bulkCreateSupplierInvoices(client, entries);
+
+    if (result.errors.length > 0) {
+      for (const error of result.errors) {
+        process.stderr.write(`Error: ${error.code}: ${error.detail}\n`);
+      }
+    }
+
+    if (result.supplier_invoices.length > 0) {
+      const data =
+        opts.output === "json" || opts.output === "yaml"
+          ? result.supplier_invoices
+          : result.supplier_invoices.map((inv) => ({
+              id: inv.id,
+              file_name: inv.file_name,
+              status: inv.status,
+            }));
+
+      process.stdout.write(formatOutput(data, opts.output) + "\n");
+    }
+
+    if (result.errors.length > 0) {
+      process.exitCode = 1;
+    }
+  });
+}

--- a/packages/cli/src/commands/supplier-invoice/index.ts
+++ b/packages/cli/src/commands/supplier-invoice/index.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { registerSupplierInvoiceListCommand } from "./list.js";
+import { registerSupplierInvoiceShowCommand } from "./show.js";
+import { registerSupplierInvoiceBulkCreateCommand } from "./bulk-create.js";
+
+/**
+ * Register the `supplier-invoice` command group with list, show, and bulk-create subcommands.
+ */
+export function registerSupplierInvoiceCommands(program: Command): void {
+  const supplierInvoice = program.command("supplier-invoice").description("Manage supplier invoices");
+
+  registerSupplierInvoiceListCommand(supplierInvoice);
+  registerSupplierInvoiceShowCommand(supplierInvoice);
+  registerSupplierInvoiceBulkCreateCommand(supplierInvoice);
+}

--- a/packages/cli/src/commands/supplier-invoice/list.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/list.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+import type { PaginationMeta } from "../../pagination.js";
+
+function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "../../client.js";
+import { HttpClient } from "@qontoctl/core";
+
+describe("supplier-invoice list command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists supplier invoices in table format", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [
+          {
+            id: "inv-1",
+            supplier_name: "Acme Corp",
+            invoice_number: "INV-001",
+            status: "paid",
+            total_amount: { value: "100.00", currency: "EUR" },
+            due_date: "2026-04-01",
+            issue_date: "2026-03-01",
+            payment_date: "2026-03-15",
+            file_name: "invoice.pdf",
+            is_einvoice: false,
+            created_at: "2026-03-01T00:00:00.000Z",
+            self: "https://example.com/inv-1",
+          },
+        ],
+        meta: makeMeta({ total_count: 1 }),
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "list"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("inv-1");
+    expect(output).toContain("Acme Corp");
+    expect(output).toContain("paid");
+  });
+
+  it("lists supplier invoices in json format", async () => {
+    const invoices = [
+      {
+        id: "inv-1",
+        supplier_name: "Acme Corp",
+        invoice_number: "INV-001",
+        status: "paid",
+        total_amount: { value: "100.00", currency: "EUR" },
+        due_date: "2026-04-01",
+        issue_date: "2026-03-01",
+        payment_date: "2026-03-15",
+        file_name: "invoice.pdf",
+        is_einvoice: false,
+        created_at: "2026-03-01T00:00:00.000Z",
+        self: "https://example.com/inv-1",
+      },
+    ];
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: invoices,
+        meta: makeMeta({ total_count: 1 }),
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "supplier-invoice", "list"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as unknown[];
+    expect(parsed).toHaveLength(1);
+    const first = parsed[0] as Record<string, unknown>;
+    expect(first).toHaveProperty("id", "inv-1");
+  });
+
+  it("formats total_amount as null when absent", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [
+          {
+            id: "inv-2",
+            supplier_name: "No Amount Corp",
+            invoice_number: null,
+            status: "to_review",
+            total_amount: null,
+            due_date: null,
+            issue_date: null,
+            payment_date: null,
+            file_name: "doc.pdf",
+            is_einvoice: false,
+            created_at: "2026-03-01T00:00:00.000Z",
+            self: "https://example.com/inv-2",
+          },
+        ],
+        meta: makeMeta({ total_count: 1 }),
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "list"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  it("passes status filter to API", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [],
+        meta: makeMeta(),
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "list", "--status", "paid"], { from: "user" });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("filter[status][]")).toBe("paid");
+  });
+
+  it("passes query and sort params", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoices: [],
+        meta: makeMeta(),
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "list", "--query", "acme", "--sort-by", "created_at:desc"], {
+      from: "user",
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("query")).toBe("acme");
+    expect(url.searchParams.get("sort_by")).toBe("created_at:desc");
+  });
+});

--- a/packages/cli/src/commands/supplier-invoice/list.ts
+++ b/packages/cli/src/commands/supplier-invoice/list.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { Option } from "commander";
+import { buildSupplierInvoiceQueryParams, type ListSupplierInvoicesParams, type SupplierInvoice } from "@qontoctl/core";
+import { createClient } from "../../client.js";
+import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import type { GlobalOptions, PaginationOptions } from "../../options.js";
+import { fetchPaginated } from "../../pagination.js";
+
+interface SupplierInvoiceListOptions extends GlobalOptions, PaginationOptions {
+  readonly status?: string[] | undefined;
+  readonly dueDateFilter?: string | undefined;
+  readonly createdFrom?: string | undefined;
+  readonly createdTo?: string | undefined;
+  readonly updatedFrom?: string | undefined;
+  readonly updatedTo?: string | undefined;
+  readonly query?: string | undefined;
+  readonly sortBy?: string | undefined;
+}
+
+const SUPPLIER_INVOICE_STATUSES = [
+  "to_review",
+  "to_approve",
+  "awaiting_payment",
+  "pending",
+  "scheduled",
+  "paid",
+  "archived",
+  "rejected",
+  "discarded",
+] as const;
+
+function toTableRow(inv: SupplierInvoice): Record<string, string | null> {
+  return {
+    id: inv.id,
+    supplier_name: inv.supplier_name,
+    invoice_number: inv.invoice_number,
+    total_amount: inv.total_amount !== null ? `${inv.total_amount.value} ${inv.total_amount.currency}` : null,
+    status: inv.status,
+    due_date: inv.due_date,
+  };
+}
+
+function buildParams(opts: SupplierInvoiceListOptions): ListSupplierInvoicesParams {
+  return {
+    ...(opts.status !== undefined && { status: opts.status }),
+    ...(opts.dueDateFilter !== undefined && { due_date: opts.dueDateFilter }),
+    ...(opts.createdFrom !== undefined && { created_at_from: opts.createdFrom }),
+    ...(opts.createdTo !== undefined && { created_at_to: opts.createdTo }),
+    ...(opts.updatedFrom !== undefined && { updated_at_from: opts.updatedFrom }),
+    ...(opts.updatedTo !== undefined && { updated_at_to: opts.updatedTo }),
+    ...(opts.query !== undefined && { query: opts.query }),
+    ...(opts.sortBy !== undefined && { sort_by: opts.sortBy }),
+  };
+}
+
+export function registerSupplierInvoiceListCommand(parent: Command): void {
+  const list = parent
+    .command("list")
+    .description("List supplier invoices")
+    .addOption(new Option("--status <status...>", "filter by status").choices([...SUPPLIER_INVOICE_STATUSES]))
+    .addOption(
+      new Option("--due-date-filter <filter>", "filter by due date").choices([
+        "past_and_today",
+        "future",
+        "missing_date",
+      ]),
+    )
+    .addOption(new Option("--created-from <date>", "filter by creation date start (ISO 8601)"))
+    .addOption(new Option("--created-to <date>", "filter by creation date end (ISO 8601)"))
+    .addOption(new Option("--updated-from <date>", "filter by update date start (ISO 8601)"))
+    .addOption(new Option("--updated-to <date>", "filter by update date end (ISO 8601)"))
+    .addOption(new Option("--query <text>", "full-text search"))
+    .addOption(new Option("--sort-by <sort>", "sort order (e.g. created_at:desc)"));
+  addInheritableOptions(list);
+  list.action(async (_opts: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<SupplierInvoiceListOptions>(cmd);
+    const client = await createClient(opts);
+
+    const params = buildParams(opts);
+    const queryParams = buildSupplierInvoiceQueryParams(params);
+
+    const result = await fetchPaginated<SupplierInvoice>(
+      client,
+      "/v2/supplier_invoices",
+      "supplier_invoices",
+      opts,
+      queryParams,
+    );
+
+    const data = opts.output === "table" || opts.output === "csv" ? result.items.map(toTableRow) : result.items;
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+}

--- a/packages/cli/src/commands/supplier-invoice/show.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/show.test.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "../../client.js";
+import { HttpClient } from "@qontoctl/core";
+
+describe("supplier-invoice show command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a supplier invoice in table format", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoice: {
+          id: "inv-1",
+          supplier_name: "Acme Corp",
+          invoice_number: "INV-001",
+          status: "paid",
+          total_amount: { value: "100.00", currency: "EUR" },
+          due_date: "2026-04-01",
+          issue_date: "2026-03-01",
+          payment_date: "2026-03-15",
+          file_name: "invoice.pdf",
+          is_einvoice: false,
+          created_at: "2026-03-01T00:00:00.000Z",
+          self: "https://example.com/inv-1",
+        },
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "show", "inv-1"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("inv-1");
+    expect(output).toContain("Acme Corp");
+    expect(output).toContain("100.00 EUR");
+  });
+
+  it("shows a supplier invoice in json format", async () => {
+    const invoice = {
+      id: "inv-1",
+      supplier_name: "Acme Corp",
+      invoice_number: "INV-001",
+      status: "paid",
+      total_amount: { value: "100.00", currency: "EUR" },
+      due_date: "2026-04-01",
+      issue_date: "2026-03-01",
+      payment_date: "2026-03-15",
+      file_name: "invoice.pdf",
+      is_einvoice: false,
+      created_at: "2026-03-01T00:00:00.000Z",
+      self: "https://example.com/inv-1",
+    };
+    fetchSpy.mockReturnValue(jsonResponse({ supplier_invoice: invoice }));
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["--output", "json", "supplier-invoice", "show", "inv-1"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as Record<string, unknown>;
+    expect(parsed).toHaveProperty("id", "inv-1");
+    expect(parsed).toHaveProperty("supplier_name", "Acme Corp");
+  });
+
+  it("handles null total_amount in table format", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoice: {
+          id: "inv-2",
+          supplier_name: "No Amount",
+          invoice_number: null,
+          status: "to_review",
+          total_amount: null,
+          due_date: null,
+          issue_date: null,
+          payment_date: null,
+          file_name: "doc.pdf",
+          is_einvoice: false,
+          created_at: "2026-03-01T00:00:00.000Z",
+          self: "https://example.com/inv-2",
+        },
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "show", "inv-2"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+  });
+
+  it("calls the correct API endpoint", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        supplier_invoice: {
+          id: "inv-1",
+          supplier_name: "Test",
+          invoice_number: null,
+          status: "to_review",
+          total_amount: null,
+          due_date: null,
+          issue_date: null,
+          payment_date: null,
+          file_name: "test.pdf",
+          is_einvoice: false,
+          created_at: "2026-03-01T00:00:00.000Z",
+          self: "https://example.com/inv-1",
+        },
+      }),
+    );
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["supplier-invoice", "show", "inv-1"], { from: "user" });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/supplier_invoices/inv-1");
+  });
+});

--- a/packages/cli/src/commands/supplier-invoice/show.ts
+++ b/packages/cli/src/commands/supplier-invoice/show.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { getSupplierInvoice } from "@qontoctl/core";
+import { createClient } from "../../client.js";
+import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import type { GlobalOptions } from "../../options.js";
+
+export function registerSupplierInvoiceShowCommand(parent: Command): void {
+  const show = parent.command("show <id>").description("Show supplier invoice details");
+  addInheritableOptions(show);
+  show.action(async (id: string, _opts: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions>(cmd);
+    const client = await createClient(opts);
+
+    const invoice = await getSupplierInvoice(client, id);
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? invoice
+        : [
+            {
+              id: invoice.id,
+              supplier_name: invoice.supplier_name,
+              invoice_number: invoice.invoice_number,
+              total_amount:
+                invoice.total_amount !== null ? `${invoice.total_amount.value} ${invoice.total_amount.currency}` : null,
+              status: invoice.status,
+              due_date: invoice.due_date,
+              issue_date: invoice.issue_date,
+              payment_date: invoice.payment_date,
+              file_name: invoice.file_name,
+              is_einvoice: invoice.is_einvoice,
+              created_at: invoice.created_at,
+            },
+          ];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -11,6 +11,7 @@ import { registerEInvoicingCommands } from "./commands/einvoicing.js";
 import { registerRecurringTransferCommands } from "./commands/recurring-transfer/index.js";
 import { registerOrgCommands } from "./commands/org.js";
 import { registerAccountCommands } from "./commands/account.js";
+import { registerSupplierInvoiceCommands } from "./commands/supplier-invoice/index.js";
 import { OUTPUT_FORMATS } from "./options.js";
 
 const require = createRequire(import.meta.url);
@@ -38,6 +39,7 @@ export function createProgram(): Command {
   registerRecurringTransferCommands(program);
   registerOrgCommands(program);
   registerAccountCommands(program);
+  registerSupplierInvoiceCommands(program);
 
   program.action(() => {
     program.outputHelp();

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -228,19 +228,41 @@ export class HttpClient {
     return this.requestVoid("DELETE", path, options);
   }
 
+  /**
+   * Sends a multipart form-data POST request and parses the response as JSON.
+   *
+   * Unlike `post()`, this does NOT set `Content-Type` — the runtime sets it
+   * automatically with the correct multipart boundary.
+   */
+  async postFormData<T>(path: string, formData: FormData, options?: { readonly idempotencyKey?: string }): Promise<T> {
+    const response = await this.fetchWithRetry("POST", path, {
+      formData,
+      ...options,
+    });
+    const responseBody: unknown = await response.json();
+    this.logDebug(`Response body: ${JSON.stringify(redactSensitiveFields(responseBody))}`);
+    return responseBody as T;
+  }
+
   private async fetchWithRetry(
     method: string,
     path: string,
     options?: {
       readonly body?: unknown;
+      readonly formData?: FormData;
       readonly params?: QueryParams;
       readonly idempotencyKey?: string;
       readonly accept?: string;
     },
   ): Promise<Response> {
     const url = this.buildUrl(path, options?.params);
-    const headers = this.buildHeaders(options?.body !== undefined, options?.accept);
-    const body = options?.body !== undefined ? JSON.stringify(options.body) : undefined;
+    const isFormData = options?.formData !== undefined;
+    const headers = this.buildHeaders(!isFormData && options?.body !== undefined, options?.accept);
+    const body: string | FormData | undefined = isFormData
+      ? options.formData
+      : options?.body !== undefined
+        ? JSON.stringify(options.body)
+        : undefined;
 
     if (WRITE_METHODS.has(method.toUpperCase())) {
       headers[IDEMPOTENCY_KEY_HEADER] = options?.idempotencyKey ?? randomUUID();
@@ -249,7 +271,7 @@ export class HttpClient {
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       this.logVerbose(`${method} ${url.toString()}${attempt > 0 ? ` (retry ${attempt})` : ""}`);
       if (body !== undefined) {
-        this.logDebug(`Request body: ${body}`);
+        this.logDebug(isFormData ? "Request body: [FormData]" : `Request body: ${body as string}`);
       }
 
       const startTime = performance.now();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,21 @@ export type { Transfer, ListTransfersParams } from "./transfers/index.js";
 
 export type { Transaction, TransactionLabel, ListTransactionsParams } from "./transactions/index.js";
 
+export {
+  buildSupplierInvoiceQueryParams,
+  getSupplierInvoice,
+  bulkCreateSupplierInvoices,
+} from "./supplier-invoices/index.js";
+
+export type {
+  SupplierInvoice,
+  SupplierInvoiceAmount,
+  ListSupplierInvoicesParams,
+  BulkCreateSupplierInvoiceEntry,
+  BulkCreateSupplierInvoiceError,
+  BulkCreateSupplierInvoicesResult,
+} from "./supplier-invoices/index.js";
+
 export type { BankAccount, Organization, PaginationMeta } from "./api-types.js";
 
 export { getBulkTransfer } from "./bulk-transfers/index.js";

--- a/packages/core/src/supplier-invoices/index.ts
+++ b/packages/core/src/supplier-invoices/index.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export { buildSupplierInvoiceQueryParams, getSupplierInvoice, bulkCreateSupplierInvoices } from "./service.js";
+
+export type {
+  SupplierInvoice,
+  SupplierInvoiceAmount,
+  ListSupplierInvoicesParams,
+  BulkCreateSupplierInvoiceEntry,
+  BulkCreateSupplierInvoiceError,
+  BulkCreateSupplierInvoicesResult,
+} from "./types.js";

--- a/packages/core/src/supplier-invoices/service.ts
+++ b/packages/core/src/supplier-invoices/service.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { HttpClient, QueryParams } from "../http-client.js";
+import type {
+  BulkCreateSupplierInvoiceEntry,
+  BulkCreateSupplierInvoicesResult,
+  ListSupplierInvoicesParams,
+  SupplierInvoice,
+} from "./types.js";
+
+/**
+ * Build query parameter record from typed list parameters.
+ *
+ * Filter parameters use the `filter[key]` convention expected by the Qonto API.
+ */
+export function buildSupplierInvoiceQueryParams(params: ListSupplierInvoicesParams): QueryParams {
+  const query: Record<string, string | readonly string[]> = {};
+
+  if (params.status !== undefined && params.status.length > 0) {
+    query["filter[status][]"] = params.status;
+  }
+  if (params.due_date !== undefined) {
+    query["filter[due_date]"] = params.due_date;
+  }
+  if (params.created_at_from !== undefined) {
+    query["filter[created_at_from]"] = params.created_at_from;
+  }
+  if (params.created_at_to !== undefined) {
+    query["filter[created_at_to]"] = params.created_at_to;
+  }
+  if (params.updated_at_from !== undefined) {
+    query["filter[updated_at_from]"] = params.updated_at_from;
+  }
+  if (params.updated_at_to !== undefined) {
+    query["filter[updated_at_to]"] = params.updated_at_to;
+  }
+  if (params.query !== undefined) {
+    query["query"] = params.query;
+  }
+  if (params.sort_by !== undefined) {
+    query["sort_by"] = params.sort_by;
+  }
+
+  return query;
+}
+
+/**
+ * Fetch a single supplier invoice by ID.
+ */
+export async function getSupplierInvoice(client: HttpClient, id: string): Promise<SupplierInvoice> {
+  const response = await client.get<{ supplier_invoice: SupplierInvoice }>(
+    `/v2/supplier_invoices/${encodeURIComponent(id)}`,
+  );
+  return response.supplier_invoice;
+}
+
+/**
+ * Bulk-create supplier invoices via multipart form upload.
+ *
+ * The API always returns HTTP 200. Check `result.errors` for per-invoice failures.
+ */
+export async function bulkCreateSupplierInvoices(
+  client: HttpClient,
+  entries: readonly BulkCreateSupplierInvoiceEntry[],
+): Promise<BulkCreateSupplierInvoicesResult> {
+  const formData = new FormData();
+
+  for (const entry of entries) {
+    formData.append("supplier_invoices[][file]", entry.file, entry.fileName);
+    formData.append("supplier_invoices[][idempotency_key]", entry.idempotencyKey);
+  }
+
+  return client.postFormData<BulkCreateSupplierInvoicesResult>("/v2/supplier_invoices/bulk", formData);
+}

--- a/packages/core/src/supplier-invoices/types.ts
+++ b/packages/core/src/supplier-invoices/types.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * A monetary amount with value and currency as returned by the Qonto API.
+ */
+export interface SupplierInvoiceAmount {
+  readonly value: string;
+  readonly currency: string;
+}
+
+/**
+ * A supplier invoice as returned by the Qonto API.
+ */
+export interface SupplierInvoice {
+  readonly id: string;
+  readonly organization_id: string;
+  readonly status: string;
+  readonly source_type: string;
+  readonly source: string;
+  readonly attachment_id: string;
+  readonly display_attachment_id: string;
+  readonly file_name: string;
+  readonly invoice_number: string | null;
+  readonly supplier_name: string | null;
+  readonly total_amount: SupplierInvoiceAmount | null;
+  readonly total_amount_excluding_taxes: SupplierInvoiceAmount | null;
+  readonly total_tax_amount: SupplierInvoiceAmount | null;
+  readonly payable_amount: SupplierInvoiceAmount | null;
+  readonly issue_date: string | null;
+  readonly due_date: string | null;
+  readonly payment_date: string | null;
+  readonly scheduled_date: string | null;
+  readonly iban: string | null;
+  readonly is_einvoice: boolean;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+/**
+ * Parameters for listing supplier invoices.
+ */
+export interface ListSupplierInvoicesParams {
+  readonly status?: readonly string[];
+  readonly due_date?: string;
+  readonly created_at_from?: string;
+  readonly created_at_to?: string;
+  readonly updated_at_from?: string;
+  readonly updated_at_to?: string;
+  readonly query?: string;
+  readonly sort_by?: string;
+}
+
+/**
+ * A single entry for the bulk create endpoint.
+ */
+export interface BulkCreateSupplierInvoiceEntry {
+  readonly file: Blob;
+  readonly fileName: string;
+  readonly idempotencyKey: string;
+}
+
+/**
+ * An error from the bulk create response.
+ */
+export interface BulkCreateSupplierInvoiceError {
+  readonly code: string;
+  readonly detail: string;
+  readonly source?: {
+    readonly pointer?: string;
+  };
+}
+
+/**
+ * Response from the bulk create endpoint. Always returns HTTP 200;
+ * check the `errors` array for per-invoice failures.
+ */
+export interface BulkCreateSupplierInvoicesResult {
+  readonly supplier_invoices: readonly SupplierInvoice[];
+  readonly errors: readonly BulkCreateSupplierInvoiceError[];
+}

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -40,6 +40,9 @@ const EXPECTED_TOOLS = [
   "quote_update",
   "quote_delete",
   "request_list",
+  "supplier_invoice_list",
+  "supplier_invoice_show",
+  "supplier_invoice_bulk_create",
 ] as const;
 
 describe("MCP server via stdio (e2e)", () => {
@@ -68,7 +71,7 @@ describe("MCP server via stdio (e2e)", () => {
   });
 
   describe("tools/list", () => {
-    it("lists all 28 expected tools", async () => {
+    it("lists all 31 expected tools", async () => {
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
 

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    timeout: 15_000,
+  });
+}
+
+describe.skipIf(!hasCredentials())("supplier-invoice commands (e2e)", () => {
+  describe("supplier-invoice list", () => {
+    it("lists supplier invoices", () => {
+      const output = cli("supplier-invoice", "list");
+      expect(output).toBeDefined();
+    });
+
+    it("produces valid JSON with --output json", () => {
+      const output = cli("--output", "json", "supplier-invoice", "list");
+      const parsed = JSON.parse(output) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const item of parsed) {
+        const invoice = item as Record<string, unknown>;
+        expect(invoice).toHaveProperty("id");
+        expect(invoice).toHaveProperty("status");
+      }
+    });
+
+    it("supports --status filter", () => {
+      const output = cli("--output", "json", "supplier-invoice", "list", "--status", "paid");
+      const parsed = JSON.parse(output) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+  });
+
+  describe("supplier-invoice show", () => {
+    it("shows supplier invoice details", () => {
+      const listOutput = cli("--output", "json", "supplier-invoice", "list");
+      const invoices = JSON.parse(listOutput) as { id: string }[];
+      if (invoices.length === 0) {
+        return; // No supplier invoices available
+      }
+
+      const firstInvoice = invoices[0];
+      expect(firstInvoice).toBeDefined();
+      const invoiceId = (firstInvoice as { id: string }).id;
+      const output = cli("--output", "json", "supplier-invoice", "show", invoiceId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", invoiceId);
+      expect(parsed).toHaveProperty("status");
+    });
+  });
+});

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials())("MCP supplier invoice tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("supplier_invoice_list", () => {
+    it("returns a list of supplier invoices with expected structure", async () => {
+      const result = await client.callTool({
+        name: "supplier_invoice_list",
+        arguments: {},
+      });
+
+      const parsed = JSON.parse(firstText(result)) as {
+        supplier_invoices: unknown[];
+        meta: Record<string, unknown>;
+      };
+      expect(parsed).toHaveProperty("supplier_invoices");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.supplier_invoices)).toBe(true);
+
+      for (const item of parsed.supplier_invoices) {
+        const invoice = item as Record<string, unknown>;
+        expect(invoice).toHaveProperty("id");
+        expect(invoice).toHaveProperty("status");
+      }
+    });
+  });
+
+  describe("supplier_invoice_show", () => {
+    it("returns details for a specific supplier invoice", async () => {
+      const listResult = await client.callTool({
+        name: "supplier_invoice_list",
+        arguments: {},
+      });
+      const listParsed = JSON.parse(firstText(listResult)) as {
+        supplier_invoices: { id: string }[];
+      };
+      if (listParsed.supplier_invoices.length === 0) {
+        return; // No supplier invoices available
+      }
+
+      const firstInvoice = listParsed.supplier_invoices[0];
+      expect(firstInvoice).toBeDefined();
+      const invoiceId = (firstInvoice as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "supplier_invoice_show",
+        arguments: { id: invoiceId },
+      });
+
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", invoiceId);
+      expect(parsed).toHaveProperty("status");
+    });
+  });
+});

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -27,7 +27,7 @@ describe("createServer", () => {
       vi.restoreAllMocks();
     });
 
-    it("registers all 28 expected tools", async () => {
+    it("registers all 31 expected tools", async () => {
       const { tools } = await mcpClient.listTools();
       const toolNames = tools.map((t) => t.name);
 
@@ -59,7 +59,10 @@ describe("createServer", () => {
       expect(toolNames).toContain("quote_update");
       expect(toolNames).toContain("quote_delete");
       expect(toolNames).toContain("request_list");
-      expect(tools).toHaveLength(28);
+      expect(toolNames).toContain("supplier_invoice_list");
+      expect(toolNames).toContain("supplier_invoice_show");
+      expect(toolNames).toContain("supplier_invoice_bulk_create");
+      expect(tools).toHaveLength(31);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,6 +17,7 @@ import {
   registerRecurringTransferTools,
   registerRequestTools,
   registerStatementTools,
+  registerSupplierInvoiceTools,
   registerTransactionTools,
   registerTransferTools,
 } from "./tools/index.js";
@@ -52,6 +53,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerRecurringTransferTools(server, getClient);
   registerRequestTools(server, getClient);
   registerStatementTools(server, getClient);
+  registerSupplierInvoiceTools(server, getClient);
   registerTransactionTools(server, getClient);
   registerTransferTools(server, getClient);
 

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -13,5 +13,6 @@ export { registerQuoteTools } from "./quote.js";
 export { registerRecurringTransferTools } from "./recurring-transfer.js";
 export { registerRequestTools } from "./request.js";
 export { registerStatementTools } from "./statement.js";
+export { registerSupplierInvoiceTools } from "./supplier-invoice.js";
 export { registerTransactionTools } from "./transactions.js";
 export { registerTransferTools } from "./transfer.js";

--- a/packages/mcp/src/tools/supplier-invoice.test.ts
+++ b/packages/mcp/src/tools/supplier-invoice.test.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { connectInMemory } from "../testing/mcp-helpers.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockResolvedValue(Buffer.from("fake-pdf-content")),
+}));
+
+describe("supplier-invoice MCP tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    ({ mcpClient } = await connectInMemory(fetchSpy));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("supplier_invoice_list", () => {
+    it("returns supplier invoices from API", async () => {
+      const supplier_invoices = [
+        {
+          id: "inv-1",
+          supplier_name: "Acme Corp",
+          invoice_number: "INV-001",
+          status: "paid",
+          total_amount: { value: "100.00", currency: "EUR" },
+          due_date: "2026-04-01",
+          issue_date: "2026-03-01",
+          payment_date: "2026-03-15",
+          file_name: "invoice.pdf",
+          is_einvoice: false,
+          created_at: "2026-03-01T00:00:00.000Z",
+          self: "https://thirdparty.qonto.com/v2/supplier_invoices/inv-1",
+        },
+      ];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoices,
+          meta: {
+            current_page: 1,
+            next_page: null,
+            prev_page: null,
+            total_pages: 1,
+            total_count: 1,
+            per_page: 100,
+          },
+        }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "supplier_invoice_list",
+        arguments: {},
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as { supplier_invoices: unknown[] };
+      expect(parsed.supplier_invoices).toHaveLength(1);
+    });
+
+    it("passes filter and pagination params to API", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoices: [],
+          meta: {
+            current_page: 2,
+            next_page: null,
+            prev_page: 1,
+            total_pages: 2,
+            total_count: 0,
+            per_page: 10,
+          },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "supplier_invoice_list",
+        arguments: { status: "paid", current_page: 2, per_page: 10 },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("filter[status][]")).toBe("paid");
+      expect(url.searchParams.get("current_page")).toBe("2");
+      expect(url.searchParams.get("per_page")).toBe("10");
+    });
+
+    it("passes optional query and sort params", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoices: [],
+          meta: {
+            current_page: 1,
+            next_page: null,
+            prev_page: null,
+            total_pages: 1,
+            total_count: 0,
+            per_page: 100,
+          },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "supplier_invoice_list",
+        arguments: { query: "acme", sort_by: "created_at:desc", due_date: "future" },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("query")).toBe("acme");
+      expect(url.searchParams.get("sort_by")).toBe("created_at:desc");
+      expect(url.searchParams.get("filter[due_date]")).toBe("future");
+    });
+  });
+
+  describe("supplier_invoice_show", () => {
+    it("returns a single supplier invoice", async () => {
+      const supplier_invoice = {
+        id: "inv-1",
+        supplier_name: "Acme Corp",
+        invoice_number: "INV-001",
+        status: "paid",
+        total_amount: { value: "100.00", currency: "EUR" },
+        due_date: "2026-04-01",
+        issue_date: "2026-03-01",
+        payment_date: "2026-03-15",
+        file_name: "invoice.pdf",
+        is_einvoice: false,
+        created_at: "2026-03-01T00:00:00.000Z",
+        self: "https://thirdparty.qonto.com/v2/supplier_invoices/inv-1",
+      };
+      fetchSpy.mockReturnValue(jsonResponse({ supplier_invoice }));
+
+      const result = await mcpClient.callTool({
+        name: "supplier_invoice_show",
+        arguments: { id: "inv-1" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as { id: string; supplier_name: string };
+      expect(parsed.id).toBe("inv-1");
+      expect(parsed.supplier_name).toBe("Acme Corp");
+    });
+
+    it("calls the correct API endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoice: {
+            id: "inv-1",
+            supplier_name: "Test",
+            invoice_number: null,
+            status: "to_review",
+            total_amount: null,
+            due_date: null,
+            issue_date: null,
+            payment_date: null,
+            file_name: "test.pdf",
+            is_einvoice: false,
+            created_at: "2026-03-01T00:00:00.000Z",
+            self: "https://thirdparty.qonto.com/v2/supplier_invoices/inv-1",
+          },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "supplier_invoice_show",
+        arguments: { id: "inv-1" },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/supplier_invoices/inv-1");
+    });
+  });
+
+  describe("supplier_invoice_bulk_create", () => {
+    it("reads files and sends FormData to API", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoices: [
+            {
+              id: "new-inv-1",
+              supplier_name: null,
+              invoice_number: null,
+              status: "to_review",
+              total_amount: null,
+              due_date: null,
+              issue_date: null,
+              payment_date: null,
+              file_name: "invoice.pdf",
+              is_einvoice: false,
+              created_at: "2026-03-01T00:00:00.000Z",
+              self: "https://thirdparty.qonto.com/v2/supplier_invoices/new-inv-1",
+            },
+          ],
+          errors: [],
+        }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "supplier_invoice_bulk_create",
+        arguments: { file_paths: ["/tmp/invoice.pdf"] },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as { supplier_invoices: unknown[]; errors: unknown[] };
+      expect(parsed.supplier_invoices).toHaveLength(1);
+      expect(parsed.errors).toHaveLength(0);
+    });
+
+    it("sends request to bulk endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          supplier_invoices: [],
+          errors: [],
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "supplier_invoice_bulk_create",
+        arguments: { file_paths: ["/tmp/invoice.pdf"] },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/supplier_invoices/bulk");
+    });
+  });
+});

--- a/packages/mcp/src/tools/supplier-invoice.ts
+++ b/packages/mcp/src/tools/supplier-invoice.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type HttpClient,
+  type PaginationMeta,
+  type SupplierInvoice,
+  bulkCreateSupplierInvoices,
+  type BulkCreateSupplierInvoiceEntry,
+} from "@qontoctl/core";
+import { withClient } from "../errors.js";
+
+interface PaginatedSupplierInvoicesResponse {
+  readonly supplier_invoices: readonly SupplierInvoice[];
+  readonly meta: PaginationMeta;
+}
+
+interface SingleSupplierInvoiceResponse {
+  readonly supplier_invoice: SupplierInvoice;
+}
+
+export function registerSupplierInvoiceTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
+  server.registerTool(
+    "supplier_invoice_list",
+    {
+      description: "List supplier invoices with optional filters",
+      inputSchema: {
+        status: z
+          .enum([
+            "to_review",
+            "to_approve",
+            "awaiting_payment",
+            "pending",
+            "scheduled",
+            "paid",
+            "archived",
+            "rejected",
+            "discarded",
+          ])
+          .optional()
+          .describe("Filter by status"),
+        due_date: z
+          .enum(["past_and_today", "future", "missing_date"])
+          .optional()
+          .describe("Filter by due date category"),
+        query: z.string().optional().describe("Full-text search query"),
+        sort_by: z.string().optional().describe("Sort order (e.g. created_at:desc)"),
+        current_page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      },
+    },
+    async (args) =>
+      withClient(getClient, async (client) => {
+        const params: Record<string, string> = {};
+
+        if (args.status !== undefined) params["filter[status][]"] = args.status;
+        if (args.due_date !== undefined) params["filter[due_date]"] = args.due_date;
+        if (args.query !== undefined) params["query"] = args.query;
+        if (args.sort_by !== undefined) params["sort_by"] = args.sort_by;
+        if (args.current_page !== undefined) params["current_page"] = String(args.current_page);
+        if (args.per_page !== undefined) params["per_page"] = String(args.per_page);
+
+        const response = await client.get<PaginatedSupplierInvoicesResponse>(
+          "/v2/supplier_invoices",
+          Object.keys(params).length > 0 ? params : undefined,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ supplier_invoices: response.supplier_invoices, meta: response.meta }, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "supplier_invoice_show",
+    {
+      description: "Show details of a specific supplier invoice",
+      inputSchema: {
+        id: z.string().describe("Supplier invoice ID (UUID)"),
+      },
+    },
+    async ({ id }) =>
+      withClient(getClient, async (client) => {
+        const response = await client.get<SingleSupplierInvoiceResponse>(
+          `/v2/supplier_invoices/${encodeURIComponent(id)}`,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(response.supplier_invoice, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "supplier_invoice_bulk_create",
+    {
+      description: "Create supplier invoices by uploading files from the filesystem",
+      inputSchema: {
+        file_paths: z.array(z.string()).min(1).describe("Absolute paths to invoice files (PDF, PNG, JPG)"),
+      },
+    },
+    async ({ file_paths }) =>
+      withClient(getClient, async (client) => {
+        const entries: BulkCreateSupplierInvoiceEntry[] = [];
+        for (const filePath of file_paths) {
+          const buffer = await readFile(filePath);
+          entries.push({
+            file: new Blob([buffer]),
+            fileName: basename(filePath),
+            idempotencyKey: randomUUID(),
+          });
+        }
+
+        const result = await bulkCreateSupplierInvoices(client, entries);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  supplier_invoices: result.supplier_invoices,
+                  errors: result.errors,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }),
+  );
+}


### PR DESCRIPTION
## Summary

- Add CLI commands (`supplier-invoice list`, `show`, `bulk-create`) and MCP tools (`supplier_invoice_list`, `supplier_invoice_show`, `supplier_invoice_bulk_create`) for the Qonto supplier invoices API
- Add `postFormData` method to `HttpClient` for multipart form-data uploads (used by bulk-create)
- Add E2E tests covering CLI and MCP supplier invoice operations

Closes #183

## Test plan

- [x] Unit tests pass (380 tests across all packages)
- [x] E2E tests pass (86 passed, 5 skipped)
- [x] Lint clean
- [x] License check clean
- [x] Prettier formatting clean
- [ ] CI passes on all 3 OS matrix (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)