### PR TITLE
(chore) bump registry config versions to 0.2.0

### DIFF
--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/qontoctl",
     "source": "github"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "qontoctl",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -16,7 +16,7 @@ startCommand:
   commandFunction: |-
     (config) => ({
       command: 'npx',
-      args: ['-y', 'qontoctl@0.1.0', 'mcp'],
+      args: ['-y', 'qontoctl@0.2.0', 'mcp'],
       env: {
         QONTOCTL_ORGANIZATION_SLUG: config.organizationSlug,
         QONTOCTL_SECRET_KEY: config.secretKey


### PR DESCRIPTION
## Summary
- Update `server.json` version to 0.2.0 (already published to official MCP registry)
- Update `smithery.yaml` to reference `qontoctl@0.2.0`

## Context
These files were left at 0.1.0 after the 0.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)