### PR TITLE
(fix) wrap createCard body as { card: params } per Qonto API v2

### DIFF
--- a/packages/cli/src/commands/card/card.test.ts
+++ b/packages/cli/src/commands/card/card.test.ts
@@ -294,8 +294,8 @@ describe("card commands", () => {
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/cards");
       expect(opts.method).toBe("POST");
-      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toEqual(
+      const body = JSON.parse(opts.body as string) as { card: Record<string, unknown> };
+      expect(body.card).toEqual(
         expect.objectContaining({
           holder_id: "mem-1",
           initiator_id: "mem-2",
@@ -406,8 +406,8 @@ describe("card commands", () => {
       );
 
       const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toEqual(
+      const body = JSON.parse(opts.body as string) as { card: Record<string, unknown> };
+      expect(body.card).toEqual(
         expect.objectContaining({
           ship_to_business: true,
           atm_option: true,

--- a/packages/core/src/cards/service.test.ts
+++ b/packages/core/src/cards/service.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient } from "../http-client.js";
+import { jsonResponse } from "../testing/json-response.js";
+import { createCard } from "./service.js";
+
+const MOCK_CARD = {
+  id: "card-1",
+  nickname: "My Card",
+  embossed_name: null,
+  status: "pending",
+  pin_set: false,
+  mask_pan: null,
+  exp_month: null,
+  exp_year: null,
+  last_activity_at: "2026-01-01T00:00:00Z",
+  last_digits: null,
+  ship_to_business: false,
+  atm_option: true,
+  nfc_option: true,
+  online_option: true,
+  foreign_option: true,
+  atm_monthly_limit: 1000,
+  atm_monthly_spent: 0,
+  atm_daily_limit: 500,
+  atm_daily_spent: 0,
+  atm_daily_limit_option: false,
+  payment_monthly_limit: 5000,
+  payment_monthly_spent: 0,
+  payment_daily_limit: 2000,
+  payment_daily_spent: 0,
+  payment_daily_limit_option: false,
+  payment_transaction_limit: 1000,
+  payment_transaction_limit_option: false,
+  active_days: [1, 2, 3, 4, 5],
+  holder_id: "holder-1",
+  initiator_id: "init-1",
+  bank_account_id: "ba-1",
+  organization_id: "org-1",
+  updated_at: "2026-01-01T00:00:00Z",
+  created_at: "2026-01-01T00:00:00Z",
+  shipped_at: null,
+  card_type: "debit",
+  card_level: "standard",
+  payment_lifespan_limit: 50000,
+  payment_lifespan_spent: 0,
+  pre_expires_at: null,
+  categories: [],
+  renewed: false,
+  renewal: false,
+  parent_card_summary: null,
+  had_operation: false,
+  had_pin_operation: false,
+  card_design: "default",
+  type_of_print: null,
+  upsold: false,
+  upsell: false,
+  discard_on: null,
+  reordered: false,
+  appearance: {
+    assets: {
+      front_large: "https://example.com/large.png",
+      front_small: "https://example.com/small.png",
+      front_small_wallet: "https://example.com/wallet.png",
+    },
+    theme: "light",
+    gradient_hex_color: "#FFFFFF",
+  },
+  has_only_user_liftable_locks: false,
+};
+
+describe("createCard", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("wraps params in { card: ... } in the request body", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+
+    await createCard(client, {
+      holder_id: "holder-1",
+      initiator_id: "init-1",
+      organization_id: "org-1",
+      bank_account_id: "ba-1",
+      card_level: "standard",
+    });
+
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      card: {
+        holder_id: "holder-1",
+        initiator_id: "init-1",
+        organization_id: "org-1",
+        bank_account_id: "ba-1",
+        card_level: "standard",
+      },
+    });
+  });
+});

--- a/packages/core/src/cards/service.ts
+++ b/packages/core/src/cards/service.ts
@@ -84,7 +84,7 @@ export async function createCard(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<Card> {
   const path = "/v2/cards";
-  const response = await client.post<{ card: Card }>(path, params, options);
+  const response = await client.post<{ card: Card }>(path, { card: params }, options);
   return parseResponse(z.object({ card: CardSchema }), response, path).card;
 }
 

--- a/packages/mcp/src/tools/card.test.ts
+++ b/packages/mcp/src/tools/card.test.ts
@@ -250,14 +250,14 @@ describe("card MCP tools", () => {
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/cards");
       expect(opts.method).toBe("POST");
-      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toHaveProperty("holder_id", "member-1");
-      expect(body).toHaveProperty("initiator_id", "member-1");
-      expect(body).toHaveProperty("organization_id", "org-1");
-      expect(body).toHaveProperty("bank_account_id", "acct-1");
-      expect(body).toHaveProperty("card_level", "virtual");
-      expect(body).toHaveProperty("atm_option", true);
-      expect(body).toHaveProperty("payment_monthly_limit", 5000);
+      const body = JSON.parse(opts.body as string) as { card: Record<string, unknown> };
+      expect(body.card).toHaveProperty("holder_id", "member-1");
+      expect(body.card).toHaveProperty("initiator_id", "member-1");
+      expect(body.card).toHaveProperty("organization_id", "org-1");
+      expect(body.card).toHaveProperty("bank_account_id", "acct-1");
+      expect(body.card).toHaveProperty("card_level", "virtual");
+      expect(body.card).toHaveProperty("atm_option", true);
+      expect(body.card).toHaveProperty("payment_monthly_limit", 5000);
     });
   });
 


### PR DESCRIPTION
## Summary

- Wrap `createCard` request body as `{ card: params }` to match the Qonto API v2 `POST /v2/cards` contract
- Add `cards/service.test.ts` with body-format assertion for `createCard`
- Update existing MCP and CLI tests to expect the wrapped body format

Fixes #303

## Test plan

- [x] New unit test verifies `createCard` sends `{ card: { ... } }` body
- [x] Existing MCP `card_create` test updated and passing
- [x] Existing CLI `card create` tests updated and passing
- [x] Full test suite passes (1245 tests, 0 failures)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)