### PR TITLE
(test) add CLI command tree contract test (#271)

### DIFF
--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,8 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import type { Command } from "commander";
 import { describe, it, expect } from "vitest";
 import { createProgram } from "./program.js";
+
+/**
+ * Find a subcommand by name, throwing if absent so tests fail with a clear message.
+ */
+function findCommand(parent: Command, name: string): Command {
+  const cmd = parent.commands.find((c) => c.name() === name);
+  if (cmd === undefined) {
+    throw new Error(`Expected command "${name}" not found among: ${parent.commands.map((c) => c.name()).join(", ")}`);
+  }
+  return cmd;
+}
 
 /**
  * Parse global options without requiring a subcommand.
@@ -27,17 +39,199 @@ describe("createProgram", () => {
     expect(program.name()).toBe("qontoctl");
   });
 
-  it("registers org and account subcommands", () => {
-    const program = createProgram();
-    const names = program.commands.map((c) => c.name());
-    expect(names).toContain("org");
-    expect(names).toContain("account");
-  });
+  describe("command tree registration", () => {
+    it("registers all expected top-level commands", () => {
+      const program = createProgram();
+      const names = program.commands.map((c) => c.name());
 
-  it("registers completion subcommand", () => {
-    const program = createProgram();
-    const names = program.commands.map((c) => c.name());
-    expect(names).toContain("completion");
+      expect(names).toContain("completion");
+      expect(names).toContain("beneficiary");
+      expect(names).toContain("card");
+      expect(names).toContain("einvoicing");
+      expect(names).toContain("auth");
+      expect(names).toContain("transaction");
+      expect(names).toContain("bulk-transfer");
+      expect(names).toContain("recurring-transfer");
+      expect(names).toContain("org");
+      expect(names).toContain("account");
+      expect(names).toContain("supplier-invoice");
+      expect(names).toContain("team");
+      expect(program.commands).toHaveLength(12);
+    });
+
+    it("commands have descriptions", () => {
+      const program = createProgram();
+
+      for (const cmd of program.commands) {
+        expect(cmd.description(), `Command "${cmd.name()}" should have a description`).toBeTruthy();
+      }
+    });
+
+    it("registers expected completion subcommands", () => {
+      const program = createProgram();
+      const completion = findCommand(program, "completion");
+      const names = completion.commands.map((c) => c.name());
+
+      expect(names).toContain("bash");
+      expect(names).toContain("zsh");
+      expect(names).toContain("fish");
+      expect(completion.commands).toHaveLength(3);
+    });
+
+    it("registers expected beneficiary subcommands", () => {
+      const program = createProgram();
+      const beneficiary = findCommand(program, "beneficiary");
+      const names = beneficiary.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("add");
+      expect(names).toContain("update");
+      expect(names).toContain("trust");
+      expect(names).toContain("untrust");
+      expect(beneficiary.commands).toHaveLength(6);
+    });
+
+    it("registers expected card subcommands", () => {
+      const program = createProgram();
+      const card = findCommand(program, "card");
+      const names = card.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("create");
+      expect(names).toContain("bulk-create");
+      expect(names).toContain("lock");
+      expect(names).toContain("unlock");
+      expect(names).toContain("report-lost");
+      expect(names).toContain("report-stolen");
+      expect(names).toContain("discard");
+      expect(names).toContain("update-limits");
+      expect(names).toContain("update-nickname");
+      expect(names).toContain("update-options");
+      expect(names).toContain("update-restrictions");
+      expect(names).toContain("iframe-url");
+      expect(names).toContain("appearances");
+      expect(card.commands).toHaveLength(14);
+    });
+
+    it("registers expected einvoicing subcommands", () => {
+      const program = createProgram();
+      const einvoicing = findCommand(program, "einvoicing");
+      const names = einvoicing.commands.map((c) => c.name());
+
+      expect(names).toContain("settings");
+      expect(einvoicing.commands).toHaveLength(1);
+    });
+
+    it("registers expected auth subcommands", () => {
+      const program = createProgram();
+      const auth = findCommand(program, "auth");
+      const names = auth.commands.map((c) => c.name());
+
+      expect(names).toContain("setup");
+      expect(names).toContain("login");
+      expect(names).toContain("refresh");
+      expect(names).toContain("status");
+      expect(names).toContain("revoke");
+      expect(auth.commands).toHaveLength(5);
+    });
+
+    it("registers expected transaction subcommands", () => {
+      const program = createProgram();
+      const transaction = findCommand(program, "transaction");
+      const names = transaction.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("attachment");
+      expect(transaction.commands).toHaveLength(3);
+    });
+
+    it("registers expected transaction attachment subcommands", () => {
+      const program = createProgram();
+      const transaction = findCommand(program, "transaction");
+      const attachment = findCommand(transaction, "attachment");
+      const names = attachment.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("add");
+      expect(names).toContain("remove");
+      expect(attachment.commands).toHaveLength(3);
+    });
+
+    it("registers expected bulk-transfer subcommands", () => {
+      const program = createProgram();
+      const bulkTransfer = findCommand(program, "bulk-transfer");
+      const names = bulkTransfer.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(bulkTransfer.commands).toHaveLength(2);
+    });
+
+    it("registers expected recurring-transfer subcommands", () => {
+      const program = createProgram();
+      const recurringTransfer = findCommand(program, "recurring-transfer");
+      const names = recurringTransfer.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(recurringTransfer.commands).toHaveLength(2);
+    });
+
+    it("registers expected org subcommands", () => {
+      const program = createProgram();
+      const org = findCommand(program, "org");
+      const names = org.commands.map((c) => c.name());
+
+      expect(names).toContain("show");
+      expect(org.commands).toHaveLength(1);
+    });
+
+    it("registers expected account subcommands", () => {
+      const program = createProgram();
+      const account = findCommand(program, "account");
+      const names = account.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("iban-certificate");
+      expect(names).toContain("create");
+      expect(names).toContain("update");
+      expect(names).toContain("close");
+      expect(account.commands).toHaveLength(6);
+    });
+
+    it("registers expected supplier-invoice subcommands", () => {
+      const program = createProgram();
+      const supplierInvoice = findCommand(program, "supplier-invoice");
+      const names = supplierInvoice.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("bulk-create");
+      expect(supplierInvoice.commands).toHaveLength(3);
+    });
+
+    it("registers expected team subcommands", () => {
+      const program = createProgram();
+      const team = findCommand(program, "team");
+      const names = team.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("create");
+      expect(team.commands).toHaveLength(2);
+    });
+
+    it("subcommands have descriptions", () => {
+      const program = createProgram();
+
+      for (const cmd of program.commands) {
+        for (const sub of cmd.commands) {
+          expect(sub.description(), `Subcommand "${cmd.name()} ${sub.name()}" should have a description`).toBeTruthy();
+        }
+      }
+    });
   });
 
   describe("global options", () => {

--- a/packages/qontoctl/src/cli.test.ts
+++ b/packages/qontoctl/src/cli.test.ts
@@ -1,21 +1,284 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import type { Command } from "commander";
 import { describe, expect, it } from "vitest";
-import { createProgram } from "@qontoctl/cli";
+import {
+  createAttachmentCommand,
+  createClientCommand,
+  createClientInvoiceCommand,
+  createCreditNoteCommand,
+  createInternalTransferCommand,
+  createLabelCommand,
+  createMembershipCommand,
+  createProgram,
+  createQuoteCommand,
+  createWebhookCommand,
+  registerProfileCommands,
+  registerRequestCommands,
+  registerStatementCommands,
+  registerTransferCommands,
+} from "@qontoctl/cli";
+
+/**
+ * Find a subcommand by name, throwing if absent so tests fail with a clear message.
+ */
+function findCommand(parent: Command, name: string): Command {
+  const cmd = parent.commands.find((c) => c.name() === name);
+  if (cmd === undefined) {
+    throw new Error(`Expected command "${name}" not found among: ${parent.commands.map((c) => c.name()).join(", ")}`);
+  }
+  return cmd;
+}
+
+/**
+ * Build the full umbrella program with all commands registered,
+ * mirroring packages/qontoctl/src/cli.ts without the parse/action wiring.
+ */
+function createUmbrellaProgram() {
+  const program = createProgram();
+
+  program.addCommand(createAttachmentCommand());
+  program.addCommand(createClientCommand());
+  program.addCommand(createClientInvoiceCommand());
+  program.addCommand(createCreditNoteCommand());
+  program.addCommand(createInternalTransferCommand());
+  program.addCommand(createLabelCommand());
+  program.addCommand(createMembershipCommand());
+  program.addCommand(createQuoteCommand());
+  program.addCommand(createWebhookCommand());
+  registerRequestCommands(program);
+  registerProfileCommands(program);
+  registerStatementCommands(program);
+  registerTransferCommands(program);
+
+  program.command("mcp").description("Start MCP server on stdio (for Claude Desktop, Cursor, etc.)");
+
+  return program;
+}
 
 describe("qontoctl CLI", () => {
   it("creates program with correct name", () => {
-    const program = createProgram();
+    const program = createUmbrellaProgram();
     expect(program.name()).toBe("qontoctl");
   });
 
-  it("registers mcp subcommand", () => {
-    const program = createProgram();
+  describe("command tree registration", () => {
+    it("registers all expected top-level commands", () => {
+      const program = createUmbrellaProgram();
+      const names = program.commands.map((c) => c.name());
 
-    program.command("mcp").description("Start MCP server on stdio (for Claude Desktop, Cursor, etc.)");
+      // Commands from createProgram()
+      expect(names).toContain("completion");
+      expect(names).toContain("beneficiary");
+      expect(names).toContain("card");
+      expect(names).toContain("einvoicing");
+      expect(names).toContain("auth");
+      expect(names).toContain("transaction");
+      expect(names).toContain("bulk-transfer");
+      expect(names).toContain("recurring-transfer");
+      expect(names).toContain("org");
+      expect(names).toContain("account");
+      expect(names).toContain("supplier-invoice");
+      expect(names).toContain("team");
 
-    const commandNames = program.commands.map((c) => c.name());
-    expect(commandNames).toContain("mcp");
+      // Commands added by umbrella
+      expect(names).toContain("attachment");
+      expect(names).toContain("client");
+      expect(names).toContain("client-invoice");
+      expect(names).toContain("credit-note");
+      expect(names).toContain("internal-transfer");
+      expect(names).toContain("label");
+      expect(names).toContain("membership");
+      expect(names).toContain("quote");
+      expect(names).toContain("webhook");
+      expect(names).toContain("request");
+      expect(names).toContain("profile");
+      expect(names).toContain("statement");
+      expect(names).toContain("transfer");
+      expect(names).toContain("mcp");
+      expect(program.commands).toHaveLength(26);
+    });
+
+    it("commands have descriptions", () => {
+      const program = createUmbrellaProgram();
+
+      for (const cmd of program.commands) {
+        expect(cmd.description(), `Command "${cmd.name()}" should have a description`).toBeTruthy();
+      }
+    });
+
+    it("registers expected attachment subcommands", () => {
+      const program = createUmbrellaProgram();
+      const attachment = findCommand(program, "attachment");
+      const names = attachment.commands.map((c) => c.name());
+
+      expect(names).toContain("upload");
+      expect(names).toContain("show");
+      expect(attachment.commands).toHaveLength(2);
+    });
+
+    it("registers expected client subcommands", () => {
+      const program = createUmbrellaProgram();
+      const client = findCommand(program, "client");
+      const names = client.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("create");
+      expect(names).toContain("update");
+      expect(names).toContain("delete");
+      expect(client.commands).toHaveLength(5);
+    });
+
+    it("registers expected client-invoice subcommands", () => {
+      const program = createUmbrellaProgram();
+      const clientInvoice = findCommand(program, "client-invoice");
+      const names = clientInvoice.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("create");
+      expect(names).toContain("update");
+      expect(names).toContain("delete");
+      expect(names).toContain("finalize");
+      expect(names).toContain("send");
+      expect(names).toContain("mark-paid");
+      expect(names).toContain("unmark-paid");
+      expect(names).toContain("cancel");
+      expect(names).toContain("upload");
+      expect(names).toContain("upload-show");
+      expect(clientInvoice.commands).toHaveLength(12);
+    });
+
+    it("registers expected credit-note subcommands", () => {
+      const program = createUmbrellaProgram();
+      const creditNote = findCommand(program, "credit-note");
+      const names = creditNote.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(creditNote.commands).toHaveLength(2);
+    });
+
+    it("registers expected internal-transfer subcommands", () => {
+      const program = createUmbrellaProgram();
+      const internalTransfer = findCommand(program, "internal-transfer");
+      const names = internalTransfer.commands.map((c) => c.name());
+
+      expect(names).toContain("create");
+      expect(internalTransfer.commands).toHaveLength(1);
+    });
+
+    it("registers expected label subcommands", () => {
+      const program = createUmbrellaProgram();
+      const label = findCommand(program, "label");
+      const names = label.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(label.commands).toHaveLength(2);
+    });
+
+    it("registers expected membership subcommands", () => {
+      const program = createUmbrellaProgram();
+      const membership = findCommand(program, "membership");
+      const names = membership.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("invite");
+      expect(membership.commands).toHaveLength(3);
+    });
+
+    it("registers expected quote subcommands", () => {
+      const program = createUmbrellaProgram();
+      const quote = findCommand(program, "quote");
+      const names = quote.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("create");
+      expect(names).toContain("update");
+      expect(names).toContain("delete");
+      expect(names).toContain("send");
+      expect(quote.commands).toHaveLength(6);
+    });
+
+    it("registers expected webhook subcommands", () => {
+      const program = createUmbrellaProgram();
+      const webhook = findCommand(program, "webhook");
+      const names = webhook.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("create");
+      expect(names).toContain("update");
+      expect(names).toContain("delete");
+      expect(webhook.commands).toHaveLength(5);
+    });
+
+    it("registers expected request subcommands", () => {
+      const program = createUmbrellaProgram();
+      const request = findCommand(program, "request");
+      const names = request.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("approve");
+      expect(names).toContain("decline");
+      expect(names).toContain("create-flash-card");
+      expect(names).toContain("create-virtual-card");
+      expect(names).toContain("create-multi-transfer");
+      expect(request.commands).toHaveLength(6);
+    });
+
+    it("registers expected profile subcommands", () => {
+      const program = createUmbrellaProgram();
+      const profile = findCommand(program, "profile");
+      const names = profile.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("add");
+      expect(names).toContain("remove");
+      expect(names).toContain("test");
+      expect(profile.commands).toHaveLength(5);
+    });
+
+    it("registers expected statement subcommands", () => {
+      const program = createUmbrellaProgram();
+      const statement = findCommand(program, "statement");
+      const names = statement.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("download");
+      expect(statement.commands).toHaveLength(3);
+    });
+
+    it("registers expected transfer subcommands", () => {
+      const program = createUmbrellaProgram();
+      const transfer = findCommand(program, "transfer");
+      const names = transfer.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("create");
+      expect(names).toContain("cancel");
+      expect(names).toContain("proof");
+      expect(names).toContain("verify-payee");
+      expect(names).toContain("bulk-verify-payee");
+      expect(transfer.commands).toHaveLength(7);
+    });
+
+    it("subcommands have descriptions", () => {
+      const program = createUmbrellaProgram();
+
+      for (const cmd of program.commands) {
+        for (const sub of cmd.commands) {
+          expect(sub.description(), `Subcommand "${cmd.name()} ${sub.name()}" should have a description`).toBeTruthy();
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds contract tests for the `@qontoctl/cli` command tree in `program.test.ts` — verifies all 12 top-level commands and their subcommands are registered with correct counts and non-empty descriptions
- Adds contract tests for the `qontoctl` umbrella command tree in `cli.test.ts` — verifies all 26 top-level commands (12 base + 14 umbrella-specific) and their subcommands
- Follows the existing MCP `server.test.ts` pattern: expected name list, count assertion, description non-empty check

Closes #271

## Test plan

- [x] `pnpm test` — all 450 CLI tests pass, 17 umbrella tests pass
- [x] `pnpm lint` — no errors
- [ ] CI passes on all 3 OS matrix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)