### PR TITLE
(fix) send amount as string to Qonto API

### DIFF
--- a/packages/cli/src/commands/internal-transfer.test.ts
+++ b/packages/cli/src/commands/internal-transfer.test.ts
@@ -148,7 +148,7 @@ describe("internal-transfer commands", () => {
           debit_iban: "FR7630001007941234567890185",
           credit_iban: "FR7630001007949876543210142",
           reference: "Monthly allocation",
-          amount: 1000,
+          amount: "1000",
           currency: "EUR",
         },
       });

--- a/packages/cli/src/commands/internal-transfer.ts
+++ b/packages/cli/src/commands/internal-transfer.ts
@@ -53,7 +53,7 @@ export function createInternalTransferCommand(): Command {
           debit_iban: opts.debitIban,
           credit_iban: opts.creditIban,
           reference: opts.reference,
-          amount: parseFloat(opts.amount),
+          amount: opts.amount,
           currency: opts.currency,
         },
       },

--- a/packages/cli/src/commands/transfer/create.test.ts
+++ b/packages/cli/src/commands/transfer/create.test.ts
@@ -155,7 +155,7 @@ describe("transfer create command", () => {
         beneficiary_id: "ben-1",
         bank_account_id: "acc-1",
         reference: "Invoice 42",
-        amount: 1234.56,
+        amount: "1234.56",
         currency: "EUR",
         note: "Monthly fee",
         scheduled_date: "2026-04-01",

--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -53,7 +53,7 @@ export function registerTransferCreateCommand(parent: Command): void {
       beneficiary_id: opts.beneficiary,
       bank_account_id: opts.debitAccount,
       reference: opts.reference,
-      amount: parseFloat(opts.amount),
+      amount: opts.amount,
       currency: opts.currency,
       ...(opts.note !== undefined ? { note: opts.note } : {}),
       ...(opts.scheduledDate !== undefined ? { scheduled_date: opts.scheduledDate } : {}),

--- a/packages/core/src/internal-transfers/service.test.ts
+++ b/packages/core/src/internal-transfers/service.test.ts
@@ -43,7 +43,7 @@ describe("createInternalTransfer", () => {
       debit_iban: "FR7630001007941234567890185",
       credit_iban: "FR7630001007949876543210142",
       reference: "Monthly allocation",
-      amount: 1000.0,
+      amount: "1000",
       currency: "EUR",
     });
 
@@ -58,7 +58,7 @@ describe("createInternalTransfer", () => {
         debit_iban: "FR7630001007941234567890185",
         credit_iban: "FR7630001007949876543210142",
         reference: "Monthly allocation",
-        amount: 1000.0,
+        amount: "1000",
         currency: "EUR",
       },
     });
@@ -89,7 +89,7 @@ describe("createInternalTransfer", () => {
         debit_iban: "FR76X",
         credit_iban: "FR76Y",
         reference: "Test",
-        amount: 50.0,
+        amount: "50",
         currency: "EUR",
       },
       { idempotencyKey: "key-123" },

--- a/packages/core/src/internal-transfers/types.ts
+++ b/packages/core/src/internal-transfers/types.ts
@@ -28,6 +28,6 @@ export interface CreateInternalTransferParams {
   readonly debit_iban: string;
   readonly credit_iban: string;
   readonly reference: string;
-  readonly amount: number;
+  readonly amount: string;
   readonly currency: string;
 }

--- a/packages/core/src/transfers/service.test.ts
+++ b/packages/core/src/transfers/service.test.ts
@@ -270,7 +270,7 @@ describe("createTransfer", () => {
       beneficiary_id: "ben-1",
       bank_account_id: "acc-1",
       reference: "Test Payment",
-      amount: 500,
+      amount: "500",
       currency: "EUR",
     });
     expect(result).toEqual(newTransfer);
@@ -285,7 +285,7 @@ describe("createTransfer", () => {
         beneficiary_id: "ben-1",
         bank_account_id: "acc-1",
         reference: "Test Payment",
-        amount: 500,
+        amount: "500",
         currency: "EUR",
       },
     });
@@ -298,7 +298,7 @@ describe("createTransfer", () => {
       beneficiary_id: "ben-1",
       bank_account_id: "acc-1",
       reference: "Scheduled",
-      amount: 100,
+      amount: "100",
       currency: "EUR",
       note: "Monthly payment",
       scheduled_date: "2026-04-01",

--- a/packages/core/src/transfers/types.ts
+++ b/packages/core/src/transfers/types.ts
@@ -47,7 +47,7 @@ export interface CreateTransferParams {
   readonly beneficiary_id: string;
   readonly bank_account_id: string;
   readonly reference: string;
-  readonly amount: number;
+  readonly amount: string;
   readonly currency: string;
   readonly note?: string;
   readonly scheduled_date?: string;

--- a/packages/mcp/src/tools/internal-transfer.test.ts
+++ b/packages/mcp/src/tools/internal-transfer.test.ts
@@ -79,7 +79,7 @@ describe("internal-transfer MCP tools", () => {
           debit_iban: "FR7630001007941234567890185",
           credit_iban: "FR7630001007949876543210142",
           reference: "Monthly allocation",
-          amount: 1000.0,
+          amount: "1000",
           currency: "EUR",
         },
       });

--- a/packages/mcp/src/tools/internal-transfer.ts
+++ b/packages/mcp/src/tools/internal-transfer.ts
@@ -25,7 +25,7 @@ export function registerInternalTransferTools(server: McpServer, getClient: () =
           debit_iban: args.debit_iban,
           credit_iban: args.credit_iban,
           reference: args.reference,
-          amount: args.amount,
+          amount: String(args.amount),
           currency: args.currency,
         });
 

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -98,7 +98,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
           beneficiary_id: args.beneficiary_id,
           bank_account_id: args.bank_account_id,
           reference: args.reference,
-          amount: args.amount,
+          amount: String(args.amount),
           currency: args.currency ?? "EUR",
           ...(args.note !== undefined ? { note: args.note } : {}),
           ...(args.scheduled_date !== undefined ? { scheduled_date: args.scheduled_date } : {}),


### PR DESCRIPTION
## Summary

- Changes `amount` type from `number` to `string` in `CreateTransferParams` and `CreateInternalTransferParams` core types
- MCP tools now convert numeric input to string via `String()` before passing to core services
- CLI commands pass the string amount directly instead of converting via `parseFloat()`

Closes #313

## Test plan

- [x] Unit tests updated and passing across core, CLI, and MCP packages
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)