### PR TITLE
(fix) handle undefined response from transaction attachment add

### DIFF
--- a/packages/cli/src/commands/transaction/attachment.test.ts
+++ b/packages/cli/src/commands/transaction/attachment.test.ts
@@ -107,6 +107,21 @@ describe("transaction attachment commands", () => {
       expect(opts.method).toBe("POST");
       expect(opts.body).toBeInstanceOf(FormData);
     });
+
+    it("prints success to stderr when API returns no attachment data", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+
+      const { createProgram } = await import("../../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["transaction", "attachment", "add", "tx-1", "package.json"], { from: "user" });
+
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).toHaveBeenCalledWith("Attachment package.json added to transaction tx-1.\n");
+      stderrSpy.mockRestore();
+    });
   });
 
   describe("transaction attachment remove (specific)", () => {

--- a/packages/cli/src/commands/transaction/attachment.ts
+++ b/packages/cli/src/commands/transaction/attachment.ts
@@ -63,9 +63,12 @@ export function registerTransactionAttachmentCommands(parent: Command): void {
       opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
     );
 
-    const data = opts.output === "json" || opts.output === "yaml" ? result : [attachmentToTableRow(result)];
-
-    process.stdout.write(formatOutput(data, opts.output) + "\n");
+    if (result !== undefined) {
+      const data = opts.output === "json" || opts.output === "yaml" ? result : [attachmentToTableRow(result)];
+      process.stdout.write(formatOutput(data, opts.output) + "\n");
+    } else {
+      process.stderr.write(`Attachment ${fileName} added to transaction ${transactionId}.\n`);
+    }
   });
 
   // --- remove ---

--- a/packages/core/src/attachments/service.ts
+++ b/packages/core/src/attachments/service.ts
@@ -42,6 +42,9 @@ export async function listTransactionAttachments(client: HttpClient, transaction
 
 /**
  * Attach a file to a transaction via multipart form-data.
+ *
+ * Returns the attachment details when the API includes them in the response,
+ * or `undefined` when the API responds without attachment data.
  */
 export async function addTransactionAttachment(
   client: HttpClient,
@@ -49,11 +52,11 @@ export async function addTransactionAttachment(
   file: Blob,
   fileName: string,
   options?: { readonly idempotencyKey?: string },
-): Promise<Attachment> {
+): Promise<Attachment | undefined> {
   const formData = new FormData();
   formData.append("file", file, fileName);
 
-  const response = await client.postFormData<{ attachment: Attachment }>(
+  const response = await client.postFormData<{ attachment?: Attachment }>(
     `/v2/transactions/${encodeURIComponent(transactionId)}/attachments`,
     formData,
     options,

--- a/packages/mcp/src/tools/attachment.ts
+++ b/packages/mcp/src/tools/attachment.ts
@@ -107,7 +107,10 @@ export function registerAttachmentTools(server: McpServer, getClient: () => Prom
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify(attachment, null, 2),
+              text:
+                attachment !== undefined
+                  ? JSON.stringify(attachment, null, 2)
+                  : `Attachment ${fileName} added to transaction ${transaction_id}.`,
             },
           ],
         };


### PR DESCRIPTION
## Summary

- Fix `transaction_attachment_add` MCP tool returning invalid content type when the Qonto API response doesn't include an `attachment` wrapper key
- `addTransactionAttachment` service now returns `Attachment | undefined` to honestly represent the API response
- MCP handler falls back to a text success message when attachment details are unavailable
- CLI handler prints success to stderr when no attachment data is returned

Fixes #232

## Test plan

- [x] Existing unit tests pass (434 total)
- [x] New test covers the undefined response case in CLI
- [ ] E2E test with actual API call (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)