### PR TITLE
(fix) hoist zod to root node_modules for ESM resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 auto-install-peers=true
+public-hoist-pattern[]=*zod*


### PR DESCRIPTION
## Summary

- Add `public-hoist-pattern[]=*zod*` to `.npmrc` so pnpm hoists zod to the root `node_modules`, ensuring it resolves from all workspace packages via standard Node.js ESM module resolution

## Problem

`ERR_MODULE_NOT_FOUND: Cannot find package 'zod'` when executing compiled schemas that `import { z } from "zod"`. In pnpm's strict isolation mode (default), zod was only accessible from `packages/core/node_modules/zod` — not from the root or other package resolution contexts.

## Fix

`public-hoist-pattern[]=*zod*` ensures zod is symlinked at the root `node_modules/` level, making it resolvable from any file path in the workspace via Node.js's upward `node_modules` walk.

## Verification

- `node -e "import('zod')"` from root: previously `ERR_MODULE_NOT_FOUND`, now resolves successfully
- CLI binary: loads zod-dependent schemas without errors
- Build, lint, license-check: all pass

Closes #253

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] `pnpm lint` passes
- [x] `pnpm license-check` passes
- [x] `node -e "import('zod')"` resolves from root context
- [x] CLI binary executes without `ERR_MODULE_NOT_FOUND`

🤖 Generated with [Claude Code](https://claude.com/claude-code)