### PR TITLE
(feat) add quote send command (#190)

### DIFF
--- a/packages/cli/src/commands/quote.ts
+++ b/packages/cli/src/commands/quote.ts
@@ -173,5 +173,21 @@ export function createQuoteCommand(): Command {
     }
   });
 
+  // --- send ---
+  const send = quote.command("send <id>").description("Send quote to client via email");
+  addInheritableOptions(send);
+  send.action(async (id: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions>(cmd);
+    const client = await createClient(opts);
+
+    await client.requestVoid("POST", `/v2/quotes/${encodeURIComponent(id)}/send`);
+
+    if (opts.output === "json" || opts.output === "yaml") {
+      process.stdout.write(formatOutput({ sent: true, id }, opts.output) + "\n");
+    } else {
+      process.stdout.write(`Quote ${id} sent.\n`);
+    }
+  });
+
   return quote;
 }

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -59,11 +59,12 @@ describe("createServer", () => {
       expect(toolNames).toContain("quote_create");
       expect(toolNames).toContain("quote_update");
       expect(toolNames).toContain("quote_delete");
+      expect(toolNames).toContain("quote_send");
       expect(toolNames).toContain("request_list");
       expect(toolNames).toContain("supplier_invoice_list");
       expect(toolNames).toContain("supplier_invoice_show");
       expect(toolNames).toContain("supplier_invoice_bulk_create");
-      expect(tools).toHaveLength(32);
+      expect(tools).toHaveLength(33);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/tools/quote.test.ts
+++ b/packages/mcp/src/tools/quote.test.ts
@@ -311,4 +311,35 @@ describe("quote MCP tools", () => {
       expect(opts.method).toBe("DELETE");
     });
   });
+
+  describe("quote_send", () => {
+    it("sends a quote and returns confirmation", async () => {
+      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+
+      const result = await mcpClient.callTool({
+        name: "quote_send",
+        arguments: { id: "q-123" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as { sent: boolean; id: string };
+      expect(parsed.sent).toBe(true);
+      expect(parsed.id).toBe("q-123");
+    });
+
+    it("sends POST to the correct endpoint", async () => {
+      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+
+      await mcpClient.callTool({
+        name: "quote_send",
+        arguments: { id: "q-123" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/quotes/q-123/send");
+      expect(opts.method).toBe("POST");
+    });
+  });
 });

--- a/packages/mcp/src/tools/quote.ts
+++ b/packages/mcp/src/tools/quote.ts
@@ -228,4 +228,27 @@ export function registerQuoteTools(server: McpServer, getClient: () => Promise<H
         };
       }),
   );
+
+  server.registerTool(
+    "quote_send",
+    {
+      description: "Send a quote to the client via email",
+      inputSchema: {
+        id: z.string().describe("Quote ID (UUID)"),
+      },
+    },
+    async ({ id }) =>
+      withClient(getClient, async (client) => {
+        await client.requestVoid("POST", `/v2/quotes/${encodeURIComponent(id)}/send`);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ sent: true, id }, null, 2),
+            },
+          ],
+        };
+      }),
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `quote send <id>` CLI command that sends a quote to the client via email via `POST /v2/quotes/{id}/send`
- Adds `quote_send` MCP tool with equivalent functionality
- Adds unit tests for the MCP tool (endpoint verification and response confirmation)

Closes #190

## Test plan

- [x] Unit tests pass (MCP tool: correct endpoint, correct method, confirmation response)
- [x] Server tool count updated (32 → 33)
- [x] Build, lint, and full test suite pass
- [ ] E2E: requires OAuth credentials (endpoint is OAuth-only); not covered by API key E2E suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)