### PR TITLE
(feat) add team commands (list, create)

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -16,3 +16,4 @@ export { registerOrgCommands } from "./org.js";
 export { registerAccountCommands } from "./account.js";
 export { registerTransferCommands } from "./transfer/index.js";
 export { registerSupplierInvoiceCommands } from "./supplier-invoice/index.js";
+export { createTeamCommand } from "./team.js";

--- a/packages/cli/src/commands/team.test.ts
+++ b/packages/cli/src/commands/team.test.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+import type { PaginationMeta } from "../pagination.js";
+
+function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+vi.mock("../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "../client.js";
+import { HttpClient } from "@qontoctl/core";
+
+describe("team commands", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("team list", () => {
+    it("lists teams in table format", async () => {
+      const teams = [
+        { id: "team-1", name: "Engineering" },
+        { id: "team-2", name: "Marketing" },
+      ];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams,
+          meta: makeMeta({ total_count: 2 }),
+        }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["team", "list"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("team-1");
+      expect(output).toContain("Engineering");
+      expect(output).toContain("team-2");
+      expect(output).toContain("Marketing");
+    });
+
+    it("lists teams in json format with full API fields", async () => {
+      const teams = [{ id: "team-1", name: "Engineering" }];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams,
+          meta: makeMeta({ total_count: 1 }),
+        }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["--output", "json", "team", "list"], {
+        from: "user",
+      });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as unknown[];
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toEqual({
+        id: "team-1",
+        name: "Engineering",
+      });
+    });
+
+    it("passes pagination options to API", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams: [],
+          meta: makeMeta(),
+        }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["--page", "3", "--per-page", "25", "team", "list"], { from: "user" });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("current_page")).toBe("3");
+      expect(url.searchParams.get("per_page")).toBe("25");
+    });
+
+    it("calls the correct API endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams: [],
+          meta: makeMeta(),
+        }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["team", "list"], { from: "user" });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/teams");
+    });
+  });
+
+  describe("team create", () => {
+    const createdTeam = {
+      id: "team-new",
+      name: "Design",
+    };
+
+    it("creates a team in json format", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["--output", "json", "team", "create", "--name", "Design"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", "team-new");
+      expect(parsed).toHaveProperty("name", "Design");
+    });
+
+    it("creates a team in table format", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["team", "create", "--name", "Design"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("team-new");
+      expect(output).toContain("Design");
+    });
+
+    it("sends POST with name body to the correct endpoint", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["team", "create", "--name", "Design"], { from: "user" });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/teams");
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({ name: "Design" });
+    });
+
+    it("passes idempotency key when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["team", "create", "--name", "Design", "--idempotency-key", "key-abc-123"], {
+        from: "user",
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["X-Qonto-Idempotency-Key"]).toBe("key-abc-123");
+    });
+  });
+});

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command } from "commander";
+import type { Team } from "@qontoctl/core";
+import { createClient } from "../client.js";
+import { fetchPaginated } from "../pagination.js";
+import { formatOutput } from "../formatters/index.js";
+import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
+import type { GlobalOptions, PaginationOptions, WriteOptions } from "../options.js";
+
+export function createTeamCommand(): Command {
+  const team = new Command("team").description("Manage teams");
+
+  const list = team.command("list").description("List all teams");
+  addInheritableOptions(list);
+  list.action(async (_options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & PaginationOptions>(cmd);
+    const client = await createClient(opts);
+
+    const result = await fetchPaginated<Team>(client, "/v2/teams", "teams", opts);
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? result.items
+        : result.items.map((t) => ({
+            id: t.id,
+            name: t.name,
+          }));
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  // --- create ---
+  const create = team
+    .command("create")
+    .description("Create a new team")
+    .requiredOption("--name <name>", "name for the new team");
+  addInheritableOptions(create);
+  addWriteOptions(create);
+  create.action(async (_options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<
+      GlobalOptions &
+        WriteOptions & {
+          readonly name: string;
+        }
+    >(cmd);
+    const client = await createClient(opts);
+
+    const response = await client.post<{ team: Team }>(
+      "/v2/teams",
+      { name: opts.name },
+      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    );
+    const t = response.team;
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? t
+        : [
+            {
+              id: t.id,
+              name: t.name,
+            },
+          ];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  return team;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -12,6 +12,7 @@ import { registerRecurringTransferCommands } from "./commands/recurring-transfer
 import { registerOrgCommands } from "./commands/org.js";
 import { registerAccountCommands } from "./commands/account.js";
 import { registerSupplierInvoiceCommands } from "./commands/supplier-invoice/index.js";
+import { createTeamCommand } from "./commands/team.js";
 import { registerAuthCommands } from "./commands/auth.js";
 import { OUTPUT_FORMATS } from "./options.js";
 
@@ -42,6 +43,7 @@ export function createProgram(): Command {
   registerOrgCommands(program);
   registerAccountCommands(program);
   registerSupplierInvoiceCommands(program);
+  program.addCommand(createTeamCommand());
 
   program.action(() => {
     program.outputHelp();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,7 @@ export type {
   RequestVirtualCard,
   RequestTransfer,
   RequestMultiTransfer,
+  Team,
 } from "./types/index.js";
 
 export {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,3 +15,4 @@ export type {
   RequestTransfer,
   RequestMultiTransfer,
 } from "./request.js";
+export type { Team } from "./team.js";

--- a/packages/core/src/types/team.ts
+++ b/packages/core/src/types/team.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * A Qonto team within an organization.
+ */
+export interface Team {
+  readonly id: string;
+  readonly name: string;
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -27,7 +27,7 @@ describe("createServer", () => {
       vi.restoreAllMocks();
     });
 
-    it("registers all 64 expected tools", async () => {
+    it("registers all expected tools", async () => {
       const { tools } = await mcpClient.listTools();
       const toolNames = tools.map((t) => t.name);
 
@@ -100,7 +100,9 @@ describe("createServer", () => {
       expect(toolNames).toContain("account_create");
       expect(toolNames).toContain("account_update");
       expect(toolNames).toContain("account_close");
-      expect(tools).toHaveLength(69);
+      expect(toolNames).toContain("team_list");
+      expect(toolNames).toContain("team_create");
+      expect(tools).toHaveLength(71);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -22,6 +22,7 @@ import {
   registerRequestTools,
   registerStatementTools,
   registerSupplierInvoiceTools,
+  registerTeamTools,
   registerTransactionTools,
   registerTransferTools,
 } from "./tools/index.js";
@@ -62,6 +63,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerRequestTools(server, getClient);
   registerStatementTools(server, getClient);
   registerSupplierInvoiceTools(server, getClient);
+  registerTeamTools(server, getClient);
   registerTransactionTools(server, getClient);
   registerTransferTools(server, getClient);
 

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -19,4 +19,5 @@ export { registerRequestTools } from "./request.js";
 export { registerStatementTools } from "./statement.js";
 export { registerSupplierInvoiceTools } from "./supplier-invoice.js";
 export { registerTransactionTools } from "./transactions.js";
+export { registerTeamTools } from "./team.js";
 export { registerTransferTools } from "./transfer.js";

--- a/packages/mcp/src/tools/team.test.ts
+++ b/packages/mcp/src/tools/team.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { connectInMemory } from "../testing/mcp-helpers.js";
+
+describe("team MCP tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    ({ mcpClient } = await connectInMemory(fetchSpy));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("team_list", () => {
+    it("returns teams from API", async () => {
+      const teams = [
+        { id: "team-1", name: "Engineering" },
+        { id: "team-2", name: "Marketing" },
+      ];
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams,
+          meta: {
+            current_page: 1,
+            next_page: null,
+            prev_page: null,
+            total_pages: 1,
+            total_count: 2,
+            per_page: 100,
+          },
+        }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "team_list",
+        arguments: {},
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as { teams: unknown[] };
+      expect(parsed.teams).toHaveLength(2);
+    });
+
+    it("passes pagination params to API", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams: [],
+          meta: {
+            current_page: 3,
+            next_page: null,
+            prev_page: 2,
+            total_pages: 3,
+            total_count: 0,
+            per_page: 25,
+          },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "team_list",
+        arguments: { current_page: 3, per_page: 25 },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("current_page")).toBe("3");
+      expect(url.searchParams.get("per_page")).toBe("25");
+    });
+
+    it("calls the correct API endpoint", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({
+          teams: [],
+          meta: {
+            current_page: 1,
+            next_page: null,
+            prev_page: null,
+            total_pages: 1,
+            total_count: 0,
+            per_page: 100,
+          },
+        }),
+      );
+
+      await mcpClient.callTool({
+        name: "team_list",
+        arguments: {},
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/teams");
+    });
+  });
+
+  describe("team_create", () => {
+    const createdTeam = {
+      id: "team-new",
+      name: "Design",
+    };
+
+    it("creates a team", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      const result = await mcpClient.callTool({
+        name: "team_create",
+        arguments: { name: "Design" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      const parsed = JSON.parse(first.text) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", "team-new");
+      expect(parsed).toHaveProperty("name", "Design");
+    });
+
+    it("sends POST with name body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      await mcpClient.callTool({
+        name: "team_create",
+        arguments: { name: "Design" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/teams");
+      expect(opts.method).toBe("POST");
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({ name: "Design" });
+    });
+
+    it("calls the correct API endpoint", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+
+      await mcpClient.callTool({
+        name: "team_create",
+        arguments: { name: "Design" },
+      });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/teams");
+    });
+  });
+});

--- a/packages/mcp/src/tools/team.ts
+++ b/packages/mcp/src/tools/team.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { HttpClient, PaginationMeta, Team } from "@qontoctl/core";
+import { withClient } from "../errors.js";
+
+interface PaginatedTeamsResponse {
+  readonly teams: readonly Team[];
+  readonly meta: PaginationMeta;
+}
+
+export function registerTeamTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
+  server.registerTool(
+    "team_list",
+    {
+      description: "List all teams in the organization",
+      inputSchema: {
+        current_page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+      },
+    },
+    async ({ current_page, per_page }) =>
+      withClient(getClient, async (client) => {
+        const params: Record<string, string> = {};
+        if (current_page !== undefined) params["current_page"] = String(current_page);
+        if (per_page !== undefined) params["per_page"] = String(per_page);
+
+        const response = await client.get<PaginatedTeamsResponse>(
+          "/v2/teams",
+          Object.keys(params).length > 0 ? params : undefined,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ teams: response.teams, meta: response.meta }, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "team_create",
+    {
+      description: "Create a new team in the organization",
+      inputSchema: {
+        name: z.string().min(2).max(100).describe("Name for the new team (2-100 characters)"),
+      },
+    },
+    async ({ name }) =>
+      withClient(getClient, async (client) => {
+        const response = await client.post<{ team: Team }>("/v2/teams", { name });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(response.team, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+}


### PR DESCRIPTION
## Summary

- Add `team list` and `team create` CLI commands for managing Qonto organization teams
- Add `team_list` and `team_create` MCP tools with equivalent functionality
- Add `Team` type to `@qontoctl/core` types

Closes #192

## Test plan

- [x] Unit tests for CLI `team list` (table, json, pagination, endpoint)
- [x] Unit tests for CLI `team create` (table, json, POST body, idempotency key)
- [x] Unit tests for MCP `team_list` (response, pagination, endpoint)
- [x] Unit tests for MCP `team_create` (response, POST body, endpoint)
- [x] MCP server tool count updated (69 → 71)
- [x] Build passes
- [x] Lint passes
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)