### PR TITLE
(refactor) replace readline with @clack/prompts in profile commands (#284)

### DIFF
--- a/packages/cli/src/commands/profile/add.test.ts
+++ b/packages/cli/src/commands/profile/add.test.ts
@@ -6,24 +6,21 @@ import { mkdir, readFile, stat, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { text } from "@clack/prompts";
 import { createProgram } from "../../program.js";
 
 let mockHomeDir = "";
-let mockQuestionResponses: string[] = [];
+let mockTextResponses: (string | symbol)[] = [];
+const cancelSymbol = Symbol("cancel");
 
 vi.mock("node:os", async (importOriginal) => {
   const os = await importOriginal<typeof import("node:os")>();
   return { ...os, homedir: () => mockHomeDir };
 });
 
-vi.mock("node:readline/promises", () => ({
-  createInterface: () => ({
-    question: vi.fn().mockImplementation(() => {
-      const response = mockQuestionResponses.shift();
-      return Promise.resolve(response ?? "");
-    }),
-    close: vi.fn(),
-  }),
+vi.mock("@clack/prompts", () => ({
+  text: vi.fn(),
+  isCancel: (value: unknown) => value === cancelSymbol,
 }));
 
 describe("profile add", () => {
@@ -34,10 +31,14 @@ describe("profile add", () => {
   beforeEach(async () => {
     testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
     mockHomeDir = testHome;
-    mockQuestionResponses = [];
+    mockTextResponses = [];
     await mkdir(testHome, { recursive: true });
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(text).mockImplementation(() => {
+      const response = mockTextResponses.shift() ?? "";
+      return Promise.resolve(response);
+    });
   });
 
   afterEach(async () => {
@@ -47,7 +48,7 @@ describe("profile add", () => {
   });
 
   it("creates a new profile yaml file", async () => {
-    mockQuestionResponses = ["my-org", "sk_test_12345678"];
+    mockTextResponses = ["my-org", "sk_test_12345678"];
 
     const program = createProgram();
     program.exitOverride();
@@ -62,7 +63,7 @@ describe("profile add", () => {
   });
 
   it("creates config directory if it does not exist", async () => {
-    mockQuestionResponses = ["org-slug", "secret-key-value"];
+    mockTextResponses = ["org-slug", "secret-key-value"];
 
     const program = createProgram();
     program.exitOverride();
@@ -79,7 +80,7 @@ describe("profile add", () => {
     await mkdir(configDir, { recursive: true });
     await writeFile(join(configDir, "existing.yaml"), "api-key:\n  organization-slug: org\n  secret-key: key\n");
 
-    mockQuestionResponses = ["new-org", "new-key"];
+    mockTextResponses = ["new-org", "new-key"];
 
     const program = createProgram();
     program.exitOverride();
@@ -90,32 +91,58 @@ describe("profile add", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("rejects empty organization slug", async () => {
-    mockQuestionResponses = ["", "some-key"];
+  it("validates organization slug is not empty", async () => {
+    mockTextResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
     program.exitOverride();
 
-    await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
+    await program.parseAsync(["profile", "add", "validate-slug"], { from: "user" });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Organization slug cannot be empty.");
-    expect(process.exitCode).toBe(1);
+    const slugCall = vi.mocked(text).mock.calls[0];
+    expect(slugCall).toBeDefined();
+    const slugValidate = slugCall?.[0].validate;
+    expect(slugValidate).toBeDefined();
+    expect(slugValidate?.("")).toBe("Organization slug cannot be empty.");
+    expect(slugValidate?.("  ")).toBe("Organization slug cannot be empty.");
+    expect(slugValidate?.(undefined)).toBe("Organization slug cannot be empty.");
+    expect(slugValidate?.("valid")).toBeUndefined();
   });
 
-  it("rejects empty secret key", async () => {
-    mockQuestionResponses = ["my-org", ""];
+  it("validates secret key is not empty", async () => {
+    mockTextResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
     program.exitOverride();
 
-    await program.parseAsync(["profile", "add", "bad-profile"], { from: "user" });
+    await program.parseAsync(["profile", "add", "validate-key"], { from: "user" });
 
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Secret key cannot be empty.");
-    expect(process.exitCode).toBe(1);
+    const keyCall = vi.mocked(text).mock.calls[1];
+    expect(keyCall).toBeDefined();
+    const keyValidate = keyCall?.[0].validate;
+    expect(keyValidate).toBeDefined();
+    expect(keyValidate?.("")).toBe("Secret key cannot be empty.");
+    expect(keyValidate?.("  ")).toBe("Secret key cannot be empty.");
+    expect(keyValidate?.(undefined)).toBe("Secret key cannot be empty.");
+    expect(keyValidate?.("valid")).toBeUndefined();
+  });
+
+  it("exits cleanly when user cancels", async () => {
+    mockTextResponses = [cancelSymbol];
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit");
+    }) as never);
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await expect(program.parseAsync(["profile", "add", "cancel-test"], { from: "user" })).rejects.toThrow();
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it.skipIf(process.platform === "win32")("creates config directory with 0700 permissions", async () => {
-    mockQuestionResponses = ["my-org", "my-secret"];
+    mockTextResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
     program.exitOverride();
@@ -127,7 +154,7 @@ describe("profile add", () => {
   });
 
   it.skipIf(process.platform === "win32")("creates profile file with 0600 permissions", async () => {
-    mockQuestionResponses = ["my-org", "my-secret"];
+    mockTextResponses = ["my-org", "my-secret"];
 
     const program = createProgram();
     program.exitOverride();

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -4,7 +4,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { createInterface } from "node:readline/promises";
+import { isCancel, text } from "@clack/prompts";
 import { stringify as stringifyYaml } from "yaml";
 import type { Command } from "commander";
 import { CONFIG_DIR, isValidProfileName, loadConfigFile } from "@qontoctl/core";
@@ -36,39 +36,38 @@ async function addProfile(name: string): Promise<void> {
     return;
   }
 
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-
-  try {
-    const organizationSlug = await rl.question("Organization slug: ");
-    const secretKey = await rl.question("Secret key: ");
-
-    if (organizationSlug.trim() === "") {
-      console.error("Organization slug cannot be empty.");
-      process.exitCode = 1;
-      return;
-    }
-
-    if (secretKey.trim() === "") {
-      console.error("Secret key cannot be empty.");
-      process.exitCode = 1;
-      return;
-    }
-
-    const config = {
-      "api-key": {
-        "organization-slug": organizationSlug.trim(),
-        "secret-key": secretKey.trim(),
-      },
-    };
-
-    const dir = join(homedir(), CONFIG_DIR);
-    await mkdir(dir, { recursive: true, mode: 0o700 });
-
-    const path = join(dir, `${name}.yaml`);
-    await writeFile(path, stringifyYaml(config), { encoding: "utf-8", mode: 0o600 });
-
-    console.log(`Profile "${name}" created at ${path}`);
-  } finally {
-    rl.close();
+  const organizationSlug = await text({
+    message: "Organization slug",
+    validate: (value) => {
+      if (!value || value.trim() === "") return "Organization slug cannot be empty.";
+    },
+  });
+  if (isCancel(organizationSlug)) {
+    process.exit(0);
   }
+
+  const secretKey = await text({
+    message: "Secret key",
+    validate: (value) => {
+      if (!value || value.trim() === "") return "Secret key cannot be empty.";
+    },
+  });
+  if (isCancel(secretKey)) {
+    process.exit(0);
+  }
+
+  const config = {
+    "api-key": {
+      "organization-slug": organizationSlug.trim(),
+      "secret-key": secretKey.trim(),
+    },
+  };
+
+  const dir = join(homedir(), CONFIG_DIR);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+
+  const path = join(dir, `${name}.yaml`);
+  await writeFile(path, stringifyYaml(config), { encoding: "utf-8", mode: 0o600 });
+
+  console.log(`Profile "${name}" created at ${path}`);
 }

--- a/packages/cli/src/commands/profile/remove.test.ts
+++ b/packages/cli/src/commands/profile/remove.test.ts
@@ -6,24 +6,21 @@ import { mkdir, writeFile, rm, access } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { confirm } from "@clack/prompts";
 import { createProgram } from "../../program.js";
 
 let mockHomeDir = "";
-let mockQuestionResponses: string[] = [];
+let mockConfirmResponse: boolean | symbol = false;
+const cancelSymbol = Symbol("cancel");
 
 vi.mock("node:os", async (importOriginal) => {
   const os = await importOriginal<typeof import("node:os")>();
   return { ...os, homedir: () => mockHomeDir };
 });
 
-vi.mock("node:readline/promises", () => ({
-  createInterface: () => ({
-    question: vi.fn().mockImplementation(() => {
-      const response = mockQuestionResponses.shift();
-      return Promise.resolve(response ?? "");
-    }),
-    close: vi.fn(),
-  }),
+vi.mock("@clack/prompts", () => ({
+  confirm: vi.fn(),
+  isCancel: (value: unknown) => value === cancelSymbol,
 }));
 
 describe("profile remove", () => {
@@ -34,10 +31,11 @@ describe("profile remove", () => {
   beforeEach(async () => {
     testHome = join(tmpdir(), `qontoctl-test-${randomUUID()}`);
     mockHomeDir = testHome;
-    mockQuestionResponses = [];
+    mockConfirmResponse = false;
     await mkdir(testHome, { recursive: true });
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(confirm).mockImplementation(() => Promise.resolve(mockConfirmResponse));
   });
 
   afterEach(async () => {
@@ -47,8 +45,6 @@ describe("profile remove", () => {
   });
 
   it("shows error when profile does not exist", async () => {
-    mockQuestionResponses = ["yes"];
-
     const program = createProgram();
     program.exitOverride();
 
@@ -64,7 +60,7 @@ describe("profile remove", () => {
     const filePath = join(configDir, "work.yaml");
     await writeFile(filePath, "api-key:\n  organization-slug: org\n  secret-key: key\n");
 
-    mockQuestionResponses = ["yes"];
+    mockConfirmResponse = true;
 
     const program = createProgram();
     program.exitOverride();
@@ -81,7 +77,25 @@ describe("profile remove", () => {
     const filePath = join(configDir, "work.yaml");
     await writeFile(filePath, "api-key:\n  organization-slug: org\n  secret-key: key\n");
 
-    mockQuestionResponses = ["no"];
+    mockConfirmResponse = false;
+
+    const program = createProgram();
+    program.exitOverride();
+
+    await program.parseAsync(["profile", "remove", "work"], { from: "user" });
+
+    expect(consoleSpy).toHaveBeenCalledWith("Aborted.");
+    // File should still exist
+    await expect(access(filePath)).resolves.toBeUndefined();
+  });
+
+  it("aborts when user cancels", async () => {
+    const configDir = join(testHome, ".qontoctl");
+    await mkdir(configDir, { recursive: true });
+    const filePath = join(configDir, "work.yaml");
+    await writeFile(filePath, "api-key:\n  organization-slug: org\n  secret-key: key\n");
+
+    mockConfirmResponse = cancelSymbol;
 
     const program = createProgram();
     program.exitOverride();

--- a/packages/cli/src/commands/profile/remove.ts
+++ b/packages/cli/src/commands/profile/remove.ts
@@ -4,7 +4,7 @@
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { createInterface } from "node:readline/promises";
+import { confirm, isCancel } from "@clack/prompts";
 import type { Command } from "commander";
 import { CONFIG_DIR, isValidProfileName, loadConfigFile } from "@qontoctl/core";
 import { addInheritableOptions } from "../../inherited-options.js";
@@ -35,21 +35,16 @@ async function removeProfile(name: string): Promise<void> {
     return;
   }
 
-  const rl = createInterface({ input: process.stdin, output: process.stderr });
-
-  try {
-    const answer = await rl.question(`Remove profile "${name}"? (yes/no): `);
-
-    if (answer.trim().toLowerCase() !== "yes") {
-      console.log("Aborted.");
-      return;
-    }
-
-    const path = join(homedir(), CONFIG_DIR, `${name}.yaml`);
-    await unlink(path);
-
-    console.log(`Profile "${name}" removed.`);
-  } finally {
-    rl.close();
+  const shouldRemove = await confirm({
+    message: `Remove profile "${name}"?`,
+  });
+  if (isCancel(shouldRemove) || !shouldRemove) {
+    console.log("Aborted.");
+    return;
   }
+
+  const path = join(homedir(), CONFIG_DIR, `${name}.yaml`);
+  await unlink(path);
+
+  console.log(`Profile "${name}" removed.`);
 }


### PR DESCRIPTION
## Summary

- Replace `readline/promises` with `@clack/prompts` in `profile add` and `profile remove` commands
- `profile add` now uses `text()` with inline validation for organization slug and secret key
- `profile remove` now uses `confirm()` instead of manual yes/no string parsing
- Both commands handle Ctrl+C cleanly via `isCancel()`
- Updated tests to mock `@clack/prompts` instead of `readline/promises`

Closes #284

## Test plan

- [x] All 1,227 unit tests pass
- [x] ESLint passes
- [x] Build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)