### PR TITLE
(feat) show configured scopes in auth status (#283)

### DIFF
--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -311,6 +311,57 @@ describe("registerAuthCommands", () => {
       expect(output).not.toMatch(/Remaining: \d+h/);
     });
 
+    it("shows configured scopes", async () => {
+      const future = new Date(Date.now() + 7200_000).toISOString();
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "token",
+            accessTokenExpiresAt: future,
+            scopes: ["organization.read", "payment.write"],
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "status"], { from: "user" });
+
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("Scopes: organization.read, payment.write");
+    });
+
+    it("shows not configured when no scopes", async () => {
+      const future = new Date(Date.now() + 7200_000).toISOString();
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "token",
+            accessTokenExpiresAt: future,
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "status"], { from: "user" });
+
+      const output = stdoutSpy.mock.calls.map((c) => c[0]).join("");
+      expect(output).toContain("Scopes: not configured (run auth setup)");
+    });
+
     it("throws when no OAuth config", async () => {
       resolveConfigMock.mockResolvedValue({
         config: {},

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -380,6 +380,12 @@ export function registerAuthCommands(program: Command): void {
     }
 
     process.stdout.write(`Refresh token: ${hasRefreshToken ? "Available" : "Not available"}\n`);
+
+    if (oauth.scopes && oauth.scopes.length > 0) {
+      process.stdout.write(`Scopes: ${oauth.scopes.join(", ")}\n`);
+    } else {
+      process.stdout.write("Scopes: not configured (run auth setup)\n");
+    }
   });
 
   // auth revoke


### PR DESCRIPTION
## Summary

- Display configured OAuth scopes in `auth status` output
- Shows `Scopes: organization.read, payment.write, ...` when scopes are stored
- Shows `Scopes: not configured (run auth setup)` when no scopes are present

Closes #283
Depends on: #280 (merged)

## Test plan

- [x] Unit test: scopes displayed when configured
- [x] Unit test: "not configured" message when no scopes
- [x] All 467 existing tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)