### PR TITLE
(fix) surface actionable guidance on OAuth scope 403 errors

### DIFF
--- a/packages/cli/src/error-handler.test.ts
+++ b/packages/cli/src/error-handler.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigError,
   AuthError,
   QontoApiError,
+  QontoOAuthScopeError,
   QontoRateLimitError,
   QontoScaRequiredError,
   ScaTimeoutError,
@@ -50,6 +51,22 @@ describe("handleCliError", () => {
       expect(output).toContain("Authentication error:");
       expect(output).toContain("Missing organization slug");
       expect(output).toContain("Verify your API key credentials");
+      expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe("QontoOAuthScopeError", () => {
+    it("shows scope remediation guidance", () => {
+      const error = new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Qonto API error (HTTP 403):");
+      expect(output).toContain("missing required oauth scope");
+      expect(output).toContain("OAuth token is missing a required scope");
+      expect(output).toContain("qontoctl auth setup");
+      expect(output).toContain("qontoctl auth login");
       expect(process.exitCode).toBe(1);
     });
   });

--- a/packages/cli/src/error-handler.ts
+++ b/packages/cli/src/error-handler.ts
@@ -5,6 +5,7 @@ import {
   ConfigError,
   AuthError,
   QontoApiError,
+  QontoOAuthScopeError,
   QontoRateLimitError,
   QontoScaRequiredError,
   ScaTimeoutError,
@@ -44,6 +45,21 @@ export function handleCliError(error: unknown, debug: boolean): void {
         `Authentication error: ${error.message}`,
         "",
         "Verify your API key credentials in ~/.qontoctl.yaml or environment variables.",
+      ].join("\n") + "\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (error instanceof QontoOAuthScopeError) {
+    const details = error.errors.map((e) => `  - ${e.code}: ${e.detail}`).join("\n");
+    process.stderr.write(
+      [
+        `Qonto API error (HTTP 403):`,
+        details,
+        "",
+        "Your OAuth token is missing a required scope for this operation.",
+        'Run "qontoctl auth setup" to select the needed scopes, then "qontoctl auth login" to re-authenticate.',
       ].join("\n") + "\n",
     );
     process.exitCode = 1;

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -2,7 +2,13 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { HttpClient, QontoApiError, QontoRateLimitError, QontoScaRequiredError } from "./http-client.js";
+import {
+  HttpClient,
+  QontoApiError,
+  QontoOAuthScopeError,
+  QontoRateLimitError,
+  QontoScaRequiredError,
+} from "./http-client.js";
 import { binaryResponse } from "./testing/binary-response.js";
 import { jsonResponse } from "./testing/json-response.js";
 
@@ -487,6 +493,59 @@ describe("HttpClient", () => {
       const apiError = error as QontoApiError;
       expect(apiError.status).toBe(502);
       expect(apiError.errors[0]?.code).toBe("unknown");
+    });
+
+    it("throws QontoOAuthScopeError on 403 with missing oauth scope", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "forbidden",
+                detail: "missing required oauth scope",
+              },
+            ],
+          },
+          { status: 403 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "Bearer token",
+      });
+
+      const error = await client.post("/v2/internal_transfers", {}).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoOAuthScopeError);
+      expect(error).toBeInstanceOf(QontoApiError);
+      const scopeError = error as QontoOAuthScopeError;
+      expect(scopeError.status).toBe(403);
+      expect(scopeError.errors).toEqual([{ code: "forbidden", detail: "missing required oauth scope" }]);
+    });
+
+    it("throws generic QontoApiError on 403 without oauth scope message", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "forbidden",
+                detail: "Access denied",
+              },
+            ],
+          },
+          { status: 403 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "Bearer token",
+      });
+
+      const error = await client.post("/v2/internal_transfers", {}).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect(error).not.toBeInstanceOf(QontoOAuthScopeError);
     });
 
     it("preserves source information in error entries", async () => {
@@ -1046,6 +1105,28 @@ describe("HttpClient", () => {
 
     it("is an instance of Error", () => {
       const error = new QontoScaRequiredError("tok-abc");
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("QontoOAuthScopeError", () => {
+    it("has correct name property", () => {
+      const error = new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]);
+      expect(error.name).toBe("QontoOAuthScopeError");
+    });
+
+    it("has status 403", () => {
+      const error = new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]);
+      expect(error.status).toBe(403);
+    });
+
+    it("is an instance of QontoApiError", () => {
+      const error = new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]);
+      expect(error).toBeInstanceOf(QontoApiError);
+    });
+
+    it("is an instance of Error", () => {
+      const error = new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]);
       expect(error).toBeInstanceOf(Error);
     });
   });

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -42,6 +42,19 @@ export class QontoApiError extends Error {
 }
 
 /**
+ * Error thrown when the Qonto API returns 403 due to a missing OAuth scope.
+ *
+ * Extends {@link QontoApiError} so existing `instanceof QontoApiError` checks
+ * still match, while consumers can narrow to this subclass for targeted handling.
+ */
+export class QontoOAuthScopeError extends QontoApiError {
+  constructor(errors: readonly QontoApiErrorEntry[]) {
+    super(403, errors);
+    this.name = "QontoOAuthScopeError";
+  }
+}
+
+/**
  * Error thrown when all retry attempts are exhausted on 429 responses.
  */
 export class QontoRateLimitError extends Error {
@@ -377,6 +390,14 @@ export class HttpClient {
       if (!response.ok) {
         const errorBody = await this.safeReadJson(response);
         const errors: readonly QontoApiErrorEntry[] = this.extractErrors(errorBody);
+
+        if (
+          response.status === 403 &&
+          errors.some((e) => e.detail.toLowerCase().includes("missing required oauth scope"))
+        ) {
+          throw new QontoOAuthScopeError(errors);
+        }
+
         throw new QontoApiError(response.status, errors);
       }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@
 export {
   HttpClient,
   QontoApiError,
+  QontoOAuthScopeError,
   QontoRateLimitError,
   QontoScaRequiredError,
   type Authorization,

--- a/packages/mcp/src/errors.test.ts
+++ b/packages/mcp/src/errors.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigError,
   AuthError,
   QontoApiError,
+  QontoOAuthScopeError,
   QontoRateLimitError,
   QontoScaRequiredError,
   HttpClient,
@@ -97,6 +98,35 @@ describe("withClient", () => {
       const text = (result.content[0] as { type: "text"; text: string }).text;
       expect(text).toContain("invalid: Field A");
       expect(text).toContain("missing: Field B");
+    });
+  });
+
+  describe("QontoOAuthScopeError", () => {
+    it("formats scope error with remediation guidance", async () => {
+      const factory = () =>
+        Promise.reject(new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]));
+      const result = await withClient(factory, async () => ({
+        content: [{ type: "text" as const, text: "unreachable" }],
+      }));
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      expect(text).toContain("HTTP 403");
+      expect(text).toContain("missing required oauth scope");
+      expect(text).toContain("qontoctl auth setup");
+      expect(text).toContain("qontoctl auth login");
+    });
+
+    it("is matched before generic QontoApiError handler", async () => {
+      const factory = () =>
+        Promise.reject(new QontoOAuthScopeError([{ code: "forbidden", detail: "missing required oauth scope" }]));
+      const result = await withClient(factory, async () => ({
+        content: [{ type: "text" as const, text: "unreachable" }],
+      }));
+
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      // Must contain the remediation guidance (not just generic API error format)
+      expect(text).toContain("OAuth token is missing a required scope");
     });
   });
 

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -6,6 +6,7 @@ import {
   ConfigError,
   AuthError,
   QontoApiError,
+  QontoOAuthScopeError,
   QontoRateLimitError,
   QontoScaRequiredError,
 } from "@qontoctl/core";
@@ -43,6 +44,19 @@ function formatAuthError(error: AuthError): CallToolResult {
       `Authentication error: ${error.message}`,
       "",
       "Verify your API key credentials in ~/.qontoctl.yaml or environment variables.",
+    ].join("\n"),
+  );
+}
+
+function formatOAuthScopeError(error: QontoOAuthScopeError): CallToolResult {
+  const details = error.errors.map((e) => `  - ${e.code}: ${e.detail}`).join("\n");
+  return textError(
+    [
+      `Qonto API error (HTTP 403):`,
+      details,
+      "",
+      "Your OAuth token is missing a required scope for this operation.",
+      'Run "qontoctl auth setup" to select the needed scopes, then "qontoctl auth login" to re-authenticate.',
     ].join("\n"),
   );
 }
@@ -94,6 +108,7 @@ export async function withClient(
     if (error instanceof ConfigError) return formatConfigError(error);
     if (error instanceof AuthError) return formatAuthError(error);
     if (error instanceof QontoScaRequiredError) return formatScaRequiredResponse(error);
+    if (error instanceof QontoOAuthScopeError) return formatOAuthScopeError(error);
     if (error instanceof QontoApiError) return formatApiError(error);
     if (error instanceof QontoRateLimitError) return formatRateLimitError(error);
 


### PR DESCRIPTION
## Summary

- Adds `QontoOAuthScopeError` (extends `QontoApiError`) in core, detected when the Qonto API returns HTTP 403 with "missing required oauth scope"
- CLI and MCP error handlers now show actionable remediation: re-run `auth setup` to select scopes, then `auth login` to re-authenticate
- Previously the raw API error was shown with no guidance on how to fix it

Closes #297

## Test plan

- [x] Core: `QontoOAuthScopeError` class tests (name, status, inheritance)
- [x] Core: HTTP client throws `QontoOAuthScopeError` on 403 scope errors
- [x] Core: HTTP client throws generic `QontoApiError` on non-scope 403 errors
- [x] MCP: `withClient` formats scope errors with remediation guidance
- [x] CLI: `handleCliError` formats scope errors with remediation guidance
- [x] All existing tests pass (533 core, 221 mcp, 485 cli)

🤖 Generated with [Claude Code](https://claude.com/claude-code)