### PR TITLE
(test) add E2E tests for auth commands (#274)

### DIFF
--- a/packages/e2e/src/auth/auth.e2e.test.ts
+++ b/packages/e2e/src/auth/auth.e2e.test.ts
@@ -49,9 +49,7 @@ describe("auth commands (e2e)", () => {
     it("--help includes setup guide URL", () => {
       const { stdout, exitCode } = cli(["auth", "setup", "--help"]);
       expect(exitCode).toBe(0);
-      expect(stdout).toContain(
-        "https://github.com/alexey-pelykh/qontoctl/blob/main/docs/oauth-setup.md",
-      );
+      expect(stdout).toContain("https://github.com/alexey-pelykh/qontoctl/blob/main/docs/oauth-setup.md");
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds E2E tests for auth CLI commands: `auth setup --help`, `auth status`, `auth refresh`, and `auth revoke`
- Structural tests use isolated temp directories with fake OAuth configs — no real credentials needed
- Tests cover: help text URL, not-logged-in status, active/expired token display, missing refresh token error, and token clearing on revoke
- Documents `auth setup`, `auth login`, and `auth refresh` happy path as deferred (require TTY/browser/real OAuth)

Closes #274

## Test plan
- [x] All 6 E2E tests pass locally (`pnpm exec vitest run --config vitest.e2e.config.ts packages/e2e/src/auth/auth.e2e.test.ts`)
- [x] Unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [ ] CI passes on all 3 OS matrix (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)