### PR TITLE
(fix) place vop_proof_token at request body root (#331)

### DIFF
--- a/packages/core/src/transfers/service.test.ts
+++ b/packages/core/src/transfers/service.test.ts
@@ -282,13 +282,13 @@ describe("createTransfer", () => {
 
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body).toEqual({
+      vop_proof_token: "tok_abc123",
       transfer: {
         beneficiary_id: "ben-1",
         bank_account_id: "acc-1",
         reference: "Test Payment",
         amount: "500",
         currency: "EUR",
-        vop_proof_token: "tok_abc123",
       },
     });
   });

--- a/packages/core/src/transfers/service.ts
+++ b/packages/core/src/transfers/service.ts
@@ -120,7 +120,8 @@ export async function createTransfer(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<Transfer> {
   const endpointPath = "/v2/sepa/transfers";
-  const response = await client.post(endpointPath, { transfer: params }, options);
+  const { vop_proof_token, ...transferFields } = params;
+  const response = await client.post(endpointPath, { vop_proof_token, transfer: transferFields }, options);
   return parseResponse(TransferResponseSchema, response, endpointPath).transfer;
 }
 

--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -191,9 +191,9 @@ describe("transfer MCP tools", () => {
       const transferCall = calls.find((c) => c[0].pathname === "/v2/sepa/transfers") as [URL, RequestInit] | undefined;
       expect(transferCall).toBeDefined();
       const body = JSON.parse((transferCall as [URL, RequestInit])[1].body as string) as {
-        transfer: { vop_proof_token: string };
+        vop_proof_token: string;
       };
-      expect(body.transfer.vop_proof_token).toBe("explicit-token");
+      expect(body.vop_proof_token).toBe("explicit-token");
     });
 
     it("auto-resolves vop_proof_token via getBeneficiary + verifyPayee on match", async () => {
@@ -221,9 +221,9 @@ describe("transfer MCP tools", () => {
 
       // Should have used the auto-resolved token
       const body = JSON.parse((transferCall as [URL, RequestInit])[1].body as string) as {
-        transfer: { vop_proof_token: string };
+        vop_proof_token: string;
       };
-      expect(body.transfer.vop_proof_token).toBe("auto-token-123");
+      expect(body.vop_proof_token).toBe("auto-token-123");
     });
 
     it("includes VoP status in response on mismatch", async () => {


### PR DESCRIPTION
## Summary

- Moves `vop_proof_token` from inside the `transfer` wrapper to the top level of the request body in `createTransfer()`
- The Qonto API expects `{ vop_proof_token, transfer: { ... } }` but the code was sending `{ transfer: { ..., vop_proof_token } }`
- This caused HTTP 401 `vop_proof_token_missing` for both auto-resolved and explicitly-provided tokens

Closes #331

## Test plan

- [x] Core service test updated to assert correct body structure
- [x] MCP tool tests updated to assert token at body root
- [x] All unit tests pass (`pnpm test` — 10/10 tasks)
- [x] Lint passes (`pnpm lint`)
- [ ] E2E: verify transfer creation succeeds with VoP token

🤖 Generated with [Claude Code](https://claude.com/claude-code)