### PR TITLE
(fix) wrap beneficiary body as { beneficiary: params } per Qonto API v2

### DIFF
--- a/packages/cli/src/commands/beneficiary/add.test.ts
+++ b/packages/cli/src/commands/beneficiary/add.test.ts
@@ -96,8 +96,12 @@ describe("beneficiary add command", () => {
     expect(url.pathname).toBe("/v2/sepa/beneficiaries");
     expect(opts.method).toBe("POST");
     const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-    expect(body).toHaveProperty("name", "New Corp");
-    expect(body).toHaveProperty("iban", "FR7630001007941234567890185");
-    expect(body).toHaveProperty("bic", "BNPAFRPP");
+    expect(body).toEqual({
+      beneficiary: {
+        name: "New Corp",
+        iban: "FR7630001007941234567890185",
+        bic: "BNPAFRPP",
+      },
+    });
   });
 });

--- a/packages/cli/src/commands/beneficiary/update.test.ts
+++ b/packages/cli/src/commands/beneficiary/update.test.ts
@@ -90,6 +90,10 @@ describe("beneficiary update command", () => {
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/ben-1");
     expect(opts.method).toBe("PUT");
     const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-    expect(body).toHaveProperty("name", "Updated Corp");
+    expect(body).toEqual({
+      beneficiary: {
+        name: "Updated Corp",
+      },
+    });
   });
 });

--- a/packages/core/src/beneficiaries/service.test.ts
+++ b/packages/core/src/beneficiaries/service.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HttpClient } from "../http-client.js";
 import { jsonResponse } from "../testing/json-response.js";
-import { buildBeneficiaryQueryParams, getBeneficiary } from "./service.js";
+import { buildBeneficiaryQueryParams, createBeneficiary, getBeneficiary, updateBeneficiary } from "./service.js";
 import type { ListBeneficiariesParams } from "./types.js";
 
 describe("buildBeneficiaryQueryParams", () => {
@@ -111,5 +111,109 @@ describe("getBeneficiary", () => {
 
     const [url] = fetchSpy.mock.calls[0] as [URL];
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/a%2Fb");
+  });
+});
+
+describe("createBeneficiary", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("wraps params in a beneficiary key", async () => {
+    const beneficiary = {
+      id: "ben-new",
+      name: "Acme Corp",
+      iban: "FR7630001007941234567890185",
+      bic: "BNPAFRPP",
+      email: null,
+      activity_tag: null,
+      status: "pending",
+      trusted: false,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-01T00:00:00Z",
+    };
+    fetchSpy.mockReturnValue(jsonResponse({ beneficiary }));
+
+    const result = await createBeneficiary(client, {
+      name: "Acme Corp",
+      iban: "FR7630001007941234567890185",
+      bic: "BNPAFRPP",
+    });
+
+    expect(result).toEqual(beneficiary);
+
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sepa/beneficiaries");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      beneficiary: {
+        name: "Acme Corp",
+        iban: "FR7630001007941234567890185",
+        bic: "BNPAFRPP",
+      },
+    });
+  });
+});
+
+describe("updateBeneficiary", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("wraps params in a beneficiary key", async () => {
+    const beneficiary = {
+      id: "ben-1",
+      name: "Updated Corp",
+      iban: "FR7630001007941234567890185",
+      bic: "BNPAFRPP",
+      email: null,
+      activity_tag: null,
+      status: "validated",
+      trusted: true,
+      created_at: "2025-01-01T00:00:00Z",
+      updated_at: "2025-01-02T00:00:00Z",
+    };
+    fetchSpy.mockReturnValue(jsonResponse({ beneficiary }));
+
+    const result = await updateBeneficiary(client, "ben-1", {
+      name: "Updated Corp",
+    });
+
+    expect(result).toEqual(beneficiary);
+
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sepa/beneficiaries/ben-1");
+    expect(opts.method).toBe("PUT");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      beneficiary: {
+        name: "Updated Corp",
+      },
+    });
   });
 });

--- a/packages/core/src/beneficiaries/service.ts
+++ b/packages/core/src/beneficiaries/service.ts
@@ -74,7 +74,7 @@ export async function createBeneficiary(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<Beneficiary> {
   const endpointPath = "/v2/sepa/beneficiaries";
-  const response = await client.post(endpointPath, params, options);
+  const response = await client.post(endpointPath, { beneficiary: params }, options);
   return parseResponse(BeneficiaryResponseSchema, response, endpointPath).beneficiary;
 }
 
@@ -88,7 +88,7 @@ export async function updateBeneficiary(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<Beneficiary> {
   const endpointPath = `/v2/sepa/beneficiaries/${encodeURIComponent(id)}`;
-  const response = await client.put(endpointPath, params, options);
+  const response = await client.put(endpointPath, { beneficiary: params }, options);
   return parseResponse(BeneficiaryResponseSchema, response, endpointPath).beneficiary;
 }
 

--- a/packages/mcp/src/tools/beneficiary.test.ts
+++ b/packages/mcp/src/tools/beneficiary.test.ts
@@ -224,9 +224,13 @@ describe("beneficiary MCP tools", () => {
       expect(url.pathname).toBe("/v2/sepa/beneficiaries");
       expect(opts.method).toBe("POST");
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toHaveProperty("name", "New Corp");
-      expect(body).toHaveProperty("iban", "FR7630001007941234567890185");
-      expect(body).toHaveProperty("bic", "BNPAFRPP");
+      expect(body).toEqual({
+        beneficiary: {
+          name: "New Corp",
+          iban: "FR7630001007941234567890185",
+          bic: "BNPAFRPP",
+        },
+      });
     });
   });
 
@@ -272,7 +276,11 @@ describe("beneficiary MCP tools", () => {
       expect(url.pathname).toBe("/v2/sepa/beneficiaries/ben-1");
       expect(opts.method).toBe("PUT");
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toHaveProperty("name", "Updated Corp");
+      expect(body).toEqual({
+        beneficiary: {
+          name: "Updated Corp",
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- Wrap `createBeneficiary` and `updateBeneficiary` request bodies as `{ beneficiary: params }` per Qonto API v2 spec
- Update body-format assertions in core, CLI, and MCP tests to match the wrapped structure
- Add new unit tests for `createBeneficiary` and `updateBeneficiary` in core service tests

Closes #302

## Test plan

- [x] Core unit tests pass with body-format assertions for both methods
- [x] CLI beneficiary add/update tests updated and passing
- [x] MCP beneficiary add/update tests updated and passing
- [x] All 1,246 tests pass across all packages
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)