### PR TITLE
(fix) correct attachment file_size type to match API response

### DIFF
--- a/packages/cli/src/commands/attachment.test.ts
+++ b/packages/cli/src/commands/attachment.test.ts
@@ -15,7 +15,7 @@ import { HttpClient } from "@qontoctl/core";
 const sampleAttachment = {
   id: "att-123",
   file_name: "invoice.pdf",
-  file_size: 12345,
+  file_size: "12345",
   file_content_type: "application/pdf",
   url: "https://example.com/attachments/att-123",
   created_at: "2026-03-01T10:00:00Z",
@@ -74,7 +74,7 @@ describe("attachment commands", () => {
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", "att-123");
       expect(parsed).toHaveProperty("file_name", "invoice.pdf");
-      expect(parsed).toHaveProperty("file_size", 12345);
+      expect(parsed).toHaveProperty("file_size", "12345");
       expect(parsed).toHaveProperty("file_content_type", "application/pdf");
     });
 

--- a/packages/cli/src/commands/transaction/attachment.test.ts
+++ b/packages/cli/src/commands/transaction/attachment.test.ts
@@ -14,7 +14,7 @@ import { HttpClient } from "@qontoctl/core";
 const sampleAttachment = {
   id: "att-123",
   file_name: "receipt.png",
-  file_size: 5678,
+  file_size: "5678",
   file_content_type: "image/png",
   url: "https://example.com/attachments/att-123",
   created_at: "2026-03-01T10:00:00Z",

--- a/packages/core/src/attachments/schemas.test.ts
+++ b/packages/core/src/attachments/schemas.test.ts
@@ -9,7 +9,7 @@ describe("AttachmentSchema", () => {
   const validAttachment = {
     id: "att-1",
     file_name: "invoice.pdf",
-    file_size: 12345,
+    file_size: "12345",
     file_content_type: "application/pdf",
     url: "https://example.com/attachments/att-1",
     created_at: "2026-03-01T10:00:00Z",
@@ -32,7 +32,8 @@ describe("AttachmentSchema", () => {
     expect(() => AttachmentSchema.parse(withoutId)).toThrow(z.ZodError);
   });
 
-  it("rejects when field has wrong type", () => {
-    expect(() => AttachmentSchema.parse({ ...validAttachment, file_size: "not-a-number" })).toThrow(z.ZodError);
+  it("coerces numeric file_size to string", () => {
+    const result = AttachmentSchema.parse({ ...validAttachment, file_size: 12345 });
+    expect(result.file_size).toBe("12345");
   });
 });

--- a/packages/core/src/attachments/schemas.ts
+++ b/packages/core/src/attachments/schemas.ts
@@ -10,7 +10,7 @@ import type { Attachment } from "./types.js";
 export const AttachmentSchema = z.object({
   id: z.string(),
   file_name: z.string(),
-  file_size: z.number(),
+  file_size: z.coerce.string(),
   file_content_type: z.string(),
   url: z.string(),
   created_at: z.string(),

--- a/packages/core/src/attachments/service.test.ts
+++ b/packages/core/src/attachments/service.test.ts
@@ -16,7 +16,7 @@ import {
 const sampleAttachment = {
   id: "att-1",
   file_name: "invoice.pdf",
-  file_size: 12345,
+  file_size: "12345",
   file_content_type: "application/pdf",
   url: "https://example.com/attachments/att-1",
   created_at: "2026-03-01T10:00:00Z",

--- a/packages/core/src/attachments/types.ts
+++ b/packages/core/src/attachments/types.ts
@@ -7,7 +7,7 @@
 export interface Attachment {
   readonly id: string;
   readonly file_name: string;
-  readonly file_size: number;
+  readonly file_size: string;
   readonly file_content_type: string;
   readonly url: string;
   readonly created_at: string;

--- a/packages/mcp/src/tools/attachment.test.ts
+++ b/packages/mcp/src/tools/attachment.test.ts
@@ -11,7 +11,7 @@ function makeAttachment(overrides: Record<string, unknown> = {}) {
     id: "att-1",
     created_at: "2026-01-15T10:00:00Z",
     file_name: "receipt.pdf",
-    file_size: 12345,
+    file_size: "12345",
     file_content_type: "application/pdf",
     url: "https://example.com/files/receipt.pdf",
     ...overrides,


### PR DESCRIPTION
## Summary

- Change `file_size` in attachment schema from `z.number()` to `z.coerce.string()` to match actual Qonto API responses
- Update `Attachment` type interface (`number` → `string`)
- Update test fixtures across core, CLI, and MCP packages to use string values
- Add coercion test (numeric → string) matching the established statements pattern

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)