### PR TITLE
(fix) log primary error body and propagate non-auth errors in fallback

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -1245,6 +1245,69 @@ describe("HttpClient", () => {
       expect(key1).toBeDefined();
       expect(key1).toBe(key2);
     });
+
+    it("logs primary error body in debug mode before fallback", async () => {
+      const primaryBody = { errors: [{ code: "unauthorized", detail: "Unauthorized" }] };
+      fetchSpy
+        .mockReturnValueOnce(jsonResponse(primaryBody, { status: 401 }))
+        .mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "oauth-token",
+        fallbackAuthorization: "slug:key",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining("Primary auth error response body:"));
+    });
+
+    it("propagates non-auth 401 error directly instead of falling back", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          { errors: [{ code: "vop_proof_token_missing", detail: "VOP proof token is required" }] },
+          { status: 401 },
+        ),
+      );
+
+      const onFallback = vi.fn();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "oauth-token",
+        fallbackAuthorization: "slug:key",
+        onFallback,
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect((error as QontoApiError).status).toBe(401);
+      expect((error as QontoApiError).errors[0]?.code).toBe("vop_proof_token_missing");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(onFallback).not.toHaveBeenCalled();
+    });
+
+    it("propagates non-auth 403 error directly instead of falling back", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({ errors: [{ code: "insufficient_funds", detail: "Insufficient funds" }] }, { status: 403 }),
+      );
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "oauth-token",
+        fallbackAuthorization: "slug:key",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect((error as QontoApiError).status).toBe(403);
+      expect((error as QontoApiError).errors[0]?.code).toBe("insufficient_funds");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("QontoScaRequiredError", () => {

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -404,6 +404,16 @@ export class HttpClient {
       }
 
       if ((response.status === 401 || response.status === 403) && this.fallbackAuthorization !== undefined) {
+        const primaryErrorBody = await this.safeReadJson(response);
+        const primaryErrors = this.extractErrors(primaryErrorBody);
+
+        this.logDebug(`Primary auth error response body: ${JSON.stringify(redactSensitiveFields(primaryErrorBody))}`);
+
+        if (!this.isAuthError(primaryErrors)) {
+          this.logVerbose(`${response.status} error is not auth-related, propagating primary error`);
+          throw new QontoApiError(response.status, primaryErrors);
+        }
+
         this.logVerbose(`${response.status} with primary auth, retrying with fallback authorization`);
         this.onFallback?.(method, path);
 
@@ -531,6 +541,11 @@ export class HttpClient {
       return (body as { sca_session_token: string }).sca_session_token;
     }
     return "unknown";
+  }
+
+  private isAuthError(errors: readonly QontoApiErrorEntry[]): boolean {
+    const authPattern = /\b(unauthorized|forbidden|unauthenticated|authentication|authorization|oauth)\b/i;
+    return errors.some((e) => authPattern.test(e.code) || authPattern.test(e.detail));
   }
 
   private extractErrors(body: unknown): readonly QontoApiErrorEntry[] {


### PR DESCRIPTION
## Summary

- Read and debug-log the primary auth error response body before triggering the API key fallback, so diagnosis is possible in debug mode
- Discriminate auth errors from domain errors: non-auth 401/403 errors (e.g. `vop_proof_token_missing`) are now propagated directly instead of masking them behind the fallback error
- Add `isAuthError` helper that pattern-matches error codes/details for auth-related keywords

Closes #317

## Test plan

- [x] Existing fallback tests still pass (auth 401/403 triggers fallback as before)
- [x] New test: debug logger receives primary error body before fallback
- [x] New test: non-auth 401 error (`vop_proof_token_missing`) propagates directly, no fallback triggered
- [x] New test: non-auth 403 error (`insufficient_funds`) propagates directly, no fallback triggered
- [x] All 555 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)