### PR TITLE
(feat) add account management commands (create, update, close) (#171)

### DIFF
--- a/packages/cli/src/commands/account.test.ts
+++ b/packages/cli/src/commands/account.test.ts
@@ -21,15 +21,28 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
     ...actual,
     getBankAccount: vi.fn(),
     getIbanCertificate: vi.fn(),
+    createBankAccount: vi.fn(),
+    updateBankAccount: vi.fn(),
+    closeBankAccount: vi.fn(),
   };
 });
+
+vi.mock("../sca.js", () => ({
+  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
+    operation(undefined),
+  ),
+}));
 
 const { createClient } = await import("../client.js");
 const createClientMock = vi.mocked(createClient);
 
-const { getBankAccount, getIbanCertificate } = await import("@qontoctl/core");
+const { getBankAccount, getIbanCertificate, createBankAccount, updateBankAccount, closeBankAccount } =
+  await import("@qontoctl/core");
 const getBankAccountMock = vi.mocked(getBankAccount);
 const getIbanCertificateMock = vi.mocked(getIbanCertificate);
+const createBankAccountMock = vi.mocked(createBankAccount);
+const updateBankAccountMock = vi.mocked(updateBankAccount);
+const closeBankAccountMock = vi.mocked(closeBankAccount);
 
 const { writeFile } = await import("node:fs/promises");
 const writeFileMock = vi.mocked(writeFile);
@@ -68,11 +81,13 @@ function makeAccount(overrides: Record<string, unknown> = {}) {
 describe("registerAccountCommands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
     stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -290,6 +305,138 @@ describe("registerAccountCommands", () => {
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("Downloaded: my-cert.pdf");
+    });
+  });
+
+  describe("account create", () => {
+    it("creates a bank account in table format", async () => {
+      const account = makeAccount({ name: "New Account" });
+      createBankAccountMock.mockResolvedValue(account);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "create", "--name", "New Account"], { from: "user" });
+
+      expect(createBankAccountMock).toHaveBeenCalledWith(expect.anything(), { name: "New Account" }, expect.anything());
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("acc-1");
+      expect(output).toContain("New Account");
+    });
+
+    it("creates a bank account in json format", async () => {
+      const account = makeAccount({ name: "New Account" });
+      createBankAccountMock.mockResolvedValue(account);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "json");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "create", "--name", "New Account"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as typeof account;
+      expect(parsed.id).toBe("acc-1");
+      expect(parsed.name).toBe("New Account");
+    });
+  });
+
+  describe("account update", () => {
+    it("updates a bank account in table format", async () => {
+      const account = makeAccount({ name: "Updated Name" });
+      updateBankAccountMock.mockResolvedValue(account);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "update", "acc-1", "--name", "Updated Name"], { from: "user" });
+
+      expect(updateBankAccountMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "acc-1",
+        { name: "Updated Name" },
+        expect.anything(),
+      );
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("acc-1");
+      expect(output).toContain("Updated Name");
+    });
+
+    it("updates a bank account in json format", async () => {
+      const account = makeAccount({ name: "Updated Name" });
+      updateBankAccountMock.mockResolvedValue(account);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "json");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "update", "acc-1", "--name", "Updated Name"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as typeof account;
+      expect(parsed.id).toBe("acc-1");
+      expect(parsed.name).toBe("Updated Name");
+    });
+  });
+
+  describe("account close", () => {
+    it("closes a bank account with --yes flag", async () => {
+      closeBankAccountMock.mockResolvedValue(undefined);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "close", "acc-1", "--yes"], { from: "user" });
+
+      expect(closeBankAccountMock).toHaveBeenCalledWith(expect.anything(), "acc-1", expect.anything());
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Account acc-1 closed.");
+    });
+
+    it("closes a bank account in json format", async () => {
+      closeBankAccountMock.mockResolvedValue(undefined);
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "json");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "close", "acc-1", "--yes"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as { closed: boolean; id: string };
+      expect(parsed.closed).toBe(true);
+      expect(parsed.id).toBe("acc-1");
+    });
+
+    it("exits with error when --yes is not provided", async () => {
+      createClientMock.mockResolvedValue({} as never);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAccountCommands(program);
+
+      await program.parseAsync(["account", "close", "acc-1"], { from: "user" });
+
+      expect(stderrSpy).toHaveBeenCalled();
+      const errorOutput = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(errorOutput).toContain("About to close account acc-1");
+      expect(errorOutput).toContain("--yes");
+      expect(process.exitCode).toBe(1);
     });
   });
 });

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -3,13 +3,20 @@
 
 import { writeFile } from "node:fs/promises";
 import { Command, Option } from "commander";
-import { getBankAccount, getIbanCertificate } from "@qontoctl/core";
+import {
+  createBankAccount,
+  getBankAccount,
+  getIbanCertificate,
+  updateBankAccount,
+  closeBankAccount,
+} from "@qontoctl/core";
 import type { BankAccount } from "@qontoctl/core";
 import { createClient } from "../client.js";
 import { formatOutput } from "../formatters/index.js";
-import { addInheritableOptions, resolveGlobalOptions } from "../inherited-options.js";
+import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import { fetchPaginated } from "../pagination.js";
-import type { GlobalOptions, PaginationOptions } from "../options.js";
+import type { GlobalOptions, PaginationOptions, WriteOptions } from "../options.js";
+import { executeWithCliSca } from "../sca.js";
 
 /**
  * Pick the fields shown in table/csv list output.
@@ -88,5 +95,128 @@ export function registerAccountCommands(program: Command): void {
 
     await writeFile(outputFile, buffer);
     process.stdout.write(`Downloaded: ${outputFile}\n`);
+  });
+
+  // --- create ---
+  const create = account
+    .command("create")
+    .description("Create a new bank account")
+    .addOption(new Option("--name <name>", "account name").makeOptionMandatory());
+  addInheritableOptions(create);
+  addWriteOptions(create);
+  create.action(async (_options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { name: string }>(cmd);
+    const client = await createClient(opts);
+
+    const bankAccount = await executeWithCliSca(
+      client,
+      (scaSessionToken) =>
+        createBankAccount(
+          client,
+          { name: opts.name },
+          {
+            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { verbose: opts.verbose === true || opts.debug === true },
+    );
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? bankAccount
+        : [
+            {
+              id: bankAccount.id,
+              name: bankAccount.name,
+              iban: bankAccount.iban,
+              bic: bankAccount.bic,
+              balance: bankAccount.balance,
+              currency: bankAccount.currency,
+              status: bankAccount.status,
+            },
+          ];
+
+    const output = formatOutput(data, opts.output);
+    process.stdout.write(output + "\n");
+  });
+
+  // --- update ---
+  const update = account
+    .command("update")
+    .description("Update a bank account")
+    .argument("<id>", "Bank account ID")
+    .option("--name <name>", "new account name");
+  addInheritableOptions(update);
+  addWriteOptions(update);
+  update.action(async (id: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { name?: string | undefined }>(cmd);
+    const client = await createClient(opts);
+
+    const params: Record<string, string> = {};
+    if (opts.name !== undefined) params["name"] = opts.name;
+
+    const bankAccount = await executeWithCliSca(
+      client,
+      (scaSessionToken) =>
+        updateBankAccount(client, id, params, {
+          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+        }),
+      { verbose: opts.verbose === true || opts.debug === true },
+    );
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? bankAccount
+        : [
+            {
+              id: bankAccount.id,
+              name: bankAccount.name,
+              iban: bankAccount.iban,
+              bic: bankAccount.bic,
+              balance: bankAccount.balance,
+              currency: bankAccount.currency,
+              status: bankAccount.status,
+            },
+          ];
+
+    const output = formatOutput(data, opts.output);
+    process.stdout.write(output + "\n");
+  });
+
+  // --- close ---
+  const close = account
+    .command("close")
+    .description("Close a bank account")
+    .argument("<id>", "Bank account ID")
+    .addOption(new Option("--yes", "skip confirmation prompt"));
+  addInheritableOptions(close);
+  addWriteOptions(close);
+  close.action(async (id: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { yes?: true | undefined }>(cmd);
+    const client = await createClient(opts);
+
+    if (opts.yes !== true) {
+      process.stderr.write(`About to close account ${id}. Use --yes to confirm.\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    await executeWithCliSca(
+      client,
+      (scaSessionToken) =>
+        closeBankAccount(client, id, {
+          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+        }),
+      { verbose: opts.verbose === true || opts.debug === true },
+    );
+
+    if (opts.output === "json" || opts.output === "yaml") {
+      process.stdout.write(formatOutput({ closed: true, id }, opts.output) + "\n");
+    } else {
+      process.stdout.write(`Account ${id} closed.\n`);
+    }
   });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,7 +132,16 @@ export {
 
 export type { Attachment } from "./attachments/index.js";
 
-export { getBankAccount, getIbanCertificate, resolveDefaultBankAccount } from "./services/bank-accounts.js";
+export {
+  createBankAccount,
+  getBankAccount,
+  getIbanCertificate,
+  updateBankAccount,
+  closeBankAccount,
+  resolveDefaultBankAccount,
+} from "./services/bank-accounts.js";
+
+export type { CreateBankAccountParams, UpdateBankAccountParams } from "./services/bank-accounts.js";
 export { getEInvoicingSettings } from "./services/einvoicing.js";
 export { getOrganization } from "./services/organization.js";
 

--- a/packages/core/src/services/bank-accounts.ts
+++ b/packages/core/src/services/bank-accounts.ts
@@ -8,6 +8,14 @@ interface BankAccountResponse {
   readonly bank_account: BankAccount;
 }
 
+export interface CreateBankAccountParams {
+  readonly name: string;
+}
+
+export interface UpdateBankAccountParams {
+  readonly name?: string | undefined;
+}
+
 /**
  * Fetch a single bank account by ID.
  *
@@ -29,6 +37,60 @@ export async function getBankAccount(client: HttpClient, id: string): Promise<Ba
  */
 export async function getIbanCertificate(client: HttpClient, id: string): Promise<Buffer> {
   return client.getBuffer(`/v2/bank_accounts/${encodeURIComponent(id)}/iban_certificate`);
+}
+
+/**
+ * Create a new business bank account.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param params - The bank account creation parameters.
+ * @param options - Optional idempotency key and SCA session token.
+ * @returns The created bank account details.
+ */
+export async function createBankAccount(
+  client: HttpClient,
+  params: CreateBankAccountParams,
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
+): Promise<BankAccount> {
+  const response = await client.post<BankAccountResponse>("/v2/bank_accounts", { bank_account: params }, options);
+  return response.bank_account;
+}
+
+/**
+ * Update an existing business bank account.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param id - The bank account UUID.
+ * @param params - The fields to update.
+ * @param options - Optional idempotency key and SCA session token.
+ * @returns The updated bank account details.
+ */
+export async function updateBankAccount(
+  client: HttpClient,
+  id: string,
+  params: UpdateBankAccountParams,
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
+): Promise<BankAccount> {
+  const response = await client.request<BankAccountResponse>("PUT", `/v2/bank_accounts/${encodeURIComponent(id)}`, {
+    body: { bank_account: params },
+    ...options,
+  });
+  return response.bank_account;
+}
+
+/**
+ * Close a business bank account.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param id - The bank account UUID.
+ * @param options - Optional idempotency key and SCA session token.
+ */
+export async function closeBankAccount(
+  client: HttpClient,
+  id: string,
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
+): Promise<void> {
+  await client.requestVoid("POST", `/v2/bank_accounts/${encodeURIComponent(id)}/close`, options);
 }
 
 /**

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -74,7 +74,10 @@ describe("createServer", () => {
       expect(toolNames).toContain("transaction_attachment_list");
       expect(toolNames).toContain("transaction_attachment_add");
       expect(toolNames).toContain("transaction_attachment_remove");
-      expect(tools).toHaveLength(43);
+      expect(toolNames).toContain("account_create");
+      expect(toolNames).toContain("account_update");
+      expect(toolNames).toContain("account_close");
+      expect(tools).toHaveLength(46);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/tools/accounts.test.ts
+++ b/packages/mcp/src/tools/accounts.test.ts
@@ -119,4 +119,123 @@ describe("account MCP tools", () => {
       expect(url.pathname).toBe("/v2/bank_accounts/acc-1/iban_certificate");
     });
   });
+
+  describe("account_create", () => {
+    it("creates an account and returns the result", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          bank_account: { id: "acc-new", name: "New Account", status: "active" },
+        }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "account_create",
+        arguments: { name: "New Account" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as {
+        id: string;
+        name: string;
+      };
+      expect(parsed.id).toBe("acc-new");
+      expect(parsed.name).toBe("New Account");
+    });
+
+    it("sends POST with wrapped body to the correct endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          bank_account: { id: "acc-new", name: "New Account" },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "account_create",
+        arguments: { name: "New Account" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/bank_accounts");
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body as string) as { bank_account: { name: string } };
+      expect(body.bank_account.name).toBe("New Account");
+    });
+  });
+
+  describe("account_update", () => {
+    it("updates an account and returns the result", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          bank_account: { id: "acc-1", name: "Updated Name", status: "active" },
+        }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "account_update",
+        arguments: { id: "acc-1", name: "Updated Name" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as {
+        id: string;
+        name: string;
+      };
+      expect(parsed.id).toBe("acc-1");
+      expect(parsed.name).toBe("Updated Name");
+    });
+
+    it("sends PUT with wrapped body to the correct endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          bank_account: { id: "acc-1", name: "Updated Name" },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "account_update",
+        arguments: { id: "acc-1", name: "Updated Name" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/bank_accounts/acc-1");
+      expect(opts.method).toBe("PUT");
+      const body = JSON.parse(opts.body as string) as { bank_account: { name: string } };
+      expect(body.bank_account.name).toBe("Updated Name");
+    });
+  });
+
+  describe("account_close", () => {
+    it("closes an account and returns confirmation", async () => {
+      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+
+      const result = await mcpClient.callTool({
+        name: "account_close",
+        arguments: { id: "acc-1" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as {
+        closed: boolean;
+        id: string;
+      };
+      expect(parsed.closed).toBe(true);
+      expect(parsed.id).toBe("acc-1");
+    });
+
+    it("sends POST to the correct close endpoint", async () => {
+      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+
+      await mcpClient.callTool({
+        name: "account_close",
+        arguments: { id: "acc-1" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/bank_accounts/acc-1/close");
+      expect(opts.method).toBe("POST");
+    });
+  });
 });

--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -6,6 +6,10 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type HttpClient, getIbanCertificate } from "@qontoctl/core";
 import { withClient } from "../errors.js";
 
+interface BankAccountResponse {
+  readonly bank_account: unknown;
+}
+
 export function registerAccountTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool("account_list", { description: "List all bank accounts for the organization" }, async () =>
     withClient(getClient, async (client) => {
@@ -55,6 +59,71 @@ export function registerAccountTools(server: McpServer, getClient: () => Promise
               },
             },
           ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "account_create",
+    {
+      description: "Create a new bank account",
+      inputSchema: {
+        name: z.string().describe("Account name"),
+      },
+    },
+    async ({ name }) =>
+      withClient(getClient, async (client) => {
+        const response = await client.post<BankAccountResponse>("/v2/bank_accounts", {
+          bank_account: { name },
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(response.bank_account, null, 2) }],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "account_update",
+    {
+      description: "Update an existing bank account",
+      inputSchema: {
+        id: z.string().describe("Bank account UUID"),
+        name: z.string().optional().describe("New account name"),
+      },
+    },
+    async ({ id, ...fields }) =>
+      withClient(getClient, async (client) => {
+        const body: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(fields)) {
+          if (value !== undefined) {
+            body[key] = value;
+          }
+        }
+
+        const response = await client.request<BankAccountResponse>(
+          "PUT",
+          `/v2/bank_accounts/${encodeURIComponent(id)}`,
+          { body: { bank_account: body } },
+        );
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(response.bank_account, null, 2) }],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "account_close",
+    {
+      description: "Close a bank account",
+      inputSchema: {
+        id: z.string().describe("Bank account UUID"),
+      },
+    },
+    async ({ id }) =>
+      withClient(getClient, async (client) => {
+        await client.requestVoid("POST", `/v2/bank_accounts/${encodeURIComponent(id)}/close`);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ closed: true, id }, null, 2) }],
         };
       }),
   );


### PR DESCRIPTION
## Summary

- Add `account create`, `account update`, and `account close` CLI commands with SCA handling and idempotency key support
- Add `account_create`, `account_update`, and `account_close` MCP tools
- Add core service functions (`createBankAccount`, `updateBankAccount`, `closeBankAccount`) in `@qontoctl/core`

## Details

- **Create/Update** wrap request body in `{ bank_account: params }` per Qonto API convention
- **Update** uses `PUT` method (not PATCH) via `client.request("PUT", ...)`
- **Close** uses `POST /v2/bank_accounts/{id}/close` with `--yes` confirmation prompt (matches `client delete` pattern)
- All write operations support `--idempotency-key` option and SCA flow via `executeWithCliSca`
- MCP tools delegate SCA handling to the existing `withClient` error handler

## Test plan

- [x] Unit tests for CLI commands (create table/json, update table/json, close with/without --yes)
- [x] Unit tests for MCP tools (create, update, close with endpoint verification)
- [x] Server tool count updated (43 → 46)
- [x] Build passes across all packages
- [x] Lint passes across all packages
- [x] All existing tests continue to pass

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)