### PR TITLE
(fix) wrap createTransfer body as { transfer: params } (#301)

### DIFF
--- a/packages/core/src/transfers/service.test.ts
+++ b/packages/core/src/transfers/service.test.ts
@@ -281,11 +281,13 @@ describe("createTransfer", () => {
 
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body).toEqual({
-      beneficiary_id: "ben-1",
-      debit_account_id: "acc-1",
-      reference: "Test Payment",
-      amount: 500,
-      currency: "EUR",
+      transfer: {
+        beneficiary_id: "ben-1",
+        debit_account_id: "acc-1",
+        reference: "Test Payment",
+        amount: 500,
+        currency: "EUR",
+      },
     });
   });
 
@@ -303,9 +305,9 @@ describe("createTransfer", () => {
     });
 
     const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-    const body = JSON.parse(init.body as string) as Record<string, unknown>;
-    expect(body.note).toBe("Monthly payment");
-    expect(body.scheduled_date).toBe("2026-04-01");
+    const body = JSON.parse(init.body as string) as { transfer: Record<string, unknown> };
+    expect(body.transfer.note).toBe("Monthly payment");
+    expect(body.transfer.scheduled_date).toBe("2026-04-01");
   });
 });
 

--- a/packages/core/src/transfers/service.ts
+++ b/packages/core/src/transfers/service.ts
@@ -87,7 +87,7 @@ export async function createTransfer(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<Transfer> {
   const endpointPath = "/v2/sepa/transfers";
-  const response = await client.post(endpointPath, params, options);
+  const response = await client.post(endpointPath, { transfer: params }, options);
   return parseResponse(TransferResponseSchema, response, endpointPath).transfer;
 }
 


### PR DESCRIPTION
## Summary

- Wraps `createTransfer` request body as `{ transfer: params }` per Qonto API v2 `POST /v2/sepa/transfers` contract
- Updates unit tests to assert the wrapped body format
- Fixes HTTP 400 `missing_key: transfer is missing` error

Closes #301, closes #296

## Test plan

- [x] Unit tests updated to assert `{ transfer: { ... } }` body shape
- [x] All 1,244 unit tests pass across all packages
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)