### PR TITLE
(fix) fix profile add E2E tests with non-interactive options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ ESLint enforces this via `eslint-plugin-header`.
 
 ### E2E Testing
 
-**When to run:** After implementing or modifying code that touches Qonto API interactions, CLI commands, MCP tools, or any behavior covered by E2E tests — run E2E tests locally to validate before completing the task.
+**When to run:** E2E tests MUST be run locally and pass before submitting a PR or preparing a release. Also run after implementing or modifying code that touches Qonto API interactions, CLI commands, MCP tools, or any behavior covered by E2E tests.
 
 **Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with API key credentials. The config resolver picks this up from CWD automatically — no env var overrides needed.
 

--- a/packages/cli/src/commands/profile/add.ts
+++ b/packages/cli/src/commands/profile/add.ts
@@ -10,18 +10,27 @@ import type { Command } from "commander";
 import { CONFIG_DIR, isValidProfileName, loadConfigFile } from "@qontoctl/core";
 import { addInheritableOptions } from "../../inherited-options.js";
 
+interface AddOptions {
+  organizationSlug?: string;
+  secretKey?: string;
+}
+
 /**
  * Register the `profile add <name>` subcommand.
  */
 export function registerAddCommand(parent: Command): void {
-  const add = parent.command("add <name>").description("create a new profile interactively");
+  const add = parent
+    .command("add <name>")
+    .description("create a new profile interactively")
+    .option("--organization-slug <slug>", "organization slug (skip interactive prompt)")
+    .option("--secret-key <key>", "secret key (skip interactive prompt)");
   addInheritableOptions(add);
-  add.action(async (name: string) => {
-    await addProfile(name);
+  add.action(async (name: string, opts: AddOptions) => {
+    await addProfile(name, opts);
   });
 }
 
-async function addProfile(name: string): Promise<void> {
+async function addProfile(name: string, opts: AddOptions): Promise<void> {
   if (!isValidProfileName(name)) {
     console.error("Invalid profile name: must not contain path separators or '..'.");
     process.exitCode = 1;
@@ -36,24 +45,40 @@ async function addProfile(name: string): Promise<void> {
     return;
   }
 
-  const organizationSlug = await text({
-    message: "Organization slug",
-    validate: (value) => {
-      if (!value || value.trim() === "") return "Organization slug cannot be empty.";
-    },
-  });
-  if (isCancel(organizationSlug)) {
-    process.exit(0);
-  }
+  let organizationSlug: string;
+  let secretKey: string;
 
-  const secretKey = await text({
-    message: "Secret key",
-    validate: (value) => {
-      if (!value || value.trim() === "") return "Secret key cannot be empty.";
-    },
-  });
-  if (isCancel(secretKey)) {
-    process.exit(0);
+  if (opts.organizationSlug !== undefined && opts.secretKey !== undefined) {
+    // Non-interactive mode
+    organizationSlug = opts.organizationSlug;
+    secretKey = opts.secretKey;
+  } else if (opts.organizationSlug !== undefined || opts.secretKey !== undefined) {
+    console.error("Both --organization-slug and --secret-key must be provided together.");
+    process.exitCode = 1;
+    return;
+  } else {
+    // Interactive mode
+    const slugResult = await text({
+      message: "Organization slug",
+      validate: (value) => {
+        if (!value || value.trim() === "") return "Organization slug cannot be empty.";
+      },
+    });
+    if (isCancel(slugResult)) {
+      process.exit(0);
+    }
+    organizationSlug = slugResult;
+
+    const keyResult = await text({
+      message: "Secret key",
+      validate: (value) => {
+        if (!value || value.trim() === "") return "Secret key cannot be empty.";
+      },
+    });
+    if (isCancel(keyResult)) {
+      process.exit(0);
+    }
+    secretKey = keyResult;
   }
 
   const config = {

--- a/packages/e2e/src/profile/profile.e2e.test.ts
+++ b/packages/e2e/src/profile/profile.e2e.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -39,47 +39,6 @@ function cli(
     stderr: result.stderr,
     exitCode: result.status ?? 1,
   };
-}
-
-/**
- * Run the CLI asynchronously, feeding stdin lines one at a time after
- * each prompt appears on stderr. This is required because Node.js
- * readline/promises closes when the input stream ends, which prevents
- * subsequent question() calls from resolving if all data is piped at once.
- */
-function cliInteractive(
-  args: string[],
-  options: { env?: Record<string, string>; lines: string[] },
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return new Promise((resolve) => {
-    const child: ChildProcess = spawn("node", [CLI_PATH, ...args], {
-      env: options.env,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let idx = 0;
-
-    child.stdout?.setEncoding("utf-8");
-    child.stderr?.setEncoding("utf-8");
-    child.stdout?.on("data", (d: string) => (stdout += d));
-
-    // Wait for each prompt on stderr before writing the next input line.
-    child.stderr?.on("data", (d: string) => {
-      stderr += d;
-      if (idx < options.lines.length) {
-        child.stdin?.write(options.lines[idx++] + "\n");
-      }
-      if (idx >= options.lines.length) {
-        child.stdin?.end();
-      }
-    });
-
-    child.on("close", (code) => {
-      resolve({ stdout, stderr, exitCode: code ?? 1 });
-    });
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -183,11 +142,11 @@ describe("profile commands (e2e)", () => {
       rmSync(addDir, { recursive: true, force: true });
     });
 
-    it("creates a new profile yaml from interactive input", async () => {
-      const { stdout, exitCode } = await cliInteractive(["profile", "add", "myprofile"], {
-        env: homeEnv(addDir),
-        lines: ["test-org-slug", "sk_test_secretkey123"],
-      });
+    it("creates a new profile yaml with non-interactive options", () => {
+      const { stdout, exitCode } = cli(
+        ["profile", "add", "myprofile", "--organization-slug", "test-org-slug", "--secret-key", "sk_test_secretkey123"],
+        { env: homeEnv(addDir) },
+      );
       expect(exitCode).toBe(0);
       expect(stdout).toContain('Profile "myprofile" created');
 
@@ -199,12 +158,12 @@ describe("profile commands (e2e)", () => {
       expect(content).toContain("secret-key: sk_test_secretkey123");
     });
 
-    it("refuses to overwrite an existing profile", async () => {
+    it("refuses to overwrite an existing profile", () => {
       // myprofile was created in the previous test
-      const { stderr, exitCode } = await cliInteractive(["profile", "add", "myprofile"], {
-        env: homeEnv(addDir),
-        lines: ["new-org", "new-key"],
-      });
+      const { stderr, exitCode } = cli(
+        ["profile", "add", "myprofile", "--organization-slug", "new-org", "--secret-key", "new-key"],
+        { env: homeEnv(addDir) },
+      );
       expect(exitCode).not.toBe(0);
       expect(stderr).toContain("already exists");
     });


### PR DESCRIPTION
## Summary

- Add `--organization-slug` and `--secret-key` options to `profile add` for non-interactive profile creation
- Fix 2 failing E2E tests that timed out because `@clack/prompts` is incompatible with piped stdin (Node.js 24 exits code 13 — unsettled top-level await)
- Make E2E tests mandatory before PR submission and release in CLAUDE.md

## Root Cause

`@clack/prompts` v1.1.0 uses keypress events with `terminal: true` readline. When stdin is piped (non-TTY), keypress events don't fire properly and the prompt never settles, causing Node.js 24 to exit with code 13 (unsettled top-level await).

## Test plan

- [x] `pnpm test` — 498 unit tests pass
- [x] `pnpm test:e2e` — 169 E2E tests pass (0 failures, was 2)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)