### PR TITLE
(test) add schema validation to E2E tests for all domains

### DIFF
--- a/packages/core/src/types/client.schema.ts
+++ b/packages/core/src/types/client.schema.ts
@@ -8,11 +8,11 @@ import type { Client, ClientAddress } from "./client.js";
 
 export const ClientAddressSchema = z
   .object({
-    street_address: z.string().nullable(),
-    city: z.string().nullable(),
-    zip_code: z.string().nullable(),
-    province_code: z.string().nullable(),
-    country_code: z.string().nullable(),
+    street_address: z.string().nullable().optional(),
+    city: z.string().nullable().optional(),
+    zip_code: z.string().nullable().optional(),
+    province_code: z.string().nullable().optional(),
+    country_code: z.string().nullable().optional(),
   })
   .strip() satisfies z.ZodType<ClientAddress>;
 
@@ -21,8 +21,8 @@ export const ClientSchema = z
     id: z.string(),
     type: z.string().optional(),
     name: z.string().nullable(),
-    first_name: z.string().nullable(),
-    last_name: z.string().nullable(),
+    first_name: z.string().nullable().optional(),
+    last_name: z.string().nullable().optional(),
     kind: z.enum(["company", "individual", "freelancer"]),
     email: z.string().nullable(),
     vat_number: z.string().nullable().optional(),

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -5,11 +5,11 @@
  * Address associated with a client (billing or delivery).
  */
 export interface ClientAddress {
-  readonly street_address: string | null;
-  readonly city: string | null;
-  readonly zip_code: string | null;
-  readonly province_code: string | null;
-  readonly country_code: string | null;
+  readonly street_address?: string | null | undefined;
+  readonly city?: string | null | undefined;
+  readonly zip_code?: string | null | undefined;
+  readonly province_code?: string | null | undefined;
+  readonly country_code?: string | null | undefined;
 }
 
 /**
@@ -19,8 +19,8 @@ export interface Client {
   readonly id: string;
   readonly type?: string | undefined;
   readonly name: string | null;
-  readonly first_name: string | null;
-  readonly last_name: string | null;
+  readonly first_name?: string | null | undefined;
+  readonly last_name?: string | null | undefined;
   readonly kind: "company" | "individual" | "freelancer";
   readonly email: string | null;
   readonly vat_number?: string | null | undefined;

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -63,6 +64,7 @@ describe.skipIf(!hasCredentials())("bulk-transfer CLI commands (e2e)", () => {
       if (first === undefined) return;
 
       const bt = cliJson<BulkTransferItem>("bulk-transfer", "show", first.id);
+      BulkTransferSchema.parse(bt);
       expect(bt.id).toBe(first.id);
       expect(bt).toHaveProperty("total_count");
       expect(bt).toHaveProperty("completed_count");

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -68,6 +69,7 @@ describe.skipIf(!hasCredentials())("bulk-transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const parsed = JSON.parse(textContent.text) as BulkTransferListResponse;
+      BulkTransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("bulk_transfers");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.bulk_transfers)).toBe(true);
@@ -116,6 +118,7 @@ describe.skipIf(!hasCredentials())("bulk-transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const bt = JSON.parse(textContent.text) as BulkTransferItem;
+      BulkTransferSchema.parse(bt);
       expect(bt.id).toBe(first.id);
       expect(bt).toHaveProperty("total_count");
     });

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { ClientInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -126,6 +127,7 @@ describe.skipIf(!hasCredentials())("client-invoice commands (e2e)", () => {
       const invoiceId = (invoices[0] as { id: string }).id;
       const output = cli("--output", "json", "client-invoice", "show", invoiceId);
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      ClientInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
     });

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ClientInvoiceListResponseSchema, ClientInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("MCP client invoice tools (e2e)", () => {
         client_invoices: unknown[];
         meta: Record<string, unknown>;
       };
+      ClientInvoiceListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("client_invoices");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.client_invoices)).toBe(true);
@@ -77,6 +79,7 @@ describe.skipIf(!hasCredentials())("MCP client invoice tools (e2e)", () => {
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      ClientInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
       expect(parsed).toHaveProperty("items");

--- a/packages/e2e/src/clients/cli.e2e.test.ts
+++ b/packages/e2e/src/clients/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { ClientSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("client commands (e2e)", () => {
         "FR",
       );
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      ClientSchema.parse(parsed);
       expect(parsed).toHaveProperty("id");
       expect(parsed).toHaveProperty("name", "E2E Test Client");
       expect(parsed).toHaveProperty("kind", "company");

--- a/packages/e2e/src/clients/mcp.e2e.test.ts
+++ b/packages/e2e/src/clients/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ClientListResponseSchema, ClientSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("MCP client tools (e2e)", () => {
         clients: unknown[];
         meta: Record<string, unknown>;
       };
+      ClientListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("clients");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.clients)).toBe(true);
@@ -77,6 +79,7 @@ describe.skipIf(!hasCredentials())("MCP client tools (e2e)", () => {
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      ClientSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", clientId);
       expect(parsed).toHaveProperty("name");
       expect(parsed).toHaveProperty("type");

--- a/packages/e2e/src/commands/beneficiary.e2e.test.ts
+++ b/packages/e2e/src/commands/beneficiary.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { BeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -56,6 +57,7 @@ describe.skipIf(!hasCredentials())("beneficiary commands (e2e)", () => {
       const beneficiaryId = (first as { id: string }).id;
       const output = cli("--output", "json", "beneficiary", "show", beneficiaryId);
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      BeneficiarySchema.parse(parsed);
       expect(parsed).toHaveProperty("id", beneficiaryId);
       expect(parsed).toHaveProperty("name");
       expect(parsed).toHaveProperty("iban");

--- a/packages/e2e/src/commands/credit-note.e2e.test.ts
+++ b/packages/e2e/src/commands/credit-note.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { CreditNoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -47,6 +48,7 @@ describe.skipIf(!hasCredentials())("credit-note commands (e2e)", () => {
       const creditNoteId = (firstCreditNote as { id: string }).id;
       const output = cli("--output", "json", "credit-note", "show", creditNoteId);
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      CreditNoteSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", creditNoteId);
       expect(parsed).toHaveProperty("number");
       expect(parsed).toHaveProperty("currency");

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { LabelSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -57,6 +58,7 @@ describe.skipIf(!hasCredentials())("label commands (e2e)", () => {
       expect(parsed).toHaveLength(1);
 
       const label = parsed[0] as Record<string, unknown>;
+      LabelSchema.parse(label);
       expect(label).toHaveProperty("id", labelId);
       expect(label).toHaveProperty("name");
       expect(label).toHaveProperty("parent_id");

--- a/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { BeneficiaryListResponseSchema, BeneficiarySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -51,6 +52,7 @@ describe.skipIf(!hasCredentials())("MCP beneficiary tools (e2e)", () => {
         beneficiaries: unknown[];
         meta: Record<string, unknown>;
       };
+      BeneficiaryListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("beneficiaries");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.beneficiaries)).toBe(true);
@@ -90,6 +92,7 @@ describe.skipIf(!hasCredentials())("MCP beneficiary tools (e2e)", () => {
       });
 
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      BeneficiarySchema.parse(parsed);
       expect(parsed).toHaveProperty("id", beneficiaryId);
       expect(parsed).toHaveProperty("name");
       expect(parsed).toHaveProperty("iban");

--- a/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { LabelListResponseSchema, LabelSchema, MembershipListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -51,6 +52,7 @@ describe.skipIf(!hasCredentials())("MCP label & membership tools (e2e)", () => {
         labels: unknown[];
         meta: Record<string, unknown>;
       };
+      LabelListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("labels");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.labels)).toBe(true);
@@ -88,6 +90,7 @@ describe.skipIf(!hasCredentials())("MCP label & membership tools (e2e)", () => {
       });
 
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      LabelSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", labelId);
       expect(parsed).toHaveProperty("name");
       expect(parsed).toHaveProperty("parent_id");
@@ -105,6 +108,7 @@ describe.skipIf(!hasCredentials())("MCP label & membership tools (e2e)", () => {
         memberships: unknown[];
         meta: Record<string, unknown>;
       };
+      MembershipListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("memberships");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.memberships)).toBe(true);

--- a/packages/e2e/src/commands/mcp-requests.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-requests.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { RequestListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("MCP request tools (e2e)", () => {
         requests: unknown[];
         meta: Record<string, unknown>;
       };
+      RequestListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("requests");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.requests)).toBe(true);

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { MembershipSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -32,6 +33,7 @@ describe.skipIf(!hasCredentials())("membership commands (e2e)", () => {
       const parsed = JSON.parse(output) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
       for (const item of parsed) {
+        MembershipSchema.parse(item);
         const membership = item as Record<string, unknown>;
         expect(membership).toHaveProperty("id");
         expect(membership).toHaveProperty("first_name");

--- a/packages/e2e/src/commands/request.e2e.test.ts
+++ b/packages/e2e/src/commands/request.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { type ExecFileSyncOptionsWithStringEncoding, execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { RequestSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -43,6 +44,7 @@ describe.skipIf(!hasCredentials())("request commands (e2e)", () => {
       const parsed = JSON.parse(output) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
       for (const item of parsed) {
+        RequestSchema.parse(item);
         const request = item as Record<string, unknown>;
         expect(request).toHaveProperty("id");
         expect(request).toHaveProperty("request_type");

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -25,6 +26,7 @@ describe.skipIf(!hasCredentials())("e-invoicing CLI (e2e)", () => {
   it("einvoicing settings --output json produces valid JSON with expected fields", () => {
     const output = cli(["einvoicing", "settings", "--output", "json"]);
     const settings = JSON.parse(output) as Record<string, unknown>;
+    EInvoicingSettingsSchema.parse(settings);
     expect(settings).toHaveProperty("sending_status");
     expect(settings).toHaveProperty("receiving_status");
     expect(typeof settings["sending_status"]).toBe("string");

--- a/packages/e2e/src/einvoicing/mcp.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -42,6 +43,7 @@ describe.skipIf(!hasCredentials())("e-invoicing MCP (e2e)", () => {
     expect((content[0] as { type: string }).type).toBe("text");
 
     const settings = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    EInvoicingSettingsSchema.parse(settings);
     expect(settings).toHaveProperty("sending_status");
     expect(settings).toHaveProperty("receiving_status");
     expect(typeof settings["sending_status"]).toBe("string");

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -40,6 +41,7 @@ describe.skipIf(!hasCredentials())("organization & accounts CLI (e2e)", () => {
   it("org show --output json produces valid JSON with expected fields", () => {
     const output = cli(["org", "show", "--output", "json"]);
     const org = JSON.parse(output) as Record<string, unknown>;
+    OrganizationSchema.parse(org);
     expect(org).toHaveProperty("slug");
     expect(org).toHaveProperty("legal_name");
     expect(org).toHaveProperty("bank_accounts");
@@ -87,6 +89,7 @@ describe.skipIf(!hasCredentials())("organization & accounts CLI (e2e)", () => {
   it("account show --output json produces valid JSON object", () => {
     const output = cli(["account", "show", knownAccountId, "--output", "json"]);
     const account = JSON.parse(output) as Record<string, unknown>;
+    BankAccountSchema.parse(account);
     expect(account).toHaveProperty("id", knownAccountId);
     expect(account).toHaveProperty("name");
     expect(account).toHaveProperty("iban");

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -44,6 +45,7 @@ describe.skipIf(!hasCredentials())("organization & accounts MCP (e2e)", () => {
     expect((content[0] as { type: string }).type).toBe("text");
 
     const org = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    OrganizationSchema.parse(org);
     expect(org).toHaveProperty("slug");
     expect(org).toHaveProperty("legal_name");
     expect(org).toHaveProperty("bank_accounts");
@@ -104,6 +106,7 @@ describe.skipIf(!hasCredentials())("organization & accounts MCP (e2e)", () => {
     expect((content[0] as { type: string }).type).toBe("text");
 
     const account = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    BankAccountSchema.parse(account);
     expect(account).toHaveProperty("id", accountId);
     expect(account).toHaveProperty("name");
     expect(account).toHaveProperty("iban");

--- a/packages/e2e/src/quotes/cli.e2e.test.ts
+++ b/packages/e2e/src/quotes/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { QuoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -83,6 +84,7 @@ describe.skipIf(!hasCredentials())("quote commands (e2e)", () => {
 
       const output = cli("--output", "json", "quote", "show", createdQuoteId);
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      QuoteSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", createdQuoteId);
       expect(parsed).toHaveProperty("items");
     });

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { QuoteListResponseSchema, QuoteSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("MCP quote tools (e2e)", () => {
         quotes: unknown[];
         meta: Record<string, unknown>;
       };
+      QuoteListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("quotes");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.quotes)).toBe(true);
@@ -77,6 +79,7 @@ describe.skipIf(!hasCredentials())("MCP quote tools (e2e)", () => {
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      QuoteSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", quoteId);
       expect(parsed).toHaveProperty("status");
       expect(parsed).toHaveProperty("items");

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -78,6 +79,7 @@ describe.skipIf(!hasCredentials())("recurring-transfer CLI commands (e2e)", () =
       if (first === undefined) return;
 
       const rt = cliJson<RecurringTransferItem>("recurring-transfer", "show", first.id);
+      RecurringTransferSchema.parse(rt);
       expect(rt.id).toBe(first.id);
       expect(rt).toHaveProperty("amount");
       expect(rt).toHaveProperty("frequency");

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -69,6 +70,7 @@ describe.skipIf(!hasCredentials())("recurring-transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const parsed = JSON.parse(textContent.text) as RecurringTransferListResponse;
+      RecurringTransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("recurring_transfers");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.recurring_transfers)).toBe(true);
@@ -117,6 +119,7 @@ describe.skipIf(!hasCredentials())("recurring-transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const rt = JSON.parse(textContent.text) as RecurringTransferItem;
+      RecurringTransferSchema.parse(rt);
       expect(rt.id).toBe(first.id);
       expect(rt).toHaveProperty("amount");
       expect(rt).toHaveProperty("frequency");

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StatementListResponseSchema, StatementSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -43,6 +44,7 @@ describe.skipIf(!hasCredentials())("statement MCP tools (e2e)", () => {
         statements: Record<string, unknown>[];
         meta: Record<string, unknown>;
       };
+      StatementListResponseSchema.parse(parsed);
       expect(parsed.statements.length).toBeGreaterThan(0);
       expect(parsed.meta).toHaveProperty("current_page");
 
@@ -97,6 +99,7 @@ describe.skipIf(!hasCredentials())("statement MCP tools (e2e)", () => {
 
       const showText = (showResult.content[0] as { type: string; text: string }).text;
       const showParsed = JSON.parse(showText) as Record<string, unknown>;
+      StatementSchema.parse(showParsed);
       expect(showParsed["id"]).toBe(statementId);
       expect(showParsed).toHaveProperty("bank_account_id");
       expect(showParsed).toHaveProperty("period");

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { SupplierInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -54,6 +55,7 @@ describe.skipIf(!hasCredentials())("supplier-invoice commands (e2e)", () => {
       const invoiceId = (firstInvoice as { id: string }).id;
       const output = cli("--output", "json", "supplier-invoice", "show", invoiceId);
       const parsed = JSON.parse(output) as Record<string, unknown>;
+      SupplierInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
     });

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SupplierInvoiceListResponseSchema, SupplierInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -48,6 +49,7 @@ describe.skipIf(!hasCredentials())("MCP supplier invoice tools (e2e)", () => {
         supplier_invoices: unknown[];
         meta: Record<string, unknown>;
       };
+      SupplierInvoiceListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("supplier_invoices");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.supplier_invoices)).toBe(true);
@@ -83,6 +85,7 @@ describe.skipIf(!hasCredentials())("MCP supplier invoice tools (e2e)", () => {
       });
 
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      SupplierInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
     });

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { TransactionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -55,6 +56,7 @@ describe.skipIf(!hasCredentials())("transaction CLI commands (e2e)", () => {
       expect(Array.isArray(transactions)).toBe(true);
       const txn = firstTransaction(transactions);
       if (txn !== undefined) {
+        TransactionSchema.parse(txn);
         expect(txn).toHaveProperty("id");
         expect(txn).toHaveProperty("amount");
         expect(txn).toHaveProperty("side");
@@ -226,6 +228,7 @@ describe.skipIf(!hasCredentials())("transaction CLI commands (e2e)", () => {
 
       const txnId = first.id;
       const transaction = cliJson<TransactionItem>("transaction", "show", txnId);
+      TransactionSchema.parse(transaction);
       expect(transaction.id).toBe(txnId);
       expect(transaction).toHaveProperty("amount");
       expect(transaction).toHaveProperty("side");

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { TransactionListResponseSchema, TransactionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -70,6 +71,7 @@ describe.skipIf(!hasCredentials())("transaction MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      TransactionListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("transactions");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.transactions)).toBe(true);
@@ -200,6 +202,7 @@ describe.skipIf(!hasCredentials())("transaction MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const transaction = JSON.parse(textContent.text) as TransactionItem;
+      TransactionSchema.parse(transaction);
       expect(transaction.id).toBe(txnId);
       expect(transaction).toHaveProperty("amount");
       expect(transaction).toHaveProperty("side");

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -3,6 +3,7 @@
 
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -49,6 +50,7 @@ describe.skipIf(!hasCredentials())("transfer CLI commands (e2e)", () => {
       expect(Array.isArray(transfers)).toBe(true);
       const t = firstTransfer(transfers);
       if (t !== undefined) {
+        TransferSchema.parse(t);
         expect(t).toHaveProperty("id");
         expect(t).toHaveProperty("amount");
         expect(t).toHaveProperty("beneficiary_id");
@@ -100,6 +102,7 @@ describe.skipIf(!hasCredentials())("transfer CLI commands (e2e)", () => {
 
       const transferId = first.id;
       const transfer = cliJson<TransferItem>("transfer", "show", transferId);
+      TransferSchema.parse(transfer);
       expect(transfer.id).toBe(transferId);
       expect(transfer).toHaveProperty("amount");
       expect(transfer).toHaveProperty("beneficiary_id");

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -4,6 +4,7 @@
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { cliEnv, hasCredentials } from "../sandbox.js";
 
@@ -69,6 +70,7 @@ describe.skipIf(!hasCredentials())("transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const parsed = JSON.parse(textContent.text) as TransferListResponse;
+      TransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("transfers");
       expect(parsed).toHaveProperty("meta");
       expect(Array.isArray(parsed.transfers)).toBe(true);
@@ -134,6 +136,7 @@ describe.skipIf(!hasCredentials())("transfer MCP tools (e2e)", () => {
       expect(textContent.type).toBe("text");
 
       const transfer = JSON.parse(textContent.text) as TransferItem;
+      TransferSchema.parse(transfer);
       expect(transfer.id).toBe(transferId);
       expect(transfer).toHaveProperty("amount");
       expect(transfer).toHaveProperty("beneficiary_id");


### PR DESCRIPTION
## Summary

- Add Zod schema `.parse()` calls to E2E tests across all 16 domains (transactions, statements, client-invoices, supplier-invoices, beneficiaries, transfers, recurring-transfers, bulk-transfers, clients, memberships, labels, quotes, requests, credit-notes, einvoicing, org/accounts)
- Fix `ClientAddressSchema` and `ClientSchema` where `first_name`, `last_name`, and address fields were marked required but the API omits them when not provided
- MCP tests validate full list response schemas (`*ListResponseSchema`) and individual entity schemas; CLI tests validate entity schemas on JSON output

Closes #265

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (unit tests)
- [x] `pnpm test:e2e` passes — 159 passed, 5 skipped (all schema `.parse()` calls exercised against live API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)