### PR TITLE
(fix) only preselect offline_access scope in OAuth setup and login

### DIFF
--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -196,7 +196,7 @@ describe("registerAuthCommands", () => {
       );
     });
 
-    it("defaults all scopes selected when no existing scopes", async () => {
+    it("defaults only offline_access selected when no existing scopes", async () => {
       textMock.mockResolvedValueOnce("id").mockResolvedValueOnce("secret");
       multiselectMock.mockResolvedValueOnce(["offline_access"]);
 
@@ -207,7 +207,7 @@ describe("registerAuthCommands", () => {
       await program.parseAsync(["auth", "setup"], { from: "user" });
 
       const multiselectCall = multiselectMock.mock.calls[0]?.[0] as { initialValues?: string[] } | undefined;
-      expect(multiselectCall?.initialValues).toHaveLength(16);
+      expect(multiselectCall?.initialValues).toEqual(["offline_access"]);
     });
 
     it("ensures offline_access is always included in saved scopes", async () => {
@@ -1114,7 +1114,9 @@ describe("registerAuthCommands", () => {
       simulateCallback("auth-code", MOCK_STATE_HEX);
       await parsePromise;
 
-      expect(multiselectMock).toHaveBeenCalledWith(expect.objectContaining({ message: "Select OAuth scopes" }));
+      expect(multiselectMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Select OAuth scopes (press Enter when done)" }),
+      );
       expect(saveOAuthScopesMock).toHaveBeenCalledWith(["offline_access", "organization.read"], undefined);
     });
 
@@ -1183,7 +1185,9 @@ describe("registerAuthCommands", () => {
       simulateCallback("auth-code", MOCK_STATE_HEX);
       await parsePromise;
 
-      expect(multiselectMock).toHaveBeenCalledWith(expect.objectContaining({ message: "Select OAuth scopes" }));
+      expect(multiselectMock).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Select OAuth scopes (press Enter when done)" }),
+      );
     });
   });
 });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -259,12 +259,12 @@ export function registerAuthCommands(program: Command): void {
     }
 
     const selectedScopes = await multiselect({
-      message: "Select OAuth scopes",
+      message: "Select OAuth scopes (press Enter when done)",
       options: DEFAULT_SCOPES.map((scope) => {
         const hint = SCOPE_DESCRIPTIONS[scope];
         return { value: scope, label: scope, ...(hint !== undefined ? { hint } : {}) };
       }),
-      initialValues: existingOAuth?.scopes ?? [...DEFAULT_SCOPES],
+      initialValues: existingOAuth?.scopes ?? ["offline_access"],
       required: true,
     });
     if (isCancel(selectedScopes)) {
@@ -306,12 +306,12 @@ export function registerAuthCommands(program: Command): void {
       scopes = oauth.scopes;
     } else {
       const selectedScopes = await multiselect({
-        message: "Select OAuth scopes",
+        message: "Select OAuth scopes (press Enter when done)",
         options: DEFAULT_SCOPES.map((scope) => {
           const hint = SCOPE_DESCRIPTIONS[scope];
           return { value: scope, label: scope, ...(hint !== undefined ? { hint } : {}) };
         }),
-        initialValues: [...DEFAULT_SCOPES],
+        initialValues: ["offline_access"],
         required: true,
       });
       if (isCancel(selectedScopes)) {


### PR DESCRIPTION
## Summary

- Only preselect `offline_access` (required) in OAuth scope multiselect, instead of all scopes
- Update prompt message to `"Select OAuth scopes (press Enter when done)"` for UX clarity
- Existing stored scopes are still preselected on re-run (no behavior change)

Closes #298

## Test plan

- [x] All 47 auth tests pass with updated assertions
- [ ] Manual: `qontoctl auth setup` shows only `offline_access` preselected
- [ ] Manual: `qontoctl auth login` (no stored scopes) shows only `offline_access` preselected
- [ ] Manual: re-run `auth setup` with existing scopes preselects stored scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)