### PR TITLE
(feat) add @clack/prompts dependency for interactive CLI (#279)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,6 +50,7 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
+    "@clack/prompts": "catalog:",
     "@qontoctl/core": "workspace:^",
     "commander": "catalog:",
     "yaml": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@clack/prompts':
+      specifier: ^1.1.0
+      version: 1.1.0
     '@eslint/js':
       specifier: ^9.39.2
       version: 9.39.3
@@ -92,6 +95,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.1.0
       '@qontoctl/core':
         specifier: workspace:^
         version: link:../core
@@ -243,6 +249,12 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@clack/core@1.1.0':
+    resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
+
+  '@clack/prompts@1.1.0':
+    resolution: {integrity: sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -1443,6 +1455,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1695,6 +1710,15 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@clack/core@1.1.0':
+    dependencies:
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.1.0':
+    dependencies:
+      '@clack/core': 1.1.0
+      sisteransi: 1.0.5
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2892,6 +2916,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,4 +17,5 @@ catalog:
   commander: "^14.0.3"
   turbo: "^2.8.9"
   typedoc: "^0.28.17"
+  "@clack/prompts": "^1.1.0"
   yaml: "^2.7.1"


### PR DESCRIPTION
## Summary

- Add `@clack/prompts` ^1.1.0 as production dependency to `packages/cli` via pnpm workspace catalog
- MIT license — verified AGPL-3.0 compatible via `pnpm license-check`
- All named exports (`text`, `confirm`, `multiselect`, `spinner`, `intro`, `outro`, `isCancel`) resolve correctly

Closes #279

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm license-check` passes
- [x] Named imports resolve from `packages/cli` context
- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (all 10 tasks successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)