### PR TITLE
(fix) register profile commands in createProgram()

### DIFF
--- a/packages/cli/src/commands/profile/add.test.ts
+++ b/packages/cli/src/commands/profile/add.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createProgram } from "../../program.js";
-import { registerProfileCommands } from "./index.js";
 
 let mockHomeDir = "";
 let mockQuestionResponses: string[] = [];
@@ -51,7 +50,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["my-org", "sk_test_12345678"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "work"], { from: "user" });
@@ -67,7 +65,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["org-slug", "secret-key-value"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "new-profile"], { from: "user" });
@@ -85,7 +82,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["new-org", "new-key"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "existing"], { from: "user" });
@@ -98,7 +94,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["", "some-key"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
@@ -111,7 +106,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["my-org", ""];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
@@ -124,7 +118,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "secure"], { from: "user" });
@@ -137,7 +130,6 @@ describe("profile add", () => {
     mockQuestionResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "add", "secure"], { from: "user" });

--- a/packages/cli/src/commands/profile/list.test.ts
+++ b/packages/cli/src/commands/profile/list.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createProgram } from "../../program.js";
-import { registerProfileCommands } from "./index.js";
 
 let mockHomeDir = "";
 
@@ -35,7 +34,6 @@ describe("profile list", () => {
 
   it("shows 'No profiles found' when config dir does not exist", async () => {
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "list"], { from: "user" });
@@ -47,7 +45,6 @@ describe("profile list", () => {
     await mkdir(join(testHome, ".qontoctl"), { recursive: true });
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "list"], { from: "user" });
@@ -62,7 +59,6 @@ describe("profile list", () => {
     await writeFile(join(configDir, "personal.yaml"), "api-key:\n  organization-slug: org2\n  secret-key: key2\n");
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "list"], { from: "user" });
@@ -79,7 +75,6 @@ describe("profile list", () => {
     await writeFile(join(configDir, "notes.txt"), "some notes");
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "list"], { from: "user" });
@@ -95,7 +90,6 @@ describe("profile list", () => {
     await writeFile(join(configDir, "staging.yaml"), "api-key:\n  organization-slug: org\n  secret-key: key\n");
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--output", "json", "profile", "list"], { from: "user" });

--- a/packages/cli/src/commands/profile/remove.test.ts
+++ b/packages/cli/src/commands/profile/remove.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createProgram } from "../../program.js";
-import { registerProfileCommands } from "./index.js";
 
 let mockHomeDir = "";
 let mockQuestionResponses: string[] = [];
@@ -51,7 +50,6 @@ describe("profile remove", () => {
     mockQuestionResponses = ["yes"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "remove", "nonexistent"], { from: "user" });
@@ -69,7 +67,6 @@ describe("profile remove", () => {
     mockQuestionResponses = ["yes"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "remove", "work"], { from: "user" });
@@ -87,7 +84,6 @@ describe("profile remove", () => {
     mockQuestionResponses = ["no"];
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "remove", "work"], { from: "user" });

--- a/packages/cli/src/commands/profile/show.test.ts
+++ b/packages/cli/src/commands/profile/show.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createProgram } from "../../program.js";
-import { registerProfileCommands } from "./index.js";
 
 let mockHomeDir = "";
 
@@ -37,7 +36,6 @@ describe("profile show", () => {
 
   it("shows error when profile does not exist", async () => {
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "show", "nonexistent"], { from: "user" });
@@ -55,7 +53,6 @@ describe("profile show", () => {
     );
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["profile", "show", "work"], { from: "user" });
@@ -76,7 +73,6 @@ describe("profile show", () => {
     );
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--output", "json", "profile", "show", "dev"], { from: "user" });
@@ -97,7 +93,6 @@ describe("profile show", () => {
     await writeFile(join(configDir, "short.yaml"), "api-key:\n  organization-slug: org\n  secret-key: abc\n");
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--output", "json", "profile", "show", "short"], { from: "user" });

--- a/packages/cli/src/commands/profile/test.test.ts
+++ b/packages/cli/src/commands/profile/test.test.ts
@@ -7,7 +7,6 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createProgram } from "../../program.js";
-import { registerProfileCommands } from "./index.js";
 
 let mockHomeDir = "";
 
@@ -59,7 +58,6 @@ describe("profile test", () => {
     );
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--profile", "work", "profile", "test"], { from: "user" });
@@ -84,7 +82,6 @@ describe("profile test", () => {
     );
 
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--profile", "bad", "profile", "test"], { from: "user" });
@@ -95,7 +92,6 @@ describe("profile test", () => {
 
   it("reports failure when no config found", async () => {
     const program = createProgram();
-    registerProfileCommands(program);
     program.exitOverride();
 
     await program.parseAsync(["--profile", "nonexistent", "profile", "test"], { from: "user" });

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -56,7 +56,8 @@ describe("createProgram", () => {
       expect(names).toContain("account");
       expect(names).toContain("supplier-invoice");
       expect(names).toContain("team");
-      expect(program.commands).toHaveLength(12);
+      expect(names).toContain("profile");
+      expect(program.commands).toHaveLength(13);
     });
 
     it("commands have descriptions", () => {
@@ -221,6 +222,19 @@ describe("createProgram", () => {
       expect(names).toContain("list");
       expect(names).toContain("create");
       expect(team.commands).toHaveLength(2);
+    });
+
+    it("registers expected profile subcommands", () => {
+      const program = createProgram();
+      const profile = findCommand(program, "profile");
+      const names = profile.commands.map((c) => c.name());
+
+      expect(names).toContain("list");
+      expect(names).toContain("show");
+      expect(names).toContain("add");
+      expect(names).toContain("remove");
+      expect(names).toContain("test");
+      expect(profile.commands).toHaveLength(5);
     });
 
     it("subcommands have descriptions", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -15,6 +15,7 @@ import { registerAccountCommands } from "./commands/account.js";
 import { registerSupplierInvoiceCommands } from "./commands/supplier-invoice/index.js";
 import { createTeamCommand } from "./commands/team.js";
 import { registerAuthCommands } from "./commands/auth.js";
+import { registerProfileCommands } from "./commands/profile/index.js";
 import { OUTPUT_FORMATS } from "./options.js";
 
 const require = createRequire(import.meta.url);
@@ -46,6 +47,7 @@ export function createProgram(): Command {
   registerAccountCommands(program);
   registerSupplierInvoiceCommands(program);
   program.addCommand(createTeamCommand());
+  registerProfileCommands(program);
 
   program.action(() => {
     program.outputHelp();

--- a/packages/qontoctl/src/cli.test.ts
+++ b/packages/qontoctl/src/cli.test.ts
@@ -14,7 +14,6 @@ import {
   createProgram,
   createQuoteCommand,
   createWebhookCommand,
-  registerProfileCommands,
   registerRequestCommands,
   registerStatementCommands,
   registerTransferCommands,
@@ -48,7 +47,6 @@ function createUmbrellaProgram() {
   program.addCommand(createQuoteCommand());
   program.addCommand(createWebhookCommand());
   registerRequestCommands(program);
-  registerProfileCommands(program);
   registerStatementCommands(program);
   registerTransferCommands(program);
 
@@ -81,6 +79,7 @@ describe("qontoctl CLI", () => {
       expect(names).toContain("account");
       expect(names).toContain("supplier-invoice");
       expect(names).toContain("team");
+      expect(names).toContain("profile");
 
       // Commands added by umbrella
       expect(names).toContain("attachment");
@@ -93,7 +92,6 @@ describe("qontoctl CLI", () => {
       expect(names).toContain("quote");
       expect(names).toContain("webhook");
       expect(names).toContain("request");
-      expect(names).toContain("profile");
       expect(names).toContain("statement");
       expect(names).toContain("transfer");
       expect(names).toContain("mcp");

--- a/packages/qontoctl/src/cli.ts
+++ b/packages/qontoctl/src/cli.ts
@@ -16,7 +16,6 @@ import {
   createQuoteCommand,
   createWebhookCommand,
   handleCliError,
-  registerProfileCommands,
   registerRequestCommands,
   registerStatementCommands,
   registerTransferCommands,
@@ -36,7 +35,6 @@ program.addCommand(createMembershipCommand());
 program.addCommand(createQuoteCommand());
 program.addCommand(createWebhookCommand());
 registerRequestCommands(program);
-registerProfileCommands(program);
 registerStatementCommands(program);
 registerTransferCommands(program);
 


### PR DESCRIPTION
## Summary

- Move `registerProfileCommands` from the umbrella CLI (`packages/qontoctl/src/cli.ts`) to the shared `createProgram()` factory (`packages/cli/src/program.ts`) so profile commands are available to all consumers of `@qontoctl/cli`
- Remove the now-redundant `registerProfileCommands` call from the umbrella CLI and its test helper
- Update the contract test to expect 13 top-level commands (was 12) and verify profile subcommands
- Remove duplicate `registerProfileCommands` calls from all profile unit tests (was causing double-registration)

Closes #272

## Test plan

- [x] All 465 unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Contract test verifies profile commands (list, show, add, remove, test) are registered by `createProgram()`
- [x] Umbrella contract test still passes with 26 total commands (profile now counted under `createProgram()` section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)