### PR TITLE
(feat) add response schemas for shared types

### DIFF
--- a/packages/core/src/api-types.schema.test.ts
+++ b/packages/core/src/api-types.schema.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { BankAccountSchema, OrganizationSchema, PaginationMetaSchema } from "./api-types.schema.js";
+
+const validBankAccount = {
+  id: "acc-1",
+  name: "Main Account",
+  status: "active",
+  main: true,
+  organization_id: "org-1",
+  iban: "FR7630001007941234567890185",
+  bic: "BNPAFRPP",
+  currency: "EUR",
+  balance: 10000.5,
+  balance_cents: 1000050,
+  authorized_balance: 9500.0,
+  authorized_balance_cents: 950000,
+  slug: "main-account",
+};
+
+describe("BankAccountSchema", () => {
+  it("parses a valid bank account", () => {
+    const result = BankAccountSchema.parse(validBankAccount);
+    expect(result).toEqual(validBankAccount);
+  });
+
+  it("strips unknown fields", () => {
+    const result = BankAccountSchema.parse({ ...validBankAccount, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => BankAccountSchema.parse({ id: "acc-1" })).toThrow();
+  });
+});
+
+describe("OrganizationSchema", () => {
+  const validOrg = {
+    slug: "acme-corp",
+    legal_name: "ACME Corporation",
+    bank_accounts: [validBankAccount],
+  };
+
+  it("parses a valid organization", () => {
+    const result = OrganizationSchema.parse(validOrg);
+    expect(result).toEqual(validOrg);
+  });
+
+  it("strips unknown fields from org and nested bank accounts", () => {
+    const result = OrganizationSchema.parse({
+      ...validOrg,
+      extra: true,
+      bank_accounts: [{ ...validBankAccount, extra: true }],
+    });
+    expect(result).not.toHaveProperty("extra");
+    expect(result.bank_accounts[0]).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => OrganizationSchema.parse({ slug: "acme" })).toThrow();
+  });
+});
+
+describe("PaginationMetaSchema", () => {
+  const validMeta = {
+    current_page: 1,
+    next_page: 2,
+    prev_page: null,
+    total_pages: 5,
+    total_count: 100,
+    per_page: 20,
+  };
+
+  it("parses valid pagination meta", () => {
+    const result = PaginationMetaSchema.parse(validMeta);
+    expect(result).toEqual(validMeta);
+  });
+
+  it("parses with null next_page and prev_page", () => {
+    const result = PaginationMetaSchema.parse({ ...validMeta, next_page: null });
+    expect(result.next_page).toBeNull();
+  });
+
+  it("strips unknown fields", () => {
+    const result = PaginationMetaSchema.parse({ ...validMeta, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+});

--- a/packages/core/src/api-types.schema.ts
+++ b/packages/core/src/api-types.schema.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { BankAccount, Organization, PaginationMeta } from "./api-types.js";
+
+export const BankAccountSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    status: z.string(),
+    main: z.boolean(),
+    organization_id: z.string(),
+    iban: z.string(),
+    bic: z.string(),
+    currency: z.string(),
+    balance: z.number(),
+    balance_cents: z.number(),
+    authorized_balance: z.number(),
+    authorized_balance_cents: z.number(),
+    slug: z.string(),
+  })
+  .strip() satisfies z.ZodType<BankAccount>;
+
+export const OrganizationSchema = z
+  .object({
+    slug: z.string(),
+    legal_name: z.string(),
+    bank_accounts: z.array(BankAccountSchema).readonly(),
+  })
+  .strip() satisfies z.ZodType<Organization>;
+
+export const PaginationMetaSchema = z
+  .object({
+    current_page: z.number(),
+    next_page: z.number().nullable(),
+    prev_page: z.number().nullable(),
+    total_pages: z.number(),
+    total_count: z.number(),
+    per_page: z.number(),
+  })
+  .strip() satisfies z.ZodType<PaginationMeta>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,7 +72,14 @@ export type {
   ParentCardSummary,
 } from "./types/index.js";
 export type { Client, ClientAddress } from "./types/index.js";
+export { ClientAddressSchema, ClientSchema } from "./types/index.js";
 export type { CreditNote, CreditNoteAmount, CreditNoteClient, CreditNoteItem } from "./types/index.js";
+export {
+  CreditNoteAmountSchema,
+  CreditNoteClientSchema,
+  CreditNoteItemSchema,
+  CreditNoteSchema,
+} from "./types/index.js";
 export type {
   EInvoicingSettings,
   Label,
@@ -85,6 +92,18 @@ export type {
   Team,
   WebhookSubscription,
 } from "./types/index.js";
+export { EInvoicingSettingsSchema } from "./types/index.js";
+export { LabelSchema } from "./types/index.js";
+export { MembershipSchema } from "./types/index.js";
+export {
+  QuoteAddressSchema,
+  QuoteAmountSchema,
+  QuoteClientSchema,
+  QuoteDiscountSchema,
+  QuoteItemSchema,
+  QuoteSchema,
+} from "./types/index.js";
+export { TeamSchema } from "./types/index.js";
 
 export {
   buildBeneficiaryQueryParams,
@@ -213,6 +232,7 @@ export type {
 export { parseResponse } from "./response.js";
 
 export type { BankAccount, Organization, PaginationMeta } from "./api-types.js";
+export { BankAccountSchema, OrganizationSchema, PaginationMetaSchema } from "./api-types.schema.js";
 
 export { createInternalTransfer } from "./internal-transfers/index.js";
 

--- a/packages/core/src/types/client.schema.test.ts
+++ b/packages/core/src/types/client.schema.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { ClientAddressSchema, ClientSchema } from "./client.schema.js";
+
+describe("ClientAddressSchema", () => {
+  const validAddress = {
+    street_address: "123 Main St",
+    city: "Paris",
+    zip_code: "75001",
+    province_code: null,
+    country_code: "FR",
+  };
+
+  it("parses a valid address", () => {
+    const result = ClientAddressSchema.parse(validAddress);
+    expect(result).toEqual(validAddress);
+  });
+
+  it("parses with all nullable fields set to null", () => {
+    const result = ClientAddressSchema.parse({
+      street_address: null,
+      city: null,
+      zip_code: null,
+      province_code: null,
+      country_code: null,
+    });
+    expect(result.street_address).toBeNull();
+  });
+
+  it("strips unknown fields", () => {
+    const result = ClientAddressSchema.parse({ ...validAddress, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+});
+
+describe("ClientSchema", () => {
+  const validClient = {
+    id: "client-1",
+    name: "ACME Corp",
+    first_name: null,
+    last_name: null,
+    kind: "company" as const,
+    email: "contact@acme.com",
+    vat_number: "FR12345678901",
+    tax_identification_number: null,
+    address: "123 Main St",
+    city: "Paris",
+    zip_code: "75001",
+    province_code: null,
+    country_code: "FR",
+    billing_address: {
+      street_address: "123 Main St",
+      city: "Paris",
+      zip_code: "75001",
+      province_code: null,
+      country_code: "FR",
+    },
+    delivery_address: null,
+    locale: "fr",
+    currency: "EUR",
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-06-15T12:00:00.000Z",
+  };
+
+  it("parses a valid client", () => {
+    const result = ClientSchema.parse(validClient);
+    expect(result).toEqual(validClient);
+  });
+
+  it("validates kind enum values", () => {
+    for (const kind of ["company", "individual", "freelancer"]) {
+      expect(() => ClientSchema.parse({ ...validClient, kind })).not.toThrow();
+    }
+    expect(() => ClientSchema.parse({ ...validClient, kind: "other" })).toThrow();
+  });
+
+  it("strips unknown fields from client and nested address", () => {
+    const result = ClientSchema.parse({
+      ...validClient,
+      extra: true,
+      billing_address: { ...validClient.billing_address, extra: true },
+    });
+    expect(result).not.toHaveProperty("extra");
+    expect(result.billing_address).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => ClientSchema.parse({ id: "client-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/client.schema.ts
+++ b/packages/core/src/types/client.schema.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { Client, ClientAddress } from "./client.js";
+
+export const ClientAddressSchema = z
+  .object({
+    street_address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable(),
+    country_code: z.string().nullable(),
+  })
+  .strip() satisfies z.ZodType<ClientAddress>;
+
+export const ClientSchema = z
+  .object({
+    id: z.string(),
+    name: z.string().nullable(),
+    first_name: z.string().nullable(),
+    last_name: z.string().nullable(),
+    kind: z.enum(["company", "individual", "freelancer"]),
+    email: z.string().nullable(),
+    vat_number: z.string().nullable(),
+    tax_identification_number: z.string().nullable(),
+    address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable(),
+    country_code: z.string().nullable(),
+    billing_address: ClientAddressSchema.nullable(),
+    delivery_address: ClientAddressSchema.nullable(),
+    locale: z.string().nullable(),
+    currency: z.string().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<Client>;

--- a/packages/core/src/types/credit-note.schema.test.ts
+++ b/packages/core/src/types/credit-note.schema.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  CreditNoteAmountSchema,
+  CreditNoteItemSchema,
+  CreditNoteClientSchema,
+  CreditNoteSchema,
+} from "./credit-note.schema.js";
+
+const amount = { value: "100.00", currency: "EUR" };
+
+const item = {
+  title: "Consulting",
+  description: "Strategy consulting",
+  quantity: "2",
+  unit: "hours",
+  unit_price: amount,
+  unit_price_cents: 10000,
+  vat_rate: "20.0",
+  total_vat: amount,
+  total_vat_cents: 4000,
+  total_amount: amount,
+  total_amount_cents: 20000,
+  subtotal: amount,
+  subtotal_cents: 20000,
+};
+
+const client = {
+  id: "client-1",
+  name: "ACME Corp",
+  first_name: "John",
+  last_name: "Doe",
+  type: "company",
+  email: "contact@acme.com",
+  vat_number: "FR12345678901",
+  tax_identification_number: "12345",
+  address: "123 Main St",
+  city: "Paris",
+  zip_code: "75001",
+  country_code: "FR",
+  locale: "fr",
+};
+
+const validCreditNote = {
+  id: "cn-1",
+  invoice_id: "inv-1",
+  attachment_id: "att-1",
+  number: "CN-2024-001",
+  issue_date: "2024-06-01",
+  invoice_issue_date: "2024-05-01",
+  header: "Credit Note",
+  footer: "Thank you",
+  terms_and_conditions: "Standard terms",
+  currency: "EUR",
+  vat_amount: amount,
+  vat_amount_cents: 4000,
+  total_amount: amount,
+  total_amount_cents: 20000,
+  stamp_duty_amount: "0",
+  created_at: "2024-06-01T00:00:00.000Z",
+  finalized_at: "2024-06-01T12:00:00.000Z",
+  contact_email: "contact@acme.com",
+  invoice_url: "https://example.com/invoice.pdf",
+  einvoicing_status: "not_applicable",
+  items: [item],
+  client,
+};
+
+describe("CreditNoteAmountSchema", () => {
+  it("parses a valid amount", () => {
+    expect(CreditNoteAmountSchema.parse(amount)).toEqual(amount);
+  });
+
+  it("strips unknown fields", () => {
+    const result = CreditNoteAmountSchema.parse({ ...amount, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+});
+
+describe("CreditNoteItemSchema", () => {
+  it("parses a valid item", () => {
+    expect(CreditNoteItemSchema.parse(item)).toEqual(item);
+  });
+
+  it("strips unknown fields from nested amounts", () => {
+    const result = CreditNoteItemSchema.parse({
+      ...item,
+      unit_price: { ...amount, extra: true },
+    });
+    expect(result.unit_price).not.toHaveProperty("extra");
+  });
+});
+
+describe("CreditNoteClientSchema", () => {
+  it("parses a valid client", () => {
+    expect(CreditNoteClientSchema.parse(client)).toEqual(client);
+  });
+
+  it("strips unknown fields", () => {
+    const result = CreditNoteClientSchema.parse({ ...client, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+});
+
+describe("CreditNoteSchema", () => {
+  it("parses a valid credit note", () => {
+    const result = CreditNoteSchema.parse(validCreditNote);
+    expect(result).toEqual(validCreditNote);
+  });
+
+  it("strips unknown fields from top level and nested structures", () => {
+    const result = CreditNoteSchema.parse({
+      ...validCreditNote,
+      extra: true,
+      client: { ...client, extra: true },
+      items: [{ ...item, extra: true }],
+    });
+    expect(result).not.toHaveProperty("extra");
+    expect(result.client).not.toHaveProperty("extra");
+    expect(result.items[0]).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => CreditNoteSchema.parse({ id: "cn-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/credit-note.schema.ts
+++ b/packages/core/src/types/credit-note.schema.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { CreditNote, CreditNoteAmount, CreditNoteClient, CreditNoteItem } from "./credit-note.js";
+
+export const CreditNoteAmountSchema = z
+  .object({
+    value: z.string(),
+    currency: z.string(),
+  })
+  .strip() satisfies z.ZodType<CreditNoteAmount>;
+
+export const CreditNoteItemSchema = z
+  .object({
+    title: z.string(),
+    description: z.string(),
+    quantity: z.string(),
+    unit: z.string(),
+    unit_price: CreditNoteAmountSchema,
+    unit_price_cents: z.number(),
+    vat_rate: z.string(),
+    total_vat: CreditNoteAmountSchema,
+    total_vat_cents: z.number(),
+    total_amount: CreditNoteAmountSchema,
+    total_amount_cents: z.number(),
+    subtotal: CreditNoteAmountSchema,
+    subtotal_cents: z.number(),
+  })
+  .strip() satisfies z.ZodType<CreditNoteItem>;
+
+export const CreditNoteClientSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    first_name: z.string(),
+    last_name: z.string(),
+    type: z.string(),
+    email: z.string(),
+    vat_number: z.string(),
+    tax_identification_number: z.string(),
+    address: z.string(),
+    city: z.string(),
+    zip_code: z.string(),
+    country_code: z.string(),
+    locale: z.string(),
+  })
+  .strip() satisfies z.ZodType<CreditNoteClient>;
+
+export const CreditNoteSchema = z
+  .object({
+    id: z.string(),
+    invoice_id: z.string(),
+    attachment_id: z.string(),
+    number: z.string(),
+    issue_date: z.string(),
+    invoice_issue_date: z.string(),
+    header: z.string(),
+    footer: z.string(),
+    terms_and_conditions: z.string(),
+    currency: z.string(),
+    vat_amount: CreditNoteAmountSchema,
+    vat_amount_cents: z.number(),
+    total_amount: CreditNoteAmountSchema,
+    total_amount_cents: z.number(),
+    stamp_duty_amount: z.string(),
+    created_at: z.string(),
+    finalized_at: z.string(),
+    contact_email: z.string(),
+    invoice_url: z.string(),
+    einvoicing_status: z.string(),
+    items: z.array(CreditNoteItemSchema).readonly(),
+    client: CreditNoteClientSchema,
+  })
+  .strip() satisfies z.ZodType<CreditNote>;

--- a/packages/core/src/types/einvoicing.schema.test.ts
+++ b/packages/core/src/types/einvoicing.schema.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { EInvoicingSettingsSchema } from "./einvoicing.schema.js";
+
+describe("EInvoicingSettingsSchema", () => {
+  const validSettings = {
+    sending_status: "enabled",
+    receiving_status: "disabled",
+  };
+
+  it("parses valid settings", () => {
+    const result = EInvoicingSettingsSchema.parse(validSettings);
+    expect(result).toEqual(validSettings);
+  });
+
+  it("strips unknown fields", () => {
+    const result = EInvoicingSettingsSchema.parse({ ...validSettings, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => EInvoicingSettingsSchema.parse({ sending_status: "enabled" })).toThrow();
+  });
+});

--- a/packages/core/src/types/einvoicing.schema.ts
+++ b/packages/core/src/types/einvoicing.schema.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { EInvoicingSettings } from "./einvoicing.js";
+
+export const EInvoicingSettingsSchema = z
+  .object({
+    sending_status: z.string(),
+    receiving_status: z.string(),
+  })
+  .strip() satisfies z.ZodType<EInvoicingSettings>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -11,11 +11,29 @@ export type {
   ParentCardSummary,
 } from "./card.js";
 export type { Client, ClientAddress } from "./client.js";
+export { ClientAddressSchema, ClientSchema } from "./client.schema.js";
 export type { CreditNote, CreditNoteAmount, CreditNoteClient, CreditNoteItem } from "./credit-note.js";
+export {
+  CreditNoteAmountSchema,
+  CreditNoteClientSchema,
+  CreditNoteItemSchema,
+  CreditNoteSchema,
+} from "./credit-note.schema.js";
 export type { EInvoicingSettings } from "./einvoicing.js";
+export { EInvoicingSettingsSchema } from "./einvoicing.schema.js";
 export type { Label } from "./label.js";
+export { LabelSchema } from "./label.schema.js";
 export type { Membership } from "./membership.js";
+export { MembershipSchema } from "./membership.schema.js";
 export type { Quote, QuoteAddress, QuoteAmount, QuoteClient, QuoteDiscount, QuoteItem } from "./quote.js";
+export {
+  QuoteAddressSchema,
+  QuoteAmountSchema,
+  QuoteClientSchema,
+  QuoteDiscountSchema,
+  QuoteItemSchema,
+  QuoteSchema,
+} from "./quote.schema.js";
 export type {
   Request,
   RequestFlashCard,
@@ -24,4 +42,5 @@ export type {
   RequestMultiTransfer,
 } from "./request.js";
 export type { Team } from "./team.js";
+export { TeamSchema } from "./team.schema.js";
 export type { WebhookSubscription } from "./webhook-subscription.js";

--- a/packages/core/src/types/label.schema.test.ts
+++ b/packages/core/src/types/label.schema.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { LabelSchema } from "./label.schema.js";
+
+describe("LabelSchema", () => {
+  const validLabel = {
+    id: "label-1",
+    name: "Marketing",
+    parent_id: null,
+  };
+
+  it("parses a valid label", () => {
+    const result = LabelSchema.parse(validLabel);
+    expect(result).toEqual(validLabel);
+  });
+
+  it("parses a label with parent_id", () => {
+    const result = LabelSchema.parse({ ...validLabel, parent_id: "label-0" });
+    expect(result).toEqual({ ...validLabel, parent_id: "label-0" });
+  });
+
+  it("strips unknown fields", () => {
+    const result = LabelSchema.parse({ ...validLabel, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => LabelSchema.parse({ id: "label-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/label.schema.ts
+++ b/packages/core/src/types/label.schema.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { Label } from "./label.js";
+
+export const LabelSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    parent_id: z.string().nullable(),
+  })
+  .strip() satisfies z.ZodType<Label>;

--- a/packages/core/src/types/membership.schema.test.ts
+++ b/packages/core/src/types/membership.schema.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { MembershipSchema } from "./membership.schema.js";
+
+describe("MembershipSchema", () => {
+  const validMembership = {
+    id: "member-1",
+    first_name: "John",
+    last_name: "Doe",
+    email: "john@example.com",
+    role: "admin" as const,
+    team_id: "team-1",
+    residence_country: "FR",
+    birthdate: "1990-01-01",
+    nationality: "FR",
+    birth_country: "FR",
+    ubo: false,
+    status: "active",
+  };
+
+  it("parses a valid membership", () => {
+    const result = MembershipSchema.parse(validMembership);
+    expect(result).toEqual(validMembership);
+  });
+
+  it("parses with nullable fields set to null", () => {
+    const result = MembershipSchema.parse({
+      ...validMembership,
+      residence_country: null,
+      birthdate: null,
+      nationality: null,
+      birth_country: null,
+      ubo: null,
+    });
+    expect(result.residence_country).toBeNull();
+    expect(result.birthdate).toBeNull();
+    expect(result.nationality).toBeNull();
+    expect(result.birth_country).toBeNull();
+    expect(result.ubo).toBeNull();
+  });
+
+  it("validates role enum values", () => {
+    for (const role of ["owner", "admin", "manager", "reporting", "employee", "accountant"]) {
+      expect(() => MembershipSchema.parse({ ...validMembership, role })).not.toThrow();
+    }
+    expect(() => MembershipSchema.parse({ ...validMembership, role: "superadmin" })).toThrow();
+  });
+
+  it("strips unknown fields", () => {
+    const result = MembershipSchema.parse({ ...validMembership, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => MembershipSchema.parse({ id: "member-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/membership.schema.ts
+++ b/packages/core/src/types/membership.schema.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { Membership } from "./membership.js";
+
+export const MembershipSchema = z
+  .object({
+    id: z.string(),
+    first_name: z.string(),
+    last_name: z.string(),
+    email: z.string(),
+    role: z.enum(["owner", "admin", "manager", "reporting", "employee", "accountant"]),
+    team_id: z.string(),
+    residence_country: z.string().nullable(),
+    birthdate: z.string().nullable(),
+    nationality: z.string().nullable(),
+    birth_country: z.string().nullable(),
+    ubo: z.boolean().nullable(),
+    status: z.string(),
+  })
+  .strip() satisfies z.ZodType<Membership>;

--- a/packages/core/src/types/quote.schema.test.ts
+++ b/packages/core/src/types/quote.schema.test.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  QuoteAmountSchema,
+  QuoteDiscountSchema,
+  QuoteItemSchema,
+  QuoteAddressSchema,
+  QuoteClientSchema,
+  QuoteSchema,
+} from "./quote.schema.js";
+
+const amount = { value: "100.00", currency: "EUR" };
+
+const discount = {
+  type: "percentage" as const,
+  value: "10",
+  amount,
+  amount_cents: 1000,
+};
+
+const item = {
+  title: "Consulting",
+  description: "Strategy consulting",
+  quantity: "2",
+  unit: "hours",
+  vat_rate: "20.0",
+  vat_exemption_reason: null,
+  unit_price: amount,
+  unit_price_cents: 10000,
+  total_amount: amount,
+  total_amount_cents: 20000,
+  total_vat: amount,
+  total_vat_cents: 4000,
+  subtotal: amount,
+  subtotal_cents: 20000,
+  discount: null,
+};
+
+const address = {
+  street_address: "123 Main St",
+  city: "Paris",
+  zip_code: "75001",
+  province_code: null,
+  country_code: "FR",
+};
+
+const client = {
+  id: "client-1",
+  type: "company" as const,
+  name: "ACME Corp",
+  first_name: null,
+  last_name: null,
+  email: "contact@acme.com",
+  vat_number: "FR12345678901",
+  tax_identification_number: null,
+  address: "123 Main St",
+  city: "Paris",
+  zip_code: "75001",
+  province_code: null,
+  country_code: "FR",
+  recipient_code: null,
+  locale: "fr",
+  billing_address: address,
+  delivery_address: null,
+};
+
+const validQuote = {
+  id: "quote-1",
+  organization_id: "org-1",
+  number: "Q-2024-001",
+  status: "pending_approval" as const,
+  currency: "EUR",
+  total_amount: amount,
+  total_amount_cents: 24000,
+  vat_amount: amount,
+  vat_amount_cents: 4000,
+  issue_date: "2024-01-01",
+  expiry_date: "2024-02-01",
+  created_at: "2024-01-01T00:00:00.000Z",
+  approved_at: null,
+  canceled_at: null,
+  attachment_id: null,
+  quote_url: null,
+  contact_email: "contact@acme.com",
+  terms_and_conditions: "Net 30",
+  header: null,
+  footer: null,
+  discount: null,
+  items: [item],
+  client,
+  invoice_ids: [],
+};
+
+describe("QuoteAmountSchema", () => {
+  it("parses a valid amount", () => {
+    expect(QuoteAmountSchema.parse(amount)).toEqual(amount);
+  });
+
+  it("strips unknown fields", () => {
+    const result = QuoteAmountSchema.parse({ ...amount, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+});
+
+describe("QuoteDiscountSchema", () => {
+  it("parses a valid discount", () => {
+    expect(QuoteDiscountSchema.parse(discount)).toEqual(discount);
+  });
+
+  it("validates type enum", () => {
+    expect(() => QuoteDiscountSchema.parse({ ...discount, type: "fixed" })).toThrow();
+  });
+});
+
+describe("QuoteItemSchema", () => {
+  it("parses a valid item", () => {
+    expect(QuoteItemSchema.parse(item)).toEqual(item);
+  });
+
+  it("parses an item with discount", () => {
+    const result = QuoteItemSchema.parse({ ...item, discount });
+    expect(result.discount).toEqual(discount);
+  });
+
+  it("strips unknown fields from nested amounts", () => {
+    const result = QuoteItemSchema.parse({
+      ...item,
+      unit_price: { ...amount, extra: true },
+    });
+    expect(result.unit_price).not.toHaveProperty("extra");
+  });
+});
+
+describe("QuoteAddressSchema", () => {
+  it("parses a valid address", () => {
+    expect(QuoteAddressSchema.parse(address)).toEqual(address);
+  });
+
+  it("parses with all nulls", () => {
+    const allNull = { street_address: null, city: null, zip_code: null, province_code: null, country_code: null };
+    expect(QuoteAddressSchema.parse(allNull)).toEqual(allNull);
+  });
+});
+
+describe("QuoteClientSchema", () => {
+  it("parses a valid client", () => {
+    expect(QuoteClientSchema.parse(client)).toEqual(client);
+  });
+
+  it("validates type enum", () => {
+    for (const type of ["individual", "company", "freelancer"]) {
+      expect(() => QuoteClientSchema.parse({ ...client, type })).not.toThrow();
+    }
+    expect(() => QuoteClientSchema.parse({ ...client, type: "other" })).toThrow();
+  });
+
+  it("strips unknown fields from nested address", () => {
+    const result = QuoteClientSchema.parse({
+      ...client,
+      billing_address: { ...address, extra: true },
+    });
+    expect(result.billing_address).not.toHaveProperty("extra");
+  });
+});
+
+describe("QuoteSchema", () => {
+  it("parses a valid quote", () => {
+    const result = QuoteSchema.parse(validQuote);
+    expect(result).toEqual(validQuote);
+  });
+
+  it("validates status enum", () => {
+    for (const status of ["pending_approval", "approved", "canceled"]) {
+      expect(() => QuoteSchema.parse({ ...validQuote, status })).not.toThrow();
+    }
+    expect(() => QuoteSchema.parse({ ...validQuote, status: "draft" })).toThrow();
+  });
+
+  it("strips unknown fields from top level and nested structures", () => {
+    const result = QuoteSchema.parse({
+      ...validQuote,
+      extra: true,
+      client: { ...client, extra: true },
+      items: [{ ...item, extra: true }],
+    });
+    expect(result).not.toHaveProperty("extra");
+    expect(result.client).not.toHaveProperty("extra");
+    expect(result.items[0]).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => QuoteSchema.parse({ id: "quote-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/quote.schema.ts
+++ b/packages/core/src/types/quote.schema.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { Quote, QuoteAddress, QuoteAmount, QuoteClient, QuoteDiscount, QuoteItem } from "./quote.js";
+
+export const QuoteAmountSchema = z
+  .object({
+    value: z.string(),
+    currency: z.string(),
+  })
+  .strip() satisfies z.ZodType<QuoteAmount>;
+
+export const QuoteDiscountSchema = z
+  .object({
+    type: z.enum(["percentage", "amount"]),
+    value: z.string(),
+    amount: QuoteAmountSchema,
+    amount_cents: z.number(),
+  })
+  .strip() satisfies z.ZodType<QuoteDiscount>;
+
+export const QuoteItemSchema = z
+  .object({
+    title: z.string(),
+    description: z.string().nullable(),
+    quantity: z.string(),
+    unit: z.string().nullable(),
+    vat_rate: z.string(),
+    vat_exemption_reason: z.string().nullable(),
+    unit_price: QuoteAmountSchema,
+    unit_price_cents: z.number(),
+    total_amount: QuoteAmountSchema,
+    total_amount_cents: z.number(),
+    total_vat: QuoteAmountSchema,
+    total_vat_cents: z.number(),
+    subtotal: QuoteAmountSchema,
+    subtotal_cents: z.number(),
+    discount: QuoteDiscountSchema.nullable(),
+  })
+  .strip() satisfies z.ZodType<QuoteItem>;
+
+export const QuoteAddressSchema = z
+  .object({
+    street_address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable(),
+    country_code: z.string().nullable(),
+  })
+  .strip() satisfies z.ZodType<QuoteAddress>;
+
+export const QuoteClientSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(["individual", "company", "freelancer"]),
+    name: z.string().nullable(),
+    first_name: z.string().nullable(),
+    last_name: z.string().nullable(),
+    email: z.string().nullable(),
+    vat_number: z.string().nullable(),
+    tax_identification_number: z.string().nullable(),
+    address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable(),
+    country_code: z.string().nullable(),
+    recipient_code: z.string().nullable(),
+    locale: z.string().nullable(),
+    billing_address: QuoteAddressSchema.nullable(),
+    delivery_address: QuoteAddressSchema.nullable(),
+  })
+  .strip() satisfies z.ZodType<QuoteClient>;
+
+export const QuoteSchema = z
+  .object({
+    id: z.string(),
+    organization_id: z.string(),
+    number: z.string(),
+    status: z.enum(["pending_approval", "approved", "canceled"]),
+    currency: z.string(),
+    total_amount: QuoteAmountSchema,
+    total_amount_cents: z.number(),
+    vat_amount: QuoteAmountSchema,
+    vat_amount_cents: z.number(),
+    issue_date: z.string(),
+    expiry_date: z.string(),
+    created_at: z.string(),
+    approved_at: z.string().nullable(),
+    canceled_at: z.string().nullable(),
+    attachment_id: z.string().nullable(),
+    quote_url: z.string().nullable(),
+    contact_email: z.string().nullable(),
+    terms_and_conditions: z.string().nullable(),
+    header: z.string().nullable(),
+    footer: z.string().nullable(),
+    discount: QuoteDiscountSchema.nullable(),
+    items: z.array(QuoteItemSchema).readonly(),
+    client: QuoteClientSchema,
+    invoice_ids: z.array(z.string()).readonly(),
+  })
+  .strip() satisfies z.ZodType<Quote>;

--- a/packages/core/src/types/team.schema.test.ts
+++ b/packages/core/src/types/team.schema.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { TeamSchema } from "./team.schema.js";
+
+describe("TeamSchema", () => {
+  const validTeam = {
+    id: "team-1",
+    name: "Engineering",
+  };
+
+  it("parses a valid team", () => {
+    const result = TeamSchema.parse(validTeam);
+    expect(result).toEqual(validTeam);
+  });
+
+  it("strips unknown fields", () => {
+    const result = TeamSchema.parse({ ...validTeam, extra: true });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => TeamSchema.parse({ id: "team-1" })).toThrow();
+  });
+});

--- a/packages/core/src/types/team.schema.ts
+++ b/packages/core/src/types/team.schema.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import type { Team } from "./team.js";
+
+export const TeamSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+  })
+  .strip() satisfies z.ZodType<Team>;


### PR DESCRIPTION
## Summary

Closes #241

- Define Zod schemas for all shared response types: `LabelSchema`, `MembershipSchema`, `ClientSchema`/`ClientAddressSchema`, `TeamSchema`, `QuoteSchema` (+ Amount/Discount/Item/Address/Client), `CreditNoteSchema` (+ Amount/Item/Client), `EInvoicingSettingsSchema`
- Define `OrganizationSchema`, `BankAccountSchema`, `PaginationMetaSchema` for api-types
- All schemas use `satisfies z.ZodType<T>` for compile-time type sync and `.strip()` for unknown field removal
- 56 new tests validating parse, strip, enum, and rejection behavior
- Schemas exported from `@qontoctl/core` for MCP tool consumption in Phase 4

## Test plan

- [x] `pnpm build` — compiles without errors
- [x] `pnpm test` — 347 core tests pass (56 new schema tests)
- [x] `pnpm lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)