### PR TITLE
(test) add nullable field coverage for schema tests

### DIFF
--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -166,6 +166,35 @@ describe("ClientInvoiceClientSchema", () => {
     expect(ClientInvoiceClientSchema.parse(client)).toEqual(client);
   });
 
+  it("accepts all nullable fields set to null", () => {
+    const result = ClientInvoiceClientSchema.parse({
+      ...validClient,
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: null,
+      vat_number: null,
+      tax_identification_number: null,
+      address: null,
+      city: null,
+      zip_code: null,
+      province_code: null,
+      country_code: null,
+      recipient_code: null,
+      locale: null,
+      billing_address: null,
+      delivery_address: null,
+    });
+    expect(result.name).toBeNull();
+    expect(result.email).toBeNull();
+    expect(result.vat_number).toBeNull();
+    expect(result.address).toBeNull();
+    expect(result.city).toBeNull();
+    expect(result.zip_code).toBeNull();
+    expect(result.country_code).toBeNull();
+    expect(result.locale).toBeNull();
+  });
+
   it("rejects invalid client type", () => {
     expect(() => ClientInvoiceClientSchema.parse({ ...validClient, type: "unknown" })).toThrow();
   });
@@ -260,6 +289,25 @@ describe("ClientInvoiceSchema", () => {
 
   it("rejects invalid status", () => {
     expect(() => ClientInvoiceSchema.parse({ ...validInvoice, status: "unknown" })).toThrow();
+  });
+
+  it("accepts all nullable fields set to null", () => {
+    const result = ClientInvoiceSchema.parse({
+      ...validInvoice,
+      invoice_number: null,
+      issue_date: null,
+      due_date: null,
+      attachment_id: null,
+      contact_email: null,
+      terms_and_conditions: null,
+      header: null,
+      footer: null,
+      discount: null,
+    });
+    expect(result.invoice_number).toBeNull();
+    expect(result.issue_date).toBeNull();
+    expect(result.due_date).toBeNull();
+    expect(result.contact_email).toBeNull();
   });
 
   it("strips unknown fields from nested objects", () => {

--- a/packages/core/src/types/client.schema.test.ts
+++ b/packages/core/src/types/client.schema.test.ts
@@ -86,6 +86,37 @@ describe("ClientSchema", () => {
     expect(result.billing_address).not.toHaveProperty("extra");
   });
 
+  it("accepts all nullable fields set to null", () => {
+    const result = ClientSchema.parse({
+      ...validClient,
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: null,
+      vat_number: null,
+      tax_identification_number: null,
+      address: null,
+      city: null,
+      zip_code: null,
+      province_code: null,
+      country_code: null,
+      billing_address: null,
+      delivery_address: null,
+      locale: null,
+      currency: null,
+    });
+    expect(result.name).toBeNull();
+    expect(result.email).toBeNull();
+    expect(result.vat_number).toBeNull();
+    expect(result.address).toBeNull();
+    expect(result.city).toBeNull();
+    expect(result.zip_code).toBeNull();
+    expect(result.country_code).toBeNull();
+    expect(result.billing_address).toBeNull();
+    expect(result.locale).toBeNull();
+    expect(result.currency).toBeNull();
+  });
+
   it("rejects missing required fields", () => {
     expect(() => ClientSchema.parse({ id: "client-1" })).toThrow();
   });

--- a/packages/core/src/types/quote.schema.test.ts
+++ b/packages/core/src/types/quote.schema.test.ts
@@ -156,6 +156,36 @@ describe("QuoteClientSchema", () => {
     expect(() => QuoteClientSchema.parse({ ...client, type: "other" })).toThrow();
   });
 
+  it("accepts all nullable fields set to null", () => {
+    const result = QuoteClientSchema.parse({
+      ...client,
+      name: null,
+      first_name: null,
+      last_name: null,
+      email: null,
+      vat_number: null,
+      tax_identification_number: null,
+      address: null,
+      city: null,
+      zip_code: null,
+      province_code: null,
+      country_code: null,
+      recipient_code: null,
+      locale: null,
+      billing_address: null,
+      delivery_address: null,
+    });
+    expect(result.name).toBeNull();
+    expect(result.email).toBeNull();
+    expect(result.vat_number).toBeNull();
+    expect(result.address).toBeNull();
+    expect(result.city).toBeNull();
+    expect(result.zip_code).toBeNull();
+    expect(result.country_code).toBeNull();
+    expect(result.locale).toBeNull();
+    expect(result.billing_address).toBeNull();
+  });
+
   it("strips unknown fields from nested address", () => {
     const result = QuoteClientSchema.parse({
       ...client,
@@ -188,6 +218,23 @@ describe("QuoteSchema", () => {
     expect(result).not.toHaveProperty("extra");
     expect(result.client).not.toHaveProperty("extra");
     expect(result.items[0]).not.toHaveProperty("extra");
+  });
+
+  it("accepts all nullable fields set to null", () => {
+    const result = QuoteSchema.parse({
+      ...validQuote,
+      approved_at: null,
+      canceled_at: null,
+      attachment_id: null,
+      quote_url: null,
+      contact_email: null,
+      terms_and_conditions: null,
+      header: null,
+      footer: null,
+      discount: null,
+    });
+    expect(result.contact_email).toBeNull();
+    expect(result.terms_and_conditions).toBeNull();
   });
 
   it("rejects missing required fields", () => {


### PR DESCRIPTION
## Summary

- Add comprehensive nullable field test coverage for `ClientSchema`, `QuoteClientSchema`, `QuoteSchema`, `ClientInvoiceClientSchema`, and `ClientInvoiceSchema`
- Each schema now has a dedicated test that sets **all** nullable fields to `null` simultaneously, catching future regressions from schema drift

## Test plan

- [x] `pnpm test` — all 10 test suites pass (434 CLI tests, all core schema tests green)
- [x] `pnpm lint` — no lint errors
- [x] Verified each new test exercises fields that were previously only tested with non-null values

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)