### PR TITLE
(fix) handle absent matched_name in VoP API response

### DIFF
--- a/packages/core/src/transfers/schemas.test.ts
+++ b/packages/core/src/transfers/schemas.test.ts
@@ -136,6 +136,14 @@ describe("VopResultSchema", () => {
     expect(result.matched_name).toBe("Acme Corp");
   });
 
+  it("defaults matched_name to null when absent", () => {
+    const result = VopResultSchema.parse({
+      match_result: "MATCH_RESULT_MATCH",
+      proof_token: { token: "tok_no_name" },
+    });
+    expect(result.matched_name).toBeNull();
+  });
+
   it("rejects invalid match_result", () => {
     expect(() =>
       VopResultSchema.parse({
@@ -218,6 +226,14 @@ describe("BulkVopResultEntrySchema", () => {
     });
     expect(result.id).toBe("0");
     expect(result.response?.match_result).toBe("MATCH_RESULT_MATCH");
+  });
+
+  it("defaults matched_name to null when absent in response", () => {
+    const result = BulkVopResultEntrySchema.parse({
+      id: "0",
+      response: { match_result: "MATCH_RESULT_MATCH" },
+    });
+    expect(result.response?.matched_name).toBeNull();
   });
 
   it("accepts an error entry", () => {

--- a/packages/core/src/transfers/schemas.ts
+++ b/packages/core/src/transfers/schemas.ts
@@ -50,7 +50,7 @@ const ProofTokenSchema = z.object({
 
 export const VopResultSchema = z.object({
   match_result: VopMatchResultSchema,
-  matched_name: z.nullable(z.string()),
+  matched_name: z.nullable(z.string()).optional().default(null),
   proof_token: ProofTokenSchema,
 }) satisfies z.ZodType<VopResult>;
 
@@ -61,7 +61,7 @@ export const BulkVopResultEntrySchema = z.object({
   response: z
     .object({
       match_result: VopMatchResultSchema,
-      matched_name: z.nullable(z.string()),
+      matched_name: z.nullable(z.string()).optional().default(null),
     })
     .optional(),
   error: z


### PR DESCRIPTION
## Summary

- The Qonto API may omit `matched_name` from `/v2/sepa/verify_payee` and `/v2/sepa/bulk_verify_payee` responses instead of returning `null`
- Zod schema rejected this with `expected string, received undefined`
- Added `.optional().default(null)` so absent fields default to `null`, preserving the existing `string | null` type contract
- Added test coverage for the absent `matched_name` scenario in both single and bulk VoP schemas

## Test plan

- [x] Unit tests pass (502 tests, including 2 new ones)
- [x] Validated against live Qonto API (`sas-pelykh-consulting` profile) — `MATCH_RESULT_MATCH` returned successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)