### PR TITLE
(test) add unit tests for auth login command

### DIFF
--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -13,6 +13,27 @@ vi.mock("node:readline/promises", () => ({
   })),
 }));
 
+type HttpHandler = (req: { url?: string }, res: Record<string, unknown>) => void;
+const { httpHandler, mockHttpServerClose, mockHttpServerListen, mockExec, MOCK_STATE_HEX } = vi.hoisted(() => ({
+  httpHandler: { current: undefined as HttpHandler | undefined },
+  mockHttpServerClose: vi.fn(),
+  mockHttpServerListen: vi.fn(),
+  mockExec: vi.fn(),
+  MOCK_STATE_HEX: "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8",
+}));
+vi.mock("node:http", () => ({
+  createServer: vi.fn((handler: HttpHandler) => {
+    httpHandler.current = handler;
+    return { listen: mockHttpServerListen, close: mockHttpServerClose };
+  }),
+}));
+vi.mock("node:child_process", () => ({
+  exec: mockExec,
+}));
+vi.mock("node:crypto", () => ({
+  randomBytes: vi.fn(() => Buffer.from(MOCK_STATE_HEX, "hex")),
+}));
+
 vi.mock("@qontoctl/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@qontoctl/core")>();
   return {
@@ -23,6 +44,9 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
     saveOAuthTokens: vi.fn(),
     saveOAuthClientCredentials: vi.fn(),
     clearOAuthTokens: vi.fn(),
+    generateCodeVerifier: vi.fn(),
+    generateCodeChallenge: vi.fn(),
+    exchangeCode: vi.fn(),
   };
 });
 
@@ -33,6 +57,11 @@ const {
   saveOAuthTokens,
   saveOAuthClientCredentials,
   clearOAuthTokens,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  exchangeCode,
+  OAUTH_TOKEN_URL,
+  OAUTH_TOKEN_SANDBOX_URL,
 } = await import("@qontoctl/core");
 const resolveConfigMock = vi.mocked(resolveConfig);
 const refreshAccessTokenMock = vi.mocked(refreshAccessToken);
@@ -40,6 +69,9 @@ const revokeTokenMock = vi.mocked(revokeToken);
 const saveOAuthTokensMock = vi.mocked(saveOAuthTokens);
 const saveOAuthClientCredentialsMock = vi.mocked(saveOAuthClientCredentials);
 const clearOAuthTokensMock = vi.mocked(clearOAuthTokens);
+const generateCodeVerifierMock = vi.mocked(generateCodeVerifier);
+const generateCodeChallengeMock = vi.mocked(generateCodeChallenge);
+const exchangeCodeMock = vi.mocked(exchangeCode);
 
 import { registerAuthCommands } from "./auth.js";
 
@@ -524,6 +556,310 @@ describe("registerAuthCommands", () => {
 
       expect(revokeTokenMock).not.toHaveBeenCalled();
       expect(clearOAuthTokensMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("auth login", () => {
+    const defaultOAuthConfig = {
+      config: {
+        oauth: { clientId: "test-client-id", clientSecret: "test-client-secret" },
+      },
+      endpoint: "https://thirdparty.qonto.com",
+      warnings: [] as string[],
+    };
+
+    const defaultTokenResponse = {
+      accessToken: "new-access-token",
+      refreshToken: "new-refresh-token",
+      expiresIn: 3600,
+      tokenType: "Bearer",
+    };
+
+    function callHandler(req: { url?: string }, res: Record<string, unknown>): void {
+      const handler = httpHandler.current;
+      expect(handler).toBeDefined();
+      if (handler === undefined) throw new Error("unreachable");
+      handler(req, res);
+    }
+
+    function simulateCallback(code: string, state: string): void {
+      callHandler({ url: `/callback?code=${code}&state=${state}` }, { writeHead: vi.fn(), end: vi.fn() });
+    }
+
+    function simulateCallbackError(error: string, description?: string): void {
+      const params = new URLSearchParams({ error });
+      if (description !== undefined) params.set("error_description", description);
+      callHandler({ url: `/callback?${params.toString()}` }, { writeHead: vi.fn(), end: vi.fn() });
+    }
+
+    function simulateCallbackMissingParams(): { writeHead: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> } {
+      const mockRes = { writeHead: vi.fn(), end: vi.fn() };
+      callHandler({ url: "/callback" }, mockRes);
+      return mockRes;
+    }
+
+    beforeEach(() => {
+      httpHandler.current = undefined;
+      mockHttpServerListen.mockImplementation((_port: number, _host: string, cb: () => void) => {
+        cb();
+      });
+      resolveConfigMock.mockResolvedValue(defaultOAuthConfig);
+      generateCodeVerifierMock.mockReturnValue("test-code-verifier");
+      generateCodeChallengeMock.mockReturnValue("test-code-challenge");
+      exchangeCodeMock.mockResolvedValue(defaultTokenResponse);
+      saveOAuthTokensMock.mockResolvedValue(undefined);
+    });
+
+    it("generates PKCE values and exchanges code for tokens", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(generateCodeVerifierMock).toHaveBeenCalled();
+      expect(generateCodeChallengeMock).toHaveBeenCalledWith("test-code-verifier");
+      expect(exchangeCodeMock).toHaveBeenCalledWith(
+        OAUTH_TOKEN_URL,
+        "test-client-id",
+        "test-client-secret",
+        "auth-code",
+        "http://localhost:18920/callback",
+        "test-code-verifier",
+      );
+    });
+
+    it("saves tokens with correct expiration calculation", async () => {
+      const mockNow = new Date("2026-03-23T12:00:00.000Z").getTime();
+      vi.spyOn(Date, "now").mockReturnValue(mockNow);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(
+        {
+          accessToken: "new-access-token",
+          refreshToken: "new-refresh-token",
+          tokenExpiresAt: "2026-03-23T13:00:00.000Z",
+        },
+        undefined,
+      );
+    });
+
+    it("throws on state mismatch (CSRF protection)", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", "wrong-state-value");
+
+      await expect(parsePromise).rejects.toThrow("OAuth state mismatch");
+      expect(mockHttpServerClose).toHaveBeenCalled();
+    });
+
+    it("propagates error with description from OAuth callback", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallbackError("access_denied", "User denied access");
+
+      await expect(parsePromise).rejects.toThrow("OAuth authorization failed: User denied access");
+      expect(mockHttpServerClose).toHaveBeenCalled();
+    });
+
+    it("uses error code as description when error_description is absent", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallbackError("server_error");
+
+      await expect(parsePromise).rejects.toThrow("OAuth authorization failed: server_error");
+    });
+
+    it("returns 400 when callback is missing code or state", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      const mockRes = simulateCallbackMissingParams();
+
+      await expect(parsePromise).rejects.toThrow("OAuth callback missing code or state parameter");
+      expect(mockRes.writeHead).toHaveBeenCalledWith(400, { "Content-Type": "text/html" });
+    });
+
+    it("closes server after successful login", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(mockHttpServerClose).toHaveBeenCalled();
+    });
+
+    it("closes server when login fails", async () => {
+      exchangeCodeMock.mockRejectedValue(new Error("token exchange failed"));
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+
+      await expect(parsePromise).rejects.toThrow("token exchange failed");
+      expect(mockHttpServerClose).toHaveBeenCalled();
+    });
+
+    it("uses custom port when specified", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login", "--port", "19000"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(mockHttpServerListen).toHaveBeenCalledWith(19000, "127.0.0.1", expect.any(Function));
+      expect(exchangeCodeMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        "auth-code",
+        "http://localhost:19000/callback",
+        expect.any(String),
+      );
+    });
+
+    it("uses sandbox endpoints when configured", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: { clientId: "test-client-id", clientSecret: "test-client-secret" },
+          sandbox: true,
+        },
+        endpoint: "https://thirdparty-sandbox.staging.qonto.co",
+        warnings: [],
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(exchangeCodeMock).toHaveBeenCalledWith(
+        OAUTH_TOKEN_SANDBOX_URL,
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+
+    it("omits refreshToken from saved tokens when not returned", async () => {
+      exchangeCodeMock.mockResolvedValue({
+        accessToken: "new-access-token",
+        expiresIn: 3600,
+        tokenType: "Bearer",
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(
+        expect.objectContaining({ accessToken: "new-access-token" }),
+        undefined,
+      );
+      const savedTokens = saveOAuthTokensMock.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      expect(savedTokens).toBeDefined();
+      expect(savedTokens).not.toHaveProperty("refreshToken");
+    });
+
+    it("passes profile option when specified", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.option("-p, --profile <name>", "");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login", "--profile", "work"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(expect.any(Object), { profile: "work" });
+    });
+
+    it("throws when no OAuth config", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {},
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.exitOverride();
+      registerAuthCommands(program);
+
+      await expect(program.parseAsync(["auth", "login"], { from: "user" })).rejects.toThrow(
+        "No OAuth credentials found",
+      );
+    });
+
+    it("outputs login progress messages", async () => {
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login"], { from: "user" });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      const output = stderrSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("Opening browser for authorization");
+      expect(output).toContain("Waiting for callback");
+      expect(output).toContain("Exchanging authorization code for tokens");
+      expect(output).toContain("Login successful! Tokens saved.");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds 14 unit tests for the `auth login` command, which was the only auth subcommand without test coverage
- Tests cover the full OAuth 2.0 PKCE flow: code verifier/challenge generation, authorization code exchange, token persistence, and server lifecycle
- Mocks `node:http` (callback server), `node:child_process` (browser opening), and `node:crypto` (deterministic state) using `vi.hoisted()` for proper Vitest mock hoisting

## Test plan

- [x] All 14 new tests pass locally
- [x] All 450 existing tests continue to pass (no regressions)
- [x] Lint passes clean
- [ ] CI passes on all platforms

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)