### PR TITLE
(fix) rename debit_account_id to bank_account_id in transfer_create

### DIFF
--- a/packages/cli/src/commands/transfer/create.test.ts
+++ b/packages/cli/src/commands/transfer/create.test.ts
@@ -153,7 +153,7 @@ describe("transfer create command", () => {
       expect.anything(),
       {
         beneficiary_id: "ben-1",
-        debit_account_id: "acc-1",
+        bank_account_id: "acc-1",
         reference: "Invoice 42",
         amount: 1234.56,
         currency: "EUR",

--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -51,7 +51,7 @@ export function registerTransferCreateCommand(parent: Command): void {
 
     const params: CreateTransferParams = {
       beneficiary_id: opts.beneficiary,
-      debit_account_id: opts.debitAccount,
+      bank_account_id: opts.debitAccount,
       reference: opts.reference,
       amount: parseFloat(opts.amount),
       currency: opts.currency,

--- a/packages/core/src/transfers/service.test.ts
+++ b/packages/core/src/transfers/service.test.ts
@@ -268,7 +268,7 @@ describe("createTransfer", () => {
 
     const result = await createTransfer(client, {
       beneficiary_id: "ben-1",
-      debit_account_id: "acc-1",
+      bank_account_id: "acc-1",
       reference: "Test Payment",
       amount: 500,
       currency: "EUR",
@@ -283,7 +283,7 @@ describe("createTransfer", () => {
     expect(body).toEqual({
       transfer: {
         beneficiary_id: "ben-1",
-        debit_account_id: "acc-1",
+        bank_account_id: "acc-1",
         reference: "Test Payment",
         amount: 500,
         currency: "EUR",
@@ -296,7 +296,7 @@ describe("createTransfer", () => {
 
     await createTransfer(client, {
       beneficiary_id: "ben-1",
-      debit_account_id: "acc-1",
+      bank_account_id: "acc-1",
       reference: "Scheduled",
       amount: 100,
       currency: "EUR",

--- a/packages/core/src/transfers/types.ts
+++ b/packages/core/src/transfers/types.ts
@@ -45,7 +45,7 @@ export interface ListTransfersParams {
  */
 export interface CreateTransferParams {
   readonly beneficiary_id: string;
-  readonly debit_account_id: string;
+  readonly bank_account_id: string;
   readonly reference: string;
   readonly amount: number;
   readonly currency: string;

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -84,7 +84,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
       description: "Create a SEPA transfer",
       inputSchema: {
         beneficiary_id: z.string().describe("Beneficiary UUID"),
-        debit_account_id: z.string().describe("Bank account UUID to debit"),
+        bank_account_id: z.string().describe("Bank account UUID to debit"),
         reference: z.string().describe("Transfer reference"),
         amount: z.number().positive().describe("Amount to transfer"),
         currency: z.string().optional().describe("Currency code (default: EUR)"),
@@ -96,7 +96,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
       withClient(getClient, async (client) => {
         const params: CreateTransferParams = {
           beneficiary_id: args.beneficiary_id,
-          debit_account_id: args.debit_account_id,
+          bank_account_id: args.bank_account_id,
           reference: args.reference,
           amount: args.amount,
           currency: args.currency ?? "EUR",


### PR DESCRIPTION
## Summary

- Rename `debit_account_id` to `bank_account_id` in `CreateTransferParams` to match the Qonto API contract
- Update MCP tool schema (`transfer_create`) and CLI command (`transfer create`) to use the correct field name
- Fix unit tests to reflect the corrected field name

Closes #314

## Test plan

- [x] Unit tests pass (`pnpm test` — 10/10 tasks, all green)
- [x] Build succeeds (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)