### PR TITLE
(feat) add response schemas: attachments, statements, SCA

### DIFF
--- a/packages/core/src/attachments/index.ts
+++ b/packages/core/src/attachments/index.ts
@@ -11,3 +11,5 @@ export {
 } from "./service.js";
 
 export type { Attachment } from "./types.js";
+
+export { AttachmentSchema } from "./schemas.js";

--- a/packages/core/src/attachments/schemas.test.ts
+++ b/packages/core/src/attachments/schemas.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { AttachmentSchema } from "./schemas.js";
+
+describe("AttachmentSchema", () => {
+  const validAttachment = {
+    id: "att-1",
+    file_name: "invoice.pdf",
+    file_size: 12345,
+    file_content_type: "application/pdf",
+    url: "https://example.com/attachments/att-1",
+    created_at: "2026-03-01T10:00:00Z",
+  };
+
+  it("parses a valid attachment", () => {
+    const result = AttachmentSchema.parse(validAttachment);
+    expect(result).toEqual(validAttachment);
+  });
+
+  it("strips unknown fields", () => {
+    const result = AttachmentSchema.parse({ ...validAttachment, extra: "field" });
+    expect(result).toEqual(validAttachment);
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects when required field is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _, ...withoutId } = validAttachment;
+    expect(() => AttachmentSchema.parse(withoutId)).toThrow(z.ZodError);
+  });
+
+  it("rejects when field has wrong type", () => {
+    expect(() => AttachmentSchema.parse({ ...validAttachment, file_size: "not-a-number" })).toThrow(z.ZodError);
+  });
+});

--- a/packages/core/src/attachments/schemas.ts
+++ b/packages/core/src/attachments/schemas.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { Attachment } from "./types.js";
+
+/**
+ * Zod schema for an attachment returned by the Qonto API.
+ */
+export const AttachmentSchema = z.object({
+  id: z.string(),
+  file_name: z.string(),
+  file_size: z.number(),
+  file_content_type: z.string(),
+  url: z.string(),
+  created_at: z.string(),
+}) satisfies z.ZodType<Attachment>;

--- a/packages/core/src/attachments/service.ts
+++ b/packages/core/src/attachments/service.ts
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { z } from "zod";
 import type { HttpClient } from "../http-client.js";
+import { parseResponse } from "../response.js";
+import { AttachmentSchema } from "./schemas.js";
 import type { Attachment } from "./types.js";
 
 /**
@@ -18,26 +21,26 @@ export async function uploadAttachment(
   const formData = new FormData();
   formData.append("file", file, fileName);
 
-  const response = await client.postFormData<{ attachment: Attachment }>("/v2/attachments", formData, options);
-  return response.attachment;
+  const response = await client.postFormData("/v2/attachments", formData, options);
+  return parseResponse(z.object({ attachment: AttachmentSchema }), response, "/v2/attachments").attachment;
 }
 
 /**
  * Retrieve attachment details by ID.
  */
 export async function getAttachment(client: HttpClient, id: string): Promise<Attachment> {
-  const response = await client.get<{ attachment: Attachment }>(`/v2/attachments/${encodeURIComponent(id)}`);
-  return response.attachment;
+  const endpointPath = `/v2/attachments/${encodeURIComponent(id)}`;
+  const response = await client.get(endpointPath);
+  return parseResponse(z.object({ attachment: AttachmentSchema }), response, endpointPath).attachment;
 }
 
 /**
  * List attachments for a transaction.
  */
 export async function listTransactionAttachments(client: HttpClient, transactionId: string): Promise<Attachment[]> {
-  const response = await client.get<{ attachments: Attachment[] }>(
-    `/v2/transactions/${encodeURIComponent(transactionId)}/attachments`,
-  );
-  return response.attachments;
+  const endpointPath = `/v2/transactions/${encodeURIComponent(transactionId)}/attachments`;
+  const response = await client.get(endpointPath);
+  return parseResponse(z.object({ attachments: z.array(AttachmentSchema) }), response, endpointPath).attachments;
 }
 
 /**
@@ -56,12 +59,9 @@ export async function addTransactionAttachment(
   const formData = new FormData();
   formData.append("file", file, fileName);
 
-  const response = await client.postFormData<{ attachment?: Attachment }>(
-    `/v2/transactions/${encodeURIComponent(transactionId)}/attachments`,
-    formData,
-    options,
-  );
-  return response.attachment;
+  const endpointPath = `/v2/transactions/${encodeURIComponent(transactionId)}/attachments`;
+  const response = await client.postFormData(endpointPath, formData, options);
+  return parseResponse(z.object({ attachment: AttachmentSchema.optional() }), response, endpointPath).attachment;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -130,6 +130,7 @@ export type {
 export type { Quote, QuoteAddress, QuoteAmount, QuoteClient, QuoteDiscount, QuoteItem } from "./types/index.js";
 
 export type { Statement, StatementFile } from "./statements/index.js";
+export { StatementFileSchema, StatementSchema } from "./statements/index.js";
 
 export { buildTransactionQueryParams, getTransaction } from "./transactions/index.js";
 
@@ -236,6 +237,7 @@ export {
 } from "./attachments/index.js";
 
 export type { Attachment } from "./attachments/index.js";
+export { AttachmentSchema } from "./attachments/index.js";
 
 export {
   createBankAccount,
@@ -253,6 +255,8 @@ export { getOrganization } from "./services/organization.js";
 export {
   ScaDeniedError,
   ScaTimeoutError,
+  ScaSessionSchema,
+  ScaSessionStatusSchema,
   getScaSession,
   mockScaDecision,
   pollScaSession,

--- a/packages/core/src/sca/index.ts
+++ b/packages/core/src/sca/index.ts
@@ -3,5 +3,6 @@
 
 export type { ScaMethod, ScaSession, ScaSessionStatus } from "./types.js";
 export { ScaDeniedError, ScaTimeoutError } from "./errors.js";
+export { ScaSessionSchema, ScaSessionStatusSchema } from "./schemas.js";
 export { getScaSession, mockScaDecision, pollScaSession, type PollScaSessionOptions } from "./sca-service.js";
 export { executeWithSca, type ExecuteWithScaCallbacks, type ExecuteWithScaOptions } from "./sca-handler.js";

--- a/packages/core/src/sca/sca-service.ts
+++ b/packages/core/src/sca/sca-service.ts
@@ -1,22 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { z } from "zod";
 import type { HttpClient } from "../http-client.js";
-import type { ScaSession, ScaSessionStatus } from "./types.js";
+import { parseResponse } from "../response.js";
+import type { ScaSession } from "./types.js";
 import { ScaDeniedError, ScaTimeoutError } from "./errors.js";
-
-interface ScaSessionResponse {
-  readonly sca_session: {
-    readonly status: ScaSessionStatus;
-  };
-}
+import { ScaSessionStatusSchema } from "./schemas.js";
 
 /**
  * Retrieve the current status of an SCA session.
  */
 export async function getScaSession(client: HttpClient, token: string): Promise<ScaSession> {
-  const response = await client.get<ScaSessionResponse>(`/v2/sca/sessions/${encodeURIComponent(token)}`);
-  return { token, status: response.sca_session.status };
+  const endpointPath = `/v2/sca/sessions/${encodeURIComponent(token)}`;
+  const response = await client.get(endpointPath);
+  const parsed = parseResponse(
+    z.object({ sca_session: z.object({ status: ScaSessionStatusSchema }) }),
+    response,
+    endpointPath,
+  );
+  return { token, status: parsed.sca_session.status };
 }
 
 /**

--- a/packages/core/src/sca/schemas.test.ts
+++ b/packages/core/src/sca/schemas.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { ScaSessionSchema, ScaSessionStatusSchema } from "./schemas.js";
+
+describe("ScaSessionStatusSchema", () => {
+  it("accepts valid status values", () => {
+    expect(ScaSessionStatusSchema.parse("waiting")).toBe("waiting");
+    expect(ScaSessionStatusSchema.parse("allow")).toBe("allow");
+    expect(ScaSessionStatusSchema.parse("deny")).toBe("deny");
+  });
+
+  it("rejects invalid status values", () => {
+    expect(() => ScaSessionStatusSchema.parse("unknown")).toThrow(z.ZodError);
+  });
+});
+
+describe("ScaSessionSchema", () => {
+  const validSession = {
+    token: "sca-token-123",
+    status: "waiting" as const,
+  };
+
+  it("parses a valid SCA session", () => {
+    const result = ScaSessionSchema.parse(validSession);
+    expect(result).toEqual(validSession);
+  });
+
+  it("strips unknown fields", () => {
+    const result = ScaSessionSchema.parse({ ...validSession, extra: "field" });
+    expect(result).toEqual(validSession);
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects when required field is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { token: _, ...withoutToken } = validSession;
+    expect(() => ScaSessionSchema.parse(withoutToken)).toThrow(z.ZodError);
+  });
+
+  it("rejects invalid status value", () => {
+    expect(() => ScaSessionSchema.parse({ ...validSession, status: "invalid" })).toThrow(z.ZodError);
+  });
+});

--- a/packages/core/src/sca/schemas.ts
+++ b/packages/core/src/sca/schemas.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { ScaSession } from "./types.js";
+
+/**
+ * Zod schema for the SCA session status values.
+ */
+export const ScaSessionStatusSchema = z.enum(["waiting", "allow", "deny"]);
+
+/**
+ * Zod schema for an SCA session.
+ *
+ * Note: The API response contains only `status` inside the `sca_session` envelope.
+ * The `token` field is added by the service layer from the request parameter.
+ */
+export const ScaSessionSchema = z.object({
+  token: z.string(),
+  status: ScaSessionStatusSchema,
+}) satisfies z.ZodType<ScaSession>;

--- a/packages/core/src/statements/index.ts
+++ b/packages/core/src/statements/index.ts
@@ -2,3 +2,5 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export type { Statement, StatementFile } from "./types.js";
+
+export { StatementFileSchema, StatementSchema } from "./schemas.js";

--- a/packages/core/src/statements/schemas.test.ts
+++ b/packages/core/src/statements/schemas.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { StatementFileSchema, StatementSchema } from "./schemas.js";
+
+describe("StatementFileSchema", () => {
+  const validFile = {
+    file_name: "statement-2026-01.pdf",
+    file_content_type: "application/pdf",
+    file_size: "45678",
+    file_url: "https://example.com/statements/file.pdf",
+  };
+
+  it("parses a valid statement file", () => {
+    const result = StatementFileSchema.parse(validFile);
+    expect(result).toEqual(validFile);
+  });
+
+  it("strips unknown fields", () => {
+    const result = StatementFileSchema.parse({ ...validFile, extra: "field" });
+    expect(result).toEqual(validFile);
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects when required field is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { file_name: _, ...withoutName } = validFile;
+    expect(() => StatementFileSchema.parse(withoutName)).toThrow(z.ZodError);
+  });
+});
+
+describe("StatementSchema", () => {
+  const validStatement = {
+    id: "stmt-1",
+    bank_account_id: "ba-1",
+    period: "01-2026",
+    file: {
+      file_name: "statement-2026-01.pdf",
+      file_content_type: "application/pdf",
+      file_size: "45678",
+      file_url: "https://example.com/statements/file.pdf",
+    },
+  };
+
+  it("parses a valid statement", () => {
+    const result = StatementSchema.parse(validStatement);
+    expect(result).toEqual(validStatement);
+  });
+
+  it("strips unknown fields from statement and nested file", () => {
+    const result = StatementSchema.parse({
+      ...validStatement,
+      extra: "field",
+      file: { ...validStatement.file, bonus: true },
+    });
+    expect(result).toEqual(validStatement);
+    expect(result).not.toHaveProperty("extra");
+    expect(result.file).not.toHaveProperty("bonus");
+  });
+
+  it("rejects when required field is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _, ...withoutId } = validStatement;
+    expect(() => StatementSchema.parse(withoutId)).toThrow(z.ZodError);
+  });
+
+  it("rejects when nested file is invalid", () => {
+    expect(() => StatementSchema.parse({ ...validStatement, file: { file_name: "test" } })).toThrow(z.ZodError);
+  });
+});

--- a/packages/core/src/statements/schemas.ts
+++ b/packages/core/src/statements/schemas.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { Statement, StatementFile } from "./types.js";
+
+/**
+ * Zod schema for statement file metadata.
+ */
+export const StatementFileSchema = z.object({
+  file_name: z.string(),
+  file_content_type: z.string(),
+  file_size: z.string(),
+  file_url: z.string(),
+}) satisfies z.ZodType<StatementFile>;
+
+/**
+ * Zod schema for a bank statement returned by the Qonto API.
+ */
+export const StatementSchema = z.object({
+  id: z.string(),
+  bank_account_id: z.string(),
+  period: z.string(),
+  file: StatementFileSchema,
+}) satisfies z.ZodType<Statement>;


### PR DESCRIPTION
## Summary

- Define Zod response schemas for `Attachment`, `StatementFile`, `Statement`, `ScaSession`, and `ScaSessionStatus`
- Migrate attachment service functions (`uploadAttachment`, `getAttachment`, `listTransactionAttachments`, `addTransactionAttachment`) to use `parseResponse()` instead of type assertions
- Migrate SCA service function (`getScaSession`) to use `parseResponse()` for response validation
- Add schema unit tests validating parse, strip, and rejection behavior

Closes #236

## Test plan

- [x] All existing unit tests pass
- [x] New schema tests validate parse + strip + rejection behavior
- [x] Build succeeds across all packages
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)