### PR TITLE
(feat) auto-resolve vop_proof_token in CLI transfer create

### DIFF
--- a/packages/cli/src/commands/transfer/create.test.ts
+++ b/packages/cli/src/commands/transfer/create.test.ts
@@ -14,6 +14,8 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
   return {
     ...actual,
     createTransfer: vi.fn(),
+    getBeneficiary: vi.fn(),
+    verifyPayee: vi.fn(),
   };
 });
 
@@ -26,8 +28,10 @@ vi.mock("../../sca.js", () => ({
 const { createClient } = await import("../../client.js");
 const createClientMock = vi.mocked(createClient);
 
-const { createTransfer } = await import("@qontoctl/core");
+const { createTransfer, getBeneficiary, verifyPayee } = await import("@qontoctl/core");
 const createTransferMock = vi.mocked(createTransfer);
+const getBeneficiaryMock = vi.mocked(getBeneficiary);
+const verifyPayeeMock = vi.mocked(verifyPayee);
 
 const sampleTransfer = {
   id: "txfr-new",
@@ -50,12 +54,28 @@ const sampleTransfer = {
   declined_reason: null,
 };
 
+const sampleBeneficiary = {
+  id: "ben-1",
+  name: "Acme Corp",
+  iban: "FR7612345000010009876543210",
+  bic: "BNPAFRPP",
+  email: null,
+  activity_tag: null,
+  status: "validated" as const,
+  trusted: true,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
 describe("transfer create command", () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
     createClientMock.mockResolvedValue({} as never);
   });
 
@@ -169,5 +189,158 @@ describe("transfer create command", () => {
       },
       expect.anything(),
     );
+  });
+
+  it("skips auto-verify when --vop-proof-token is provided", async () => {
+    createTransferMock.mockResolvedValue(sampleTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--reference",
+        "Test Payment",
+        "--amount",
+        "500",
+        "--vop-proof-token",
+        "tok_explicit",
+      ],
+      { from: "user" },
+    );
+
+    expect(getBeneficiaryMock).not.toHaveBeenCalled();
+    expect(verifyPayeeMock).not.toHaveBeenCalled();
+    expect(createTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_explicit" }),
+      expect.anything(),
+    );
+  });
+
+  it("auto-resolves vop_proof_token on match result", async () => {
+    getBeneficiaryMock.mockResolvedValue(sampleBeneficiary);
+    verifyPayeeMock.mockResolvedValue({
+      iban: sampleBeneficiary.iban,
+      name: sampleBeneficiary.name,
+      result: "match",
+      vop_proof_token: "tok_auto_match",
+    });
+    createTransferMock.mockResolvedValue(sampleTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--reference",
+        "Test Payment",
+        "--amount",
+        "500",
+      ],
+      { from: "user" },
+    );
+
+    expect(getBeneficiaryMock).toHaveBeenCalledWith(expect.anything(), "ben-1");
+    expect(verifyPayeeMock).toHaveBeenCalledWith(expect.anything(), {
+      iban: sampleBeneficiary.iban,
+      name: sampleBeneficiary.name,
+    });
+    expect(createTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_auto_match" }),
+      expect.anything(),
+    );
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("auto-resolves vop_proof_token on mismatch result with warning", async () => {
+    getBeneficiaryMock.mockResolvedValue(sampleBeneficiary);
+    verifyPayeeMock.mockResolvedValue({
+      iban: sampleBeneficiary.iban,
+      name: sampleBeneficiary.name,
+      result: "mismatch",
+      vop_proof_token: "tok_auto_mismatch",
+    });
+    createTransferMock.mockResolvedValue(sampleTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--reference",
+        "Test Payment",
+        "--amount",
+        "500",
+      ],
+      { from: "user" },
+    );
+
+    expect(createTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_auto_mismatch" }),
+      expect.anything(),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("mismatch"));
+  });
+
+  it("auto-resolves vop_proof_token on not_available result with warning", async () => {
+    getBeneficiaryMock.mockResolvedValue(sampleBeneficiary);
+    verifyPayeeMock.mockResolvedValue({
+      iban: sampleBeneficiary.iban,
+      name: sampleBeneficiary.name,
+      result: "not_available",
+      vop_proof_token: "tok_auto_unavail",
+    });
+    createTransferMock.mockResolvedValue(sampleTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--reference",
+        "Test Payment",
+        "--amount",
+        "500",
+      ],
+      { from: "user" },
+    );
+
+    expect(createTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_auto_unavail" }),
+      expect.anything(),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("not_available"));
   });
 });

--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -3,7 +3,14 @@
 
 import type { Command } from "commander";
 import { Option } from "commander";
-import { createTransfer, type CreateTransferParams, type Transfer } from "@qontoctl/core";
+import {
+  createTransfer,
+  getBeneficiary,
+  verifyPayee,
+  type CreateTransferParams,
+  type Transfer,
+  type HttpClient,
+} from "@qontoctl/core";
 import { createClient } from "../../client.js";
 import { formatOutput } from "../../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../../inherited-options.js";
@@ -18,7 +25,7 @@ interface TransferCreateOptions extends GlobalOptions, WriteOptions {
   readonly currency: string;
   readonly note?: string | undefined;
   readonly scheduledDate?: string | undefined;
-  readonly vopProofToken: string;
+  readonly vopProofToken?: string | undefined;
 }
 
 function toTableRow(t: Transfer): Record<string, string | number | null> {
@@ -33,6 +40,19 @@ function toTableRow(t: Transfer): Record<string, string | number | null> {
   };
 }
 
+async function resolveVopProofToken(httpClient: HttpClient, beneficiaryId: string): Promise<string> {
+  const beneficiary = await getBeneficiary(httpClient, beneficiaryId);
+  const vopResult = await verifyPayee(httpClient, { iban: beneficiary.iban, name: beneficiary.name });
+
+  if (vopResult.result === "mismatch") {
+    process.stderr.write(`Warning: VoP result is "mismatch" for beneficiary ${beneficiaryId}\n`);
+  } else if (vopResult.result === "not_available") {
+    process.stderr.write(`Warning: VoP result is "not_available" for beneficiary ${beneficiaryId}\n`);
+  }
+
+  return vopResult.vop_proof_token;
+}
+
 export function registerTransferCreateCommand(parent: Command): void {
   const create = parent
     .command("create")
@@ -44,12 +64,14 @@ export function registerTransferCreateCommand(parent: Command): void {
     .addOption(new Option("--currency <code>", "currency code").default("EUR"))
     .option("--note <text>", "optional note")
     .option("--scheduled-date <date>", "scheduled date (YYYY-MM-DD)")
-    .addOption(new Option("--vop-proof-token <token>", "VoP proof token from verify-payee").makeOptionMandatory());
+    .option("--vop-proof-token <token>", "VoP proof token (auto-resolved if omitted)");
   addInheritableOptions(create);
   addWriteOptions(create);
   create.action(async (_opts: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<TransferCreateOptions>(cmd);
     const httpClient = await createClient(opts);
+
+    const vopProofToken = opts.vopProofToken ?? (await resolveVopProofToken(httpClient, opts.beneficiary));
 
     const params: CreateTransferParams = {
       beneficiary_id: opts.beneficiary,
@@ -57,7 +79,7 @@ export function registerTransferCreateCommand(parent: Command): void {
       reference: opts.reference,
       amount: opts.amount,
       currency: opts.currency,
-      vop_proof_token: opts.vopProofToken,
+      vop_proof_token: vopProofToken,
       ...(opts.note !== undefined ? { note: opts.note } : {}),
       ...(opts.scheduledDate !== undefined ? { scheduled_date: opts.scheduledDate } : {}),
     };


### PR DESCRIPTION
## Summary

- Make `--vop-proof-token` optional in `transfer create` — when omitted, auto-fetches the beneficiary by ID, calls `verifyPayee()`, and uses the returned token
- On `match` result: proceeds silently; on `mismatch` or `not_available`: warns to stderr and proceeds
- When `--vop-proof-token` is explicitly provided, skips auto-verify (preserves existing behavior)

Closes #323

## Test plan

- [x] Existing tests pass with explicit `--vop-proof-token`
- [x] New test: auto-resolve on `match` — no stderr output
- [x] New test: auto-resolve on `mismatch` — warning to stderr
- [x] New test: auto-resolve on `not_available` — warning to stderr
- [x] New test: explicit token skips `getBeneficiary`/`verifyPayee` calls
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)