### PR TITLE
(fix) fix VoP service test for actual API field names (#350)

### DIFF
--- a/packages/core/src/transfers/service.test.ts
+++ b/packages/core/src/transfers/service.test.ts
@@ -478,6 +478,12 @@ describe("verifyPayee", () => {
     const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/sepa/verify_payee");
     expect(init.method).toBe("POST");
+
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      iban: "FR7612345000010009876543210",
+      beneficiary_name: "John Doe",
+    });
   });
 
   const vopBankErrorCodes = [
@@ -568,7 +574,7 @@ describe("verifyPayee", () => {
     await expect(
       verifyPayee(client, {
         iban: "FR7612345000010009876543210",
-        name: "John Doe",
+        beneficiary_name: "John Doe",
       }),
     ).rejects.toThrow(QontoApiError);
   });


### PR DESCRIPTION
## Summary

- Fix residual `name` field in verifyPayee error test (should be `beneficiary_name`) — missed during #349 type migration
- Add request body assertion to verifyPayee happy path test to verify `{ iban, beneficiary_name }` is sent to the API

Closes #350

## Test plan

- [x] All 659 core tests pass
- [x] Full test suite passes (all packages)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)