### PR TITLE
(fix) replace mockReturnValue with mockImplementation for fetch mocks

### DIFF
--- a/packages/cli/src/commands/account.test.ts
+++ b/packages/cli/src/commands/account.test.ts
@@ -130,7 +130,7 @@ describe("registerAccountCommands", () => {
   describe("account list", () => {
     it("lists bank accounts in table format", async () => {
       const accounts = [makeAccount(), makeAccount({ id: "acc-2", name: "Savings", balance: 5000 })];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           bank_accounts: accounts,
           meta: makeMeta({ total_count: 2 }),
@@ -161,7 +161,7 @@ describe("registerAccountCommands", () => {
 
     it("lists bank accounts in json format", async () => {
       const accounts = [makeAccount()];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           bank_accounts: accounts,
           meta: makeMeta({ total_count: 1 }),

--- a/packages/cli/src/commands/attachment.test.ts
+++ b/packages/cli/src/commands/attachment.test.ts
@@ -44,7 +44,7 @@ describe("attachment commands", () => {
 
   describe("attachment show", () => {
     it("shows attachment details in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -60,7 +60,7 @@ describe("attachment commands", () => {
     });
 
     it("shows attachment details in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -79,7 +79,7 @@ describe("attachment commands", () => {
     });
 
     it("sends GET to the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -96,7 +96,7 @@ describe("attachment commands", () => {
 
   describe("attachment upload", () => {
     it("uploads a file via multipart form-data", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -117,7 +117,7 @@ describe("attachment commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/beneficiary/add.test.ts
+++ b/packages/cli/src/commands/beneficiary/add.test.ts
@@ -46,7 +46,7 @@ describe("beneficiary add command", () => {
   });
 
   it("creates a beneficiary in table format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -63,7 +63,7 @@ describe("beneficiary add command", () => {
   });
 
   it("creates a beneficiary in json format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -81,7 +81,7 @@ describe("beneficiary add command", () => {
   });
 
   it("sends POST to the correct endpoint with body", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();

--- a/packages/cli/src/commands/beneficiary/list.test.ts
+++ b/packages/cli/src/commands/beneficiary/list.test.ts
@@ -72,7 +72,7 @@ describe("beneficiary list command", () => {
         updated_at: "2025-02-01T00:00:00.000Z",
       },
     ];
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiaries,
         meta: makeMeta({ total_count: 2 }),
@@ -108,7 +108,7 @@ describe("beneficiary list command", () => {
         updated_at: "2025-01-01T00:00:00.000Z",
       },
     ];
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiaries,
         meta: makeMeta({ total_count: 1 }),
@@ -129,7 +129,7 @@ describe("beneficiary list command", () => {
   });
 
   it("passes filter options to API", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiaries: [],
         meta: makeMeta(),
@@ -148,7 +148,7 @@ describe("beneficiary list command", () => {
   });
 
   it("passes pagination options to API", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiaries: [],
         meta: makeMeta(),
@@ -167,7 +167,7 @@ describe("beneficiary list command", () => {
   });
 
   it("calls the correct API endpoint", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiaries: [],
         meta: makeMeta(),

--- a/packages/cli/src/commands/beneficiary/show.test.ts
+++ b/packages/cli/src/commands/beneficiary/show.test.ts
@@ -45,7 +45,7 @@ describe("beneficiary show command", () => {
       created_at: "2025-01-01T00:00:00.000Z",
       updated_at: "2025-01-01T00:00:00.000Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -72,7 +72,7 @@ describe("beneficiary show command", () => {
       created_at: "2025-01-01T00:00:00.000Z",
       updated_at: "2025-01-01T00:00:00.000Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -87,7 +87,7 @@ describe("beneficiary show command", () => {
   });
 
   it("calls the correct API endpoint", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         beneficiary: {
           id: "ben-1",

--- a/packages/cli/src/commands/beneficiary/trust.test.ts
+++ b/packages/cli/src/commands/beneficiary/trust.test.ts
@@ -33,7 +33,7 @@ describe("beneficiary trust command", () => {
   });
 
   it("trusts a single beneficiary in text format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -47,7 +47,7 @@ describe("beneficiary trust command", () => {
   });
 
   it("trusts multiple beneficiaries in text format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -61,7 +61,7 @@ describe("beneficiary trust command", () => {
   });
 
   it("outputs json confirmation", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -77,7 +77,7 @@ describe("beneficiary trust command", () => {
   });
 
   it("sends POST with ids to the correct endpoint", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();

--- a/packages/cli/src/commands/beneficiary/untrust.test.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.test.ts
@@ -33,7 +33,7 @@ describe("beneficiary untrust command", () => {
   });
 
   it("untrusts a single beneficiary in text format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -47,7 +47,7 @@ describe("beneficiary untrust command", () => {
   });
 
   it("untrusts multiple beneficiaries in text format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -61,7 +61,7 @@ describe("beneficiary untrust command", () => {
   });
 
   it("outputs json confirmation", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -77,7 +77,7 @@ describe("beneficiary untrust command", () => {
   });
 
   it("sends POST with ids to the correct endpoint", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({}));
+    fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();

--- a/packages/cli/src/commands/beneficiary/update.test.ts
+++ b/packages/cli/src/commands/beneficiary/update.test.ts
@@ -46,7 +46,7 @@ describe("beneficiary update command", () => {
   });
 
   it("updates a beneficiary in table format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -61,7 +61,7 @@ describe("beneficiary update command", () => {
   });
 
   it("updates a beneficiary in json format", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -78,7 +78,7 @@ describe("beneficiary update command", () => {
   });
 
   it("sends PUT to the correct endpoint with body", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ beneficiary: sampleBeneficiary }));
+    fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();

--- a/packages/cli/src/commands/card/card.test.ts
+++ b/packages/cli/src/commands/card/card.test.ts
@@ -130,7 +130,7 @@ describe("card commands", () => {
   describe("card list", () => {
     it("lists cards in table format", async () => {
       const cards = [makeCard(), makeCard({ id: "card-2", nickname: "Second Card", status: "paused" })];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           cards,
           meta: makeMeta({ total_count: 2 }),
@@ -153,7 +153,7 @@ describe("card commands", () => {
 
     it("lists cards in json format", async () => {
       const cards = [makeCard()];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           cards,
           meta: makeMeta({ total_count: 1 }),
@@ -173,7 +173,7 @@ describe("card commands", () => {
     });
 
     it("passes filter options as query params", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           cards: [],
           meta: makeMeta(),
@@ -215,7 +215,7 @@ describe("card commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           cards: [],
           meta: makeMeta(),
@@ -236,7 +236,7 @@ describe("card commands", () => {
   describe("card create", () => {
     it("creates a card and outputs in table format", async () => {
       const card = makeCard({ status: "pending" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -267,7 +267,7 @@ describe("card commands", () => {
 
     it("sends POST to the correct endpoint with card params", async () => {
       const card = makeCard();
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -308,7 +308,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "pending" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -342,7 +342,7 @@ describe("card commands", () => {
 
     it("sends optional params when provided", async () => {
       const card = makeCard();
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -436,7 +436,7 @@ describe("card commands", () => {
   describe("card bulk-create", () => {
     it("bulk creates cards from a JSON file", async () => {
       const cards = [makeCard({ id: "card-a" }), makeCard({ id: "card-b" })];
-      fetchSpy.mockReturnValue(jsonResponse({ cards }));
+      fetchSpy.mockImplementation(() => jsonResponse({ cards }));
 
       const { readFile } = await import("node:fs/promises");
       const readFileMock = vi.mocked(readFile);
@@ -467,7 +467,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const cards = [makeCard({ id: "card-a" })];
-      fetchSpy.mockReturnValue(jsonResponse({ cards }));
+      fetchSpy.mockImplementation(() => jsonResponse({ cards }));
 
       const { readFile } = await import("node:fs/promises");
       const readFileMock = vi.mocked(readFile);
@@ -499,7 +499,7 @@ describe("card commands", () => {
   describe("card lock", () => {
     it("locks a card and outputs result", async () => {
       const card = makeCard({ status: "paused" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -515,7 +515,7 @@ describe("card commands", () => {
 
     it("calls the correct API endpoint for lock", async () => {
       const card = makeCard({ status: "paused" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -530,7 +530,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "paused" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -549,7 +549,7 @@ describe("card commands", () => {
   describe("card unlock", () => {
     it("unlocks a card and outputs result", async () => {
       const card = makeCard({ status: "live" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -565,7 +565,7 @@ describe("card commands", () => {
 
     it("calls the correct API endpoint for unlock", async () => {
       const card = makeCard({ status: "live" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -580,7 +580,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "live" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -599,7 +599,7 @@ describe("card commands", () => {
   describe("card report-lost", () => {
     it("reports a card as lost with --yes flag", async () => {
       const card = makeCard({ status: "lost" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -629,7 +629,7 @@ describe("card commands", () => {
 
     it("calls the correct API endpoint for report-lost", async () => {
       const card = makeCard({ status: "lost" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -644,7 +644,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "lost" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -662,7 +662,7 @@ describe("card commands", () => {
   describe("card report-stolen", () => {
     it("reports a card as stolen with --yes flag", async () => {
       const card = makeCard({ status: "stolen" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -692,7 +692,7 @@ describe("card commands", () => {
 
     it("calls the correct API endpoint for report-stolen", async () => {
       const card = makeCard({ status: "stolen" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -707,7 +707,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "stolen" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -725,7 +725,7 @@ describe("card commands", () => {
   describe("card discard", () => {
     it("discards a card with --yes flag", async () => {
       const card = makeCard({ status: "discarded" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -755,7 +755,7 @@ describe("card commands", () => {
 
     it("calls the correct API endpoint for discard", async () => {
       const card = makeCard({ status: "discarded" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -770,7 +770,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ status: "discarded" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -788,7 +788,7 @@ describe("card commands", () => {
   describe("card update-limits", () => {
     it("updates card limits and outputs result", async () => {
       const card = makeCard({ payment_monthly_limit: 3000 });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -805,7 +805,7 @@ describe("card commands", () => {
 
     it("sends PATCH to the correct endpoint with limit params", async () => {
       const card = makeCard({ payment_monthly_limit: 3000 });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -824,7 +824,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ payment_monthly_limit: 3000 });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -843,7 +843,7 @@ describe("card commands", () => {
 
     it("sends all limit params when provided", async () => {
       const card = makeCard();
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -897,7 +897,7 @@ describe("card commands", () => {
   describe("card update-nickname", () => {
     it("updates card nickname and outputs result", async () => {
       const card = makeCard({ nickname: "New Name" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -913,7 +913,7 @@ describe("card commands", () => {
 
     it("sends PATCH to the correct endpoint with nickname", async () => {
       const card = makeCard({ nickname: "New Name" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -930,7 +930,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ nickname: "New Name" });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -951,7 +951,7 @@ describe("card commands", () => {
   describe("card update-options", () => {
     it("updates card options and outputs result", async () => {
       const card = makeCard({ atm_option: false, nfc_option: true, online_option: true, foreign_option: false });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -981,7 +981,7 @@ describe("card commands", () => {
 
     it("sends PATCH to the correct endpoint with option params", async () => {
       const card = makeCard();
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1020,7 +1020,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard();
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1055,7 +1055,7 @@ describe("card commands", () => {
   describe("card update-restrictions", () => {
     it("updates card restrictions and outputs result", async () => {
       const card = makeCard({ active_days: [1, 2, 3], categories: ["transport"] });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1073,7 +1073,7 @@ describe("card commands", () => {
 
     it("sends PATCH to the correct endpoint with restriction params", async () => {
       const card = makeCard({ active_days: [1, 2, 3], categories: ["transport"] });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1098,7 +1098,7 @@ describe("card commands", () => {
 
     it("outputs json format when requested", async () => {
       const card = makeCard({ active_days: [1, 2, 3], categories: ["transport"] });
-      fetchSpy.mockReturnValue(jsonResponse({ card }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1130,7 +1130,7 @@ describe("card commands", () => {
 
   describe("card iframe-url", () => {
     it("gets iframe url and outputs result", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
+      fetchSpy.mockImplementation(() => jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1144,7 +1144,7 @@ describe("card commands", () => {
     });
 
     it("calls the correct API endpoint for iframe-url", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
+      fetchSpy.mockImplementation(() => jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1157,7 +1157,7 @@ describe("card commands", () => {
     });
 
     it("outputs json format when requested", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
+      fetchSpy.mockImplementation(() => jsonResponse({ iframe_url: "https://secure.qonto.com/iframe/card-1" }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1197,7 +1197,7 @@ describe("card commands", () => {
           ],
         },
       ];
-      fetchSpy.mockReturnValue(jsonResponse({ card_type_appearances: appearances }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card_type_appearances: appearances }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1213,7 +1213,7 @@ describe("card commands", () => {
     });
 
     it("calls the correct API endpoint for appearances", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ card_type_appearances: [] }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card_type_appearances: [] }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -1249,7 +1249,7 @@ describe("card commands", () => {
           ],
         },
       ];
-      fetchSpy.mockReturnValue(jsonResponse({ card_type_appearances: appearances }));
+      fetchSpy.mockImplementation(() => jsonResponse({ card_type_appearances: appearances }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/client-invoice.test.ts
+++ b/packages/cli/src/commands/client-invoice.test.ts
@@ -108,7 +108,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice list", () => {
     it("lists invoices in table format", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           client_invoices: [sampleInvoice],
           meta: {
@@ -136,7 +136,7 @@ describe("client-invoice commands", () => {
     });
 
     it("lists invoices in json format", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           client_invoices: [sampleInvoice],
           meta: {
@@ -170,7 +170,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice show", () => {
     it("shows invoice details in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -187,7 +187,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -203,7 +203,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice create", () => {
     it("creates an invoice in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -220,7 +220,7 @@ describe("client-invoice commands", () => {
     });
 
     it("sends POST to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -236,7 +236,7 @@ describe("client-invoice commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -256,7 +256,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice update", () => {
     it("updates an invoice in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -275,7 +275,7 @@ describe("client-invoice commands", () => {
     });
 
     it("sends PATCH to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -293,7 +293,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice delete", () => {
     it("deletes an invoice with --yes flag", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -312,7 +312,7 @@ describe("client-invoice commands", () => {
     });
 
     it("sends DELETE to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -345,7 +345,7 @@ describe("client-invoice commands", () => {
   describe("client-invoice finalize", () => {
     it("finalizes an invoice in json format", async () => {
       const finalized = { ...sampleInvoice, status: "pending", invoice_number: "INV-001" };
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: finalized }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: finalized }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -361,7 +361,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -378,7 +378,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice send", () => {
     it("sends an invoice in json format", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -394,7 +394,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -412,7 +412,7 @@ describe("client-invoice commands", () => {
   describe("client-invoice mark-paid", () => {
     it("marks an invoice as paid in json format", async () => {
       const paid = { ...sampleInvoice, status: "paid" };
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: paid }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: paid }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -428,7 +428,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -446,7 +446,7 @@ describe("client-invoice commands", () => {
   describe("client-invoice unmark-paid", () => {
     it("unmarks a paid invoice in json format", async () => {
       const pending = { ...sampleInvoice, status: "pending" };
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: pending }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: pending }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -462,7 +462,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -480,7 +480,7 @@ describe("client-invoice commands", () => {
   describe("client-invoice cancel", () => {
     it("cancels an invoice in json format", async () => {
       const cancelled = { ...sampleInvoice, status: "cancelled" };
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: cancelled }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: cancelled }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -496,7 +496,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client_invoice: sampleInvoice }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client_invoice: sampleInvoice }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -513,7 +513,7 @@ describe("client-invoice commands", () => {
 
   describe("client-invoice upload-show", () => {
     it("shows upload details in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ upload: sampleUpload }));
+      fetchSpy.mockImplementation(() => jsonResponse({ upload: sampleUpload }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -532,7 +532,7 @@ describe("client-invoice commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ upload: sampleUpload }));
+      fetchSpy.mockImplementation(() => jsonResponse({ upload: sampleUpload }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/client.test.ts
+++ b/packages/cli/src/commands/client.test.ts
@@ -60,7 +60,7 @@ describe("client commands", () => {
 
   describe("client list", () => {
     it("lists clients in table format", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           clients: [sampleClient],
           meta: {
@@ -88,7 +88,7 @@ describe("client commands", () => {
     });
 
     it("lists clients in json format", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           clients: [sampleClient],
           meta: {
@@ -123,7 +123,7 @@ describe("client commands", () => {
 
   describe("client show", () => {
     it("shows client details in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -141,7 +141,7 @@ describe("client commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -157,7 +157,7 @@ describe("client commands", () => {
 
   describe("client create", () => {
     it("creates a company client in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -173,7 +173,7 @@ describe("client commands", () => {
     });
 
     it("creates a client in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -192,7 +192,7 @@ describe("client commands", () => {
     });
 
     it("sends POST with flat body to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -216,7 +216,7 @@ describe("client commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -236,7 +236,7 @@ describe("client commands", () => {
 
   describe("client update", () => {
     it("updates a client in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: { ...sampleClient, name: "Acme Inc" } }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: { ...sampleClient, name: "Acme Inc" } }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -255,7 +255,7 @@ describe("client commands", () => {
     });
 
     it("sends PATCH with flat body to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ client: sampleClient }));
+      fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -279,7 +279,7 @@ describe("client commands", () => {
 
   describe("client delete", () => {
     it("deletes a client with --yes flag", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -296,7 +296,7 @@ describe("client commands", () => {
     });
 
     it("sends DELETE to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/credit-note.test.ts
+++ b/packages/cli/src/commands/credit-note.test.ts
@@ -91,7 +91,7 @@ describe("credit-note commands", () => {
   describe("credit-note list", () => {
     it("lists credit notes in table format", async () => {
       const creditNotes = [makeCreditNote(), makeCreditNote({ id: "cn-002", number: "CN-2026-002" })];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           credit_notes: creditNotes,
           meta: makeMeta({ total_count: 2 }),
@@ -116,7 +116,7 @@ describe("credit-note commands", () => {
 
     it("lists credit notes in json format", async () => {
       const creditNotes = [makeCreditNote()];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           credit_notes: creditNotes,
           meta: makeMeta({ total_count: 1 }),
@@ -141,7 +141,7 @@ describe("credit-note commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           credit_notes: [],
           meta: makeMeta(),
@@ -164,7 +164,7 @@ describe("credit-note commands", () => {
   describe("credit-note show", () => {
     it("shows credit note details in table format", async () => {
       const creditNote = makeCreditNote();
-      fetchSpy.mockReturnValue(jsonResponse({ credit_note: creditNote }));
+      fetchSpy.mockImplementation(() => jsonResponse({ credit_note: creditNote }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -184,7 +184,7 @@ describe("credit-note commands", () => {
 
     it("shows credit note in json format", async () => {
       const creditNote = makeCreditNote();
-      fetchSpy.mockReturnValue(jsonResponse({ credit_note: creditNote }));
+      fetchSpy.mockImplementation(() => jsonResponse({ credit_note: creditNote }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -201,7 +201,7 @@ describe("credit-note commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           credit_note: makeCreditNote(),
         }),

--- a/packages/cli/src/commands/internal-transfer.test.ts
+++ b/packages/cli/src/commands/internal-transfer.test.ts
@@ -49,7 +49,7 @@ describe("internal-transfer commands", () => {
 
   describe("internal-transfer create", () => {
     it("creates an internal transfer in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ internal_transfer: sampleInternalTransfer }));
+      fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -79,7 +79,7 @@ describe("internal-transfer commands", () => {
     });
 
     it("creates an internal transfer in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ internal_transfer: sampleInternalTransfer }));
+      fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -116,7 +116,7 @@ describe("internal-transfer commands", () => {
     });
 
     it("sends POST to the correct API endpoint with body", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ internal_transfer: sampleInternalTransfer }));
+      fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -155,7 +155,7 @@ describe("internal-transfer commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ internal_transfer: sampleInternalTransfer }));
+      fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -186,7 +186,7 @@ describe("internal-transfer commands", () => {
     });
 
     it("defaults currency to EUR", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ internal_transfer: sampleInternalTransfer }));
+      fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/label.test.ts
+++ b/packages/cli/src/commands/label.test.ts
@@ -52,7 +52,7 @@ describe("label commands", () => {
         { id: "abc-123", name: "Marketing", parent_id: null },
         { id: "def-456", name: "Digital", parent_id: "abc-123" },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           labels,
           meta: makeMeta({ total_count: 2 }),
@@ -76,7 +76,7 @@ describe("label commands", () => {
 
     it("lists labels in json format", async () => {
       const labels = [{ id: "abc-123", name: "Marketing", parent_id: null }];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           labels,
           meta: makeMeta({ total_count: 1 }),
@@ -104,7 +104,7 @@ describe("label commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           labels: [],
           meta: makeMeta(),
@@ -131,7 +131,7 @@ describe("label commands", () => {
         name: "Marketing",
         parent_id: "parent-id",
       };
-      fetchSpy.mockReturnValue(jsonResponse({ label }));
+      fetchSpy.mockImplementation(() => jsonResponse({ label }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -155,7 +155,7 @@ describe("label commands", () => {
         name: "Root Label",
         parent_id: null,
       };
-      fetchSpy.mockReturnValue(jsonResponse({ label }));
+      fetchSpy.mockImplementation(() => jsonResponse({ label }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -175,7 +175,7 @@ describe("label commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           label: { id: "abc-123", name: "Test", parent_id: null },
         }),

--- a/packages/cli/src/commands/membership.test.ts
+++ b/packages/cli/src/commands/membership.test.ts
@@ -78,7 +78,7 @@ describe("membership commands", () => {
           status: "active",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           memberships,
           meta: makeMeta({ total_count: 2 }),
@@ -119,7 +119,7 @@ describe("membership commands", () => {
           status: "active",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           memberships,
           meta: makeMeta({ total_count: 1 }),
@@ -156,7 +156,7 @@ describe("membership commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           memberships: [],
           meta: makeMeta(),
@@ -176,7 +176,7 @@ describe("membership commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           memberships: [],
           meta: makeMeta(),
@@ -212,7 +212,7 @@ describe("membership commands", () => {
     };
 
     it("shows current user's membership in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: sampleMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -231,7 +231,7 @@ describe("membership commands", () => {
     });
 
     it("shows current user's membership in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: sampleMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -249,7 +249,7 @@ describe("membership commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: sampleMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -280,7 +280,7 @@ describe("membership commands", () => {
     };
 
     it("invites a new member in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: invitedMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -302,7 +302,7 @@ describe("membership commands", () => {
     });
 
     it("invites a new member in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: invitedMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -321,7 +321,7 @@ describe("membership commands", () => {
     });
 
     it("sends POST with nested membership body to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: invitedMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -360,7 +360,7 @@ describe("membership commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ membership: invitedMembership }));
+      fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/profile/test.test.ts
+++ b/packages/cli/src/commands/profile/test.test.ts
@@ -46,7 +46,7 @@ describe("profile test", () => {
       "api-key:\n  organization-slug: my-org\n  secret-key: sk_test_1234\n",
     );
 
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       Promise.resolve(
         new Response(
           JSON.stringify({
@@ -70,7 +70,7 @@ describe("profile test", () => {
     await mkdir(configDir, { recursive: true });
     await writeFile(join(configDir, "bad.yaml"), "api-key:\n  organization-slug: bad-org\n  secret-key: sk_invalid\n");
 
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       Promise.resolve(
         new Response(
           JSON.stringify({

--- a/packages/cli/src/commands/request/list.test.ts
+++ b/packages/cli/src/commands/request/list.test.ts
@@ -82,7 +82,7 @@ describe("request commands", () => {
           currency: "EUR",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           requests,
           meta: makeMeta({ total_count: 2 }),
@@ -125,7 +125,7 @@ describe("request commands", () => {
           card_design: "default",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           requests,
           meta: makeMeta({ total_count: 1 }),
@@ -163,7 +163,7 @@ describe("request commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           requests: [],
           meta: makeMeta(),
@@ -183,7 +183,7 @@ describe("request commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           requests: [],
           meta: makeMeta(),

--- a/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
@@ -42,7 +42,7 @@ describe("supplier-invoice bulk-create command", () => {
   });
 
   it("creates supplier invoices from files", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [
           {
@@ -86,7 +86,7 @@ describe("supplier-invoice bulk-create command", () => {
   });
 
   it("outputs json format for created invoices", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [
           {
@@ -133,7 +133,7 @@ describe("supplier-invoice bulk-create command", () => {
   });
 
   it("writes errors to stderr and sets exit code", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [],
         errors: [
@@ -158,7 +158,7 @@ describe("supplier-invoice bulk-create command", () => {
   });
 
   it("sends FormData to the bulk endpoint", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [],
         errors: [],

--- a/packages/cli/src/commands/supplier-invoice/list.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/list.test.ts
@@ -46,7 +46,7 @@ describe("supplier-invoice list command", () => {
   });
 
   it("lists supplier invoices in table format", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [
           {
@@ -118,7 +118,7 @@ describe("supplier-invoice list command", () => {
         updated_at: "2026-03-01T00:00:00.000Z",
       },
     ];
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: invoices,
         meta: makeMeta({ total_count: 1 }),
@@ -140,7 +140,7 @@ describe("supplier-invoice list command", () => {
   });
 
   it("formats total_amount as null when absent", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [
           {
@@ -182,7 +182,7 @@ describe("supplier-invoice list command", () => {
   });
 
   it("passes status filter to API", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [],
         meta: makeMeta(),
@@ -200,7 +200,7 @@ describe("supplier-invoice list command", () => {
   });
 
   it("passes query and sort params", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoices: [],
         meta: makeMeta(),

--- a/packages/cli/src/commands/supplier-invoice/show.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/show.test.ts
@@ -33,7 +33,7 @@ describe("supplier-invoice show command", () => {
   });
 
   it("shows a supplier invoice in table format", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoice: {
           id: "inv-1",
@@ -100,7 +100,7 @@ describe("supplier-invoice show command", () => {
       created_at: "2026-03-01T00:00:00.000Z",
       updated_at: "2026-03-01T00:00:00.000Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ supplier_invoice: invoice }));
+    fetchSpy.mockImplementation(() => jsonResponse({ supplier_invoice: invoice }));
 
     const { createProgram } = await import("../../program.js");
     const program = createProgram();
@@ -116,7 +116,7 @@ describe("supplier-invoice show command", () => {
   });
 
   it("handles null total_amount in table format", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoice: {
           id: "inv-2",
@@ -155,7 +155,7 @@ describe("supplier-invoice show command", () => {
   });
 
   it("calls the correct API endpoint", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         supplier_invoice: {
           id: "inv-1",

--- a/packages/cli/src/commands/team.test.ts
+++ b/packages/cli/src/commands/team.test.ts
@@ -51,7 +51,7 @@ describe("team commands", () => {
         { id: "team-1", name: "Engineering" },
         { id: "team-2", name: "Marketing" },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           teams,
           meta: makeMeta({ total_count: 2 }),
@@ -74,7 +74,7 @@ describe("team commands", () => {
 
     it("lists teams in json format with full API fields", async () => {
       const teams = [{ id: "team-1", name: "Engineering" }];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           teams,
           meta: makeMeta({ total_count: 1 }),
@@ -100,7 +100,7 @@ describe("team commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           teams: [],
           meta: makeMeta(),
@@ -119,7 +119,7 @@ describe("team commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           teams: [],
           meta: makeMeta(),
@@ -144,7 +144,7 @@ describe("team commands", () => {
     };
 
     it("creates a team in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+      fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -160,7 +160,7 @@ describe("team commands", () => {
     });
 
     it("creates a team in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+      fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -175,7 +175,7 @@ describe("team commands", () => {
     });
 
     it("sends POST with name body to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+      fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -191,7 +191,7 @@ describe("team commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ team: createdTeam }));
+      fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/commands/transaction/attachment.test.ts
+++ b/packages/cli/src/commands/transaction/attachment.test.ts
@@ -49,7 +49,7 @@ describe("transaction attachment commands", () => {
 
   describe("transaction attachment list", () => {
     it("lists attachments for a transaction in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachments: [sampleAttachment] }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -64,7 +64,7 @@ describe("transaction attachment commands", () => {
     });
 
     it("lists attachments in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachments: [sampleAttachment] }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -80,7 +80,7 @@ describe("transaction attachment commands", () => {
     });
 
     it("sends GET to the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachments: [sampleAttachment] }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -96,7 +96,7 @@ describe("transaction attachment commands", () => {
 
   describe("transaction attachment add", () => {
     it("attaches a file to a transaction via multipart form-data", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ attachment: sampleAttachment }));
+      fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
       const { createProgram } = await import("../../program.js");
       const program = createProgram();
@@ -115,7 +115,7 @@ describe("transaction attachment commands", () => {
     });
 
     it("prints success to stderr when API returns no attachment data", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({}));
+      fetchSpy.mockImplementation(() => jsonResponse({}));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
       const { createProgram } = await import("../../program.js");
@@ -132,7 +132,7 @@ describe("transaction attachment commands", () => {
 
   describe("transaction attachment remove (specific)", () => {
     it("removes a specific attachment from a transaction", async () => {
-      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
       const { createProgram } = await import("../../program.js");
@@ -154,7 +154,7 @@ describe("transaction attachment commands", () => {
     it("removes all attachments when user confirms", async () => {
       vi.mocked(confirm).mockResolvedValue(true);
       vi.mocked(isCancel).mockReturnValue(false);
-      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
       const { createProgram } = await import("../../program.js");

--- a/packages/cli/src/commands/transaction/list.test.ts
+++ b/packages/cli/src/commands/transaction/list.test.ts
@@ -84,7 +84,7 @@ describe("transaction list command", () => {
   });
 
   it("sends request to /v2/transactions", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transactions: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transactions: [], meta: makeMeta() }));
 
     await runCommand("--bank-account", "acc-123");
 
@@ -95,7 +95,7 @@ describe("transaction list command", () => {
   });
 
   it("passes settled date filter options as query params", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transactions: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transactions: [], meta: makeMeta() }));
 
     await runCommand(
       "--bank-account",
@@ -119,7 +119,7 @@ describe("transaction list command", () => {
   });
 
   it("passes emitted date filter options as query params", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transactions: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transactions: [], meta: makeMeta() }));
 
     await runCommand("--bank-account", "acc-1", "--emitted-from", "2025-02-01", "--emitted-to", "2025-02-28");
 
@@ -129,7 +129,7 @@ describe("transaction list command", () => {
   });
 
   it("passes updated date filter options as query params", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transactions: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transactions: [], meta: makeMeta() }));
 
     await runCommand("--bank-account", "acc-1", "--updated-from", "2025-03-01", "--updated-to", "2025-03-31");
 

--- a/packages/cli/src/commands/transaction/show.test.ts
+++ b/packages/cli/src/commands/transaction/show.test.ts
@@ -86,7 +86,7 @@ describe("transaction show command", () => {
       bank_account_id: "ba-1",
       is_external_transaction: false,
     };
-    fetchSpy.mockReturnValue(jsonResponse({ transaction: txn }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transaction: txn }));
 
     await runCommand("txn-123", "--output", "json");
 
@@ -99,7 +99,7 @@ describe("transaction show command", () => {
   });
 
   it("passes includes as query params", async () => {
-    fetchSpy.mockReturnValue(
+    fetchSpy.mockImplementation(() =>
       jsonResponse({
         transaction: {
           id: "txn-1",
@@ -183,7 +183,7 @@ describe("transaction show command", () => {
       bank_account_id: "ba-1",
       is_external_transaction: false,
     };
-    fetchSpy.mockReturnValue(jsonResponse({ transaction: txn }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transaction: txn }));
 
     await runCommand("txn-1", "--output", "yaml");
 

--- a/packages/cli/src/commands/transfer/list.test.ts
+++ b/packages/cli/src/commands/transfer/list.test.ts
@@ -48,7 +48,7 @@ describe("transfer list command", () => {
   }
 
   it("sends request to /v2/sepa/transfers", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfers: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers: [], meta: makeMeta() }));
 
     await runCommand();
 
@@ -58,7 +58,7 @@ describe("transfer list command", () => {
   });
 
   it("passes status filter as array param", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfers: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers: [], meta: makeMeta() }));
 
     await runCommand("--status", "pending", "settled");
 
@@ -67,7 +67,7 @@ describe("transfer list command", () => {
   });
 
   it("passes beneficiary filter", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfers: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers: [], meta: makeMeta() }));
 
     await runCommand("--beneficiary", "ben-123");
 
@@ -76,7 +76,7 @@ describe("transfer list command", () => {
   });
 
   it("passes date range and sort params", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfers: [], meta: makeMeta() }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers: [], meta: makeMeta() }));
 
     await runCommand("--from", "2025-01-01", "--to", "2025-01-31", "--sort-by", "updated_at:desc");
 
@@ -97,7 +97,7 @@ describe("transfer list command", () => {
         reference: "Invoice 001",
       },
     ];
-    fetchSpy.mockReturnValue(jsonResponse({ transfers, meta: makeMeta({ total_count: 1 }) }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers, meta: makeMeta({ total_count: 1 }) }));
 
     await runCommand("--output", "json");
 
@@ -120,7 +120,7 @@ describe("transfer list command", () => {
         note: "should-not-appear-in-table",
       },
     ];
-    fetchSpy.mockReturnValue(jsonResponse({ transfers, meta: makeMeta({ total_count: 1 }) }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfers, meta: makeMeta({ total_count: 1 }) }));
 
     await runCommand("--output", "table");
 

--- a/packages/cli/src/commands/transfer/show.test.ts
+++ b/packages/cli/src/commands/transfer/show.test.ts
@@ -57,7 +57,7 @@ describe("transfer show command", () => {
   };
 
   it("fetches a transfer by ID", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfer: completeTransfer }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfer: completeTransfer }));
 
     await runCommand("txfr-123", "--output", "json");
 
@@ -71,7 +71,7 @@ describe("transfer show command", () => {
 
   it("outputs yaml format for single transfer", async () => {
     const transfer = { ...completeTransfer, id: "txfr-1", amount: 1500, reference: "Office Rent" };
-    fetchSpy.mockReturnValue(jsonResponse({ transfer }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfer }));
 
     await runCommand("txfr-1", "--output", "yaml");
 
@@ -81,7 +81,7 @@ describe("transfer show command", () => {
   });
 
   it("calls the correct API endpoint with encoded ID", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ transfer: { ...completeTransfer, id: "a/b" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ transfer: { ...completeTransfer, id: "a/b" } }));
 
     await runCommand("a/b", "--output", "json");
 

--- a/packages/cli/src/commands/webhook.test.ts
+++ b/packages/cli/src/commands/webhook.test.ts
@@ -71,7 +71,7 @@ describe("webhook commands", () => {
           updated_at: "2026-01-02T00:00:00Z",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           webhook_subscriptions: webhooks,
           meta: makeMeta({ total_count: 2 }),
@@ -105,7 +105,7 @@ describe("webhook commands", () => {
           updated_at: "2026-01-01T00:00:00Z",
         },
       ];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           webhook_subscriptions: webhooks,
           meta: makeMeta({ total_count: 1 }),
@@ -137,7 +137,7 @@ describe("webhook commands", () => {
     });
 
     it("passes pagination options to API", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           webhook_subscriptions: [],
           meta: makeMeta(),
@@ -157,7 +157,7 @@ describe("webhook commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           webhook_subscriptions: [],
           meta: makeMeta(),
@@ -188,7 +188,7 @@ describe("webhook commands", () => {
     };
 
     it("shows webhook details in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -207,7 +207,7 @@ describe("webhook commands", () => {
     });
 
     it("shows webhook details in table format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -225,7 +225,7 @@ describe("webhook commands", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -251,7 +251,7 @@ describe("webhook commands", () => {
     };
 
     it("creates a webhook in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -282,7 +282,7 @@ describe("webhook commands", () => {
     });
 
     it("sends POST to the correct endpoint with body", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -305,7 +305,7 @@ describe("webhook commands", () => {
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -344,7 +344,7 @@ describe("webhook commands", () => {
     };
 
     it("updates a webhook in json format", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: updatedWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -364,7 +364,7 @@ describe("webhook commands", () => {
     });
 
     it("sends PUT to the correct endpoint with body", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: updatedWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -398,7 +398,7 @@ describe("webhook commands", () => {
 
   describe("webhook delete", () => {
     it("deletes a webhook with --yes flag", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -417,7 +417,7 @@ describe("webhook commands", () => {
     });
 
     it("sends DELETE to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(new Response(null, { status: 204 }));
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();

--- a/packages/cli/src/pagination.test.ts
+++ b/packages/cli/src/pagination.test.ts
@@ -40,7 +40,7 @@ describe("pagination", () => {
     it("fetches a single page with correct query params", async () => {
       const items = [{ id: "1" }, { id: "2" }];
       const meta = makeMeta({ current_page: 1, total_count: 2 });
-      fetchSpy.mockReturnValue(jsonResponse({ transactions: items, meta }));
+      fetchSpy.mockImplementation(() => jsonResponse({ transactions: items, meta }));
 
       const result = await fetchPage(client, "/v2/transactions", "transactions", 1, 100);
 
@@ -53,7 +53,7 @@ describe("pagination", () => {
     });
 
     it("passes additional query params", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ transactions: [], meta: makeMeta() }));
+      fetchSpy.mockImplementation(() => jsonResponse({ transactions: [], meta: makeMeta() }));
 
       await fetchPage(client, "/v2/transactions", "transactions", 1, 50, {
         bank_account_id: "abc",
@@ -64,7 +64,7 @@ describe("pagination", () => {
     });
 
     it("returns empty items when collection key is missing", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ meta: makeMeta() }));
+      fetchSpy.mockImplementation(() => jsonResponse({ meta: makeMeta() }));
 
       const result = await fetchPage(client, "/v2/things", "things", 1, 100);
       expect(result.items).toEqual([]);
@@ -111,7 +111,7 @@ describe("pagination", () => {
 
     it("returns single page when there is only one", async () => {
       const items = [{ id: "1" }];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           items,
           meta: makeMeta({ total_count: 1 }),
@@ -149,7 +149,7 @@ describe("pagination", () => {
   describe("fetchPaginated", () => {
     it("fetches a specific page when --page is set", async () => {
       const items = [{ id: "3" }];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           items,
           meta: makeMeta({ current_page: 2, total_pages: 3, total_count: 5 }),
@@ -169,7 +169,7 @@ describe("pagination", () => {
 
     it("fetches only first page when --no-paginate is set", async () => {
       const items = [{ id: "1" }, { id: "2" }];
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           items,
           meta: makeMeta({
@@ -224,7 +224,7 @@ describe("pagination", () => {
     });
 
     it("uses custom --per-page value", async () => {
-      fetchSpy.mockReturnValue(
+      fetchSpy.mockImplementation(() =>
         jsonResponse({
           items: [{ id: "1" }],
           meta: makeMeta({ per_page: 25 }),

--- a/packages/cli/src/sca.test.ts
+++ b/packages/cli/src/sca.test.ts
@@ -55,7 +55,7 @@ describe("executeWithCliSca", () => {
   });
 
   it("starts spinner when SCA is required", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
     const mockSpin = createMockSpinner();
     let called = false;
 
@@ -75,7 +75,7 @@ describe("executeWithCliSca", () => {
   });
 
   it("stops spinner with success message on approval", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
     const mockSpin = createMockSpinner();
     let called = false;
 
@@ -119,7 +119,7 @@ describe("executeWithCliSca", () => {
   });
 
   it("stops spinner with error message on timeout", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "waiting" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "waiting" } }));
     const mockSpin = createMockSpinner();
     let called = false;
 
@@ -144,7 +144,7 @@ describe("executeWithCliSca", () => {
   });
 
   it("stops spinner with error message on denial", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "deny" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "deny" } }));
     const mockSpin = createMockSpinner();
     let called = false;
 
@@ -166,7 +166,7 @@ describe("executeWithCliSca", () => {
   });
 
   it("retries original operation with SCA token after approval", async () => {
-    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
     const mockSpin = createMockSpinner();
     let callCount = 0;
 


### PR DESCRIPTION
## Summary

- Replace all `fetchSpy.mockReturnValue(jsonResponse(...))` with `fetchSpy.mockImplementation(() => jsonResponse(...))` so each `fetch()` call gets a fresh `Response` with its own readable body
- Replace all `fetchSpy.mockReturnValue(new Response(...))` with `fetchSpy.mockImplementation(() => Promise.resolve(new Response(...)))` for the same reason
- 212 occurrences across 29 files in `packages/cli/src/**/*.test.ts`

## Test plan

- [x] Zero `fetchSpy.mockReturnValue` patterns remain in CLI tests
- [x] All 494 CLI unit tests pass locally
- [ ] CI passes on all 3 OS (ubuntu, macos, windows)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)