### PR TITLE
(feat) add insurance contract commands

### DIFF
--- a/packages/cli/src/commands/insurance.test.ts
+++ b/packages/cli/src/commands/insurance.test.ts
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { HttpClient } from "@qontoctl/core";
+import { registerInsuranceCommands } from "./insurance.js";
+
+vi.mock("../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "../client.js";
+
+const sampleContract = {
+  id: "ic-123",
+  insurance_type: "professional_liability",
+  status: "active",
+  provider_name: "AXA",
+  contract_number: "CNT-12345",
+  start_date: "2026-01-01",
+  end_date: "2027-01-01",
+  created_at: "2026-01-01T10:00:00Z",
+  updated_at: "2026-01-01T10:00:00Z",
+};
+
+const sampleDocument = {
+  id: "doc-123",
+  file_name: "policy.pdf",
+  file_size: "54321",
+  file_content_type: "application/pdf",
+  url: "https://example.com/documents/doc-123",
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+describe("insurance commands", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers an insurance command group", () => {
+    const program = new Command();
+    registerInsuranceCommands(program);
+
+    const insuranceCommand = program.commands.find((c) => c.name() === "insurance");
+    expect(insuranceCommand).toBeDefined();
+  });
+
+  describe("insurance show", () => {
+    it("shows contract details in table format", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "show", "ic-123"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("ic-123");
+      expect(output).toContain("AXA");
+    });
+
+    it("shows contract details in json format", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["--output", "json", "insurance", "show", "ic-123"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", "ic-123");
+      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
+      expect(parsed).toHaveProperty("provider_name", "AXA");
+    });
+
+    it("sends GET to the correct API endpoint", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "show", "ic-123"], { from: "user" });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123");
+      expect(opts.method).toBe("GET");
+    });
+  });
+
+  describe("insurance create", () => {
+    it("creates a contract in table format", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(
+        [
+          "insurance",
+          "create",
+          "--insurance-type",
+          "professional_liability",
+          "--provider-name",
+          "AXA",
+          "--start-date",
+          "2026-01-01",
+        ],
+        { from: "user" },
+      );
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("ic-123");
+      expect(output).toContain("AXA");
+    });
+
+    it("sends POST with correct body", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(
+        [
+          "insurance",
+          "create",
+          "--insurance-type",
+          "professional_liability",
+          "--provider-name",
+          "AXA",
+          "--start-date",
+          "2026-01-01",
+          "--contract-number",
+          "CNT-12345",
+        ],
+        { from: "user" },
+      );
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts");
+      expect(opts.method).toBe("POST");
+
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({
+        insurance_contract: {
+          insurance_type: "professional_liability",
+          provider_name: "AXA",
+          start_date: "2026-01-01",
+          contract_number: "CNT-12345",
+        },
+      });
+    });
+  });
+
+  describe("insurance update", () => {
+    it("updates a contract", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "update", "ic-123", "--provider-name", "Allianz"], { from: "user" });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123");
+      expect(opts.method).toBe("PUT");
+
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({ insurance_contract: { provider_name: "Allianz" } });
+    });
+  });
+
+  describe("insurance upload-doc", () => {
+    it("uploads a document via multipart form-data", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_document: sampleDocument }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "upload-doc", "ic-123", "package.json"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("doc-123");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/documents");
+      expect(opts.method).toBe("POST");
+      expect(opts.body).toBeInstanceOf(FormData);
+    });
+  });
+
+  describe("insurance remove-doc", () => {
+    it("requires --yes confirmation", async () => {
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "remove-doc", "ic-123", "doc-123"], { from: "user" });
+
+      expect(stderrSpy).toHaveBeenCalled();
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Use --yes to confirm");
+      expect(process.exitCode).toBe(1);
+      process.exitCode = undefined;
+    });
+
+    it("removes a document when --yes is provided", async () => {
+      fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(["insurance", "remove-doc", "ic-123", "doc-123", "--yes"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Document doc-123 removed");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/documents/doc-123");
+      expect(opts.method).toBe("DELETE");
+    });
+  });
+});

--- a/packages/cli/src/commands/insurance.ts
+++ b/packages/cli/src/commands/insurance.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { Command, Option } from "commander";
+import type { InsuranceContract } from "@qontoctl/core";
+import {
+  getInsuranceContract,
+  createInsuranceContract,
+  updateInsuranceContract,
+  uploadInsuranceDocument,
+  removeInsuranceDocument,
+} from "@qontoctl/core";
+import { createClient } from "../client.js";
+import { formatOutput } from "../formatters/index.js";
+import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
+import type { GlobalOptions, WriteOptions } from "../options.js";
+
+interface InsuranceCreateOptions extends GlobalOptions, WriteOptions {
+  readonly insuranceType: string;
+  readonly providerName: string;
+  readonly contractNumber?: string | undefined;
+  readonly startDate: string;
+  readonly endDate?: string | undefined;
+}
+
+interface InsuranceUpdateOptions extends GlobalOptions, WriteOptions {
+  readonly insuranceType?: string | undefined;
+  readonly providerName?: string | undefined;
+  readonly contractNumber?: string | undefined;
+  readonly startDate?: string | undefined;
+  readonly endDate?: string | undefined;
+}
+
+function contractToTableRow(c: InsuranceContract): Record<string, string> {
+  return {
+    id: c.id,
+    insurance_type: c.insurance_type,
+    status: c.status,
+    provider_name: c.provider_name,
+    contract_number: c.contract_number ?? "",
+    start_date: c.start_date,
+    end_date: c.end_date ?? "",
+  };
+}
+
+export function registerInsuranceCommands(program: Command): void {
+  const insurance = program.command("insurance").description("Manage insurance contracts");
+
+  // --- show ---
+  const show = insurance.command("show <id>").description("Show insurance contract details");
+  addInheritableOptions(show);
+  show.action(async (id: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions>(cmd);
+    const client = await createClient(opts);
+
+    const contract = await getInsuranceContract(client, id);
+
+    const data = opts.output === "json" || opts.output === "yaml" ? contract : [contractToTableRow(contract)];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  // --- create ---
+  const create = insurance
+    .command("create")
+    .description("Create a new insurance contract")
+    .addOption(new Option("--insurance-type <type>", "insurance type").makeOptionMandatory())
+    .addOption(new Option("--provider-name <name>", "insurance provider name").makeOptionMandatory())
+    .option("--contract-number <number>", "contract number")
+    .addOption(new Option("--start-date <date>", "contract start date (YYYY-MM-DD)").makeOptionMandatory())
+    .option("--end-date <date>", "contract end date (YYYY-MM-DD)");
+  addInheritableOptions(create);
+  addWriteOptions(create);
+  create.action(async (_options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<InsuranceCreateOptions>(cmd);
+    const client = await createClient(opts);
+
+    const contract = await createInsuranceContract(
+      client,
+      {
+        insurance_type: opts.insuranceType,
+        provider_name: opts.providerName,
+        start_date: opts.startDate,
+        contract_number: opts.contractNumber,
+        end_date: opts.endDate,
+      },
+      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    );
+
+    const data = opts.output === "json" || opts.output === "yaml" ? contract : [contractToTableRow(contract)];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  // --- update ---
+  const update = insurance
+    .command("update <id>")
+    .description("Update an insurance contract")
+    .option("--insurance-type <type>", "insurance type")
+    .option("--provider-name <name>", "insurance provider name")
+    .option("--contract-number <number>", "contract number")
+    .option("--start-date <date>", "contract start date (YYYY-MM-DD)")
+    .option("--end-date <date>", "contract end date (YYYY-MM-DD)");
+  addInheritableOptions(update);
+  addWriteOptions(update);
+  update.action(async (id: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<InsuranceUpdateOptions>(cmd);
+    const client = await createClient(opts);
+
+    const contract = await updateInsuranceContract(
+      client,
+      id,
+      {
+        insurance_type: opts.insuranceType,
+        provider_name: opts.providerName,
+        contract_number: opts.contractNumber,
+        start_date: opts.startDate,
+        end_date: opts.endDate,
+      },
+      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    );
+
+    const data = opts.output === "json" || opts.output === "yaml" ? contract : [contractToTableRow(contract)];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  // --- upload-doc ---
+  const uploadDoc = insurance
+    .command("upload-doc <id> <file>")
+    .description("Upload a document to an insurance contract");
+  addInheritableOptions(uploadDoc);
+  addWriteOptions(uploadDoc);
+  uploadDoc.action(async (id: string, file: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions>(cmd);
+    const client = await createClient(opts);
+
+    const buffer = await readFile(file);
+    const fileName = basename(file);
+
+    const doc = await uploadInsuranceDocument(
+      client,
+      id,
+      new Blob([buffer]),
+      fileName,
+      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    );
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? doc
+        : [
+            {
+              id: doc.id,
+              file_name: doc.file_name,
+              file_size: doc.file_size,
+              file_content_type: doc.file_content_type,
+              created_at: doc.created_at,
+            },
+          ];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  // --- remove-doc ---
+  const removeDoc = insurance
+    .command("remove-doc <id> <doc-id>")
+    .description("Remove a document from an insurance contract")
+    .addOption(new Option("--yes", "skip confirmation prompt"));
+  addInheritableOptions(removeDoc);
+  addWriteOptions(removeDoc);
+  removeDoc.action(async (id: string, docId: string, _options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { yes?: true | undefined }>(cmd);
+    const client = await createClient(opts);
+
+    if (opts.yes !== true) {
+      process.stderr.write(`About to remove document ${docId} from insurance contract ${id}. Use --yes to confirm.\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    await removeInsuranceDocument(
+      client,
+      id,
+      docId,
+      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    );
+
+    if (opts.output === "json" || opts.output === "yaml") {
+      process.stdout.write(formatOutput({ deleted: true, id: docId }, opts.output) + "\n");
+    } else {
+      process.stdout.write(`Document ${docId} removed from insurance contract ${id}.\n`);
+    }
+  });
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -56,9 +56,10 @@ describe("createProgram", () => {
       expect(names).toContain("account");
       expect(names).toContain("supplier-invoice");
       expect(names).toContain("team");
+      expect(names).toContain("insurance");
       expect(names).toContain("intl");
       expect(names).toContain("profile");
-      expect(program.commands).toHaveLength(14);
+      expect(program.commands).toHaveLength(15);
     });
 
     it("commands have descriptions", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -9,6 +9,7 @@ import { registerCardCommands } from "./commands/card/index.js";
 import { registerTransactionCommands } from "./commands/transaction/index.js";
 import { registerBulkTransferCommands } from "./commands/bulk-transfer/index.js";
 import { registerEInvoicingCommands } from "./commands/einvoicing.js";
+import { registerInsuranceCommands } from "./commands/insurance.js";
 import { registerIntlBeneficiaryCommands } from "./commands/intl-beneficiary/index.js";
 import { registerIntlTransferCommands } from "./commands/intl-transfer/index.js";
 import { registerRecurringTransferCommands } from "./commands/recurring-transfer/index.js";
@@ -49,6 +50,7 @@ export function createProgram(): Command {
   registerAccountCommands(program);
   registerSupplierInvoiceCommands(program);
   program.addCommand(createTeamCommand());
+  registerInsuranceCommands(program);
   registerIntlBeneficiaryCommands(program);
   registerIntlTransferCommands(program);
   registerProfileCommands(program);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -412,6 +412,25 @@ export type { Attachment } from "./attachments/index.js";
 export { AttachmentSchema } from "./attachments/index.js";
 
 export {
+  getInsuranceContract,
+  createInsuranceContract,
+  updateInsuranceContract,
+  uploadInsuranceDocument,
+  removeInsuranceDocument,
+  InsuranceContractSchema,
+  InsuranceContractResponseSchema,
+  InsuranceDocumentSchema,
+  InsuranceDocumentResponseSchema,
+} from "./insurance-contracts/index.js";
+
+export type {
+  InsuranceContract,
+  InsuranceDocument,
+  CreateInsuranceContractParams,
+  UpdateInsuranceContractParams,
+} from "./insurance-contracts/index.js";
+
+export {
   createBankAccount,
   getBankAccount,
   listBankAccounts,

--- a/packages/core/src/insurance-contracts/index.ts
+++ b/packages/core/src/insurance-contracts/index.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export {
+  getInsuranceContract,
+  createInsuranceContract,
+  updateInsuranceContract,
+  uploadInsuranceDocument,
+  removeInsuranceDocument,
+} from "./service.js";
+
+export type { CreateInsuranceContractParams, UpdateInsuranceContractParams } from "./service.js";
+
+export type { InsuranceContract, InsuranceDocument } from "./types.js";
+
+export {
+  InsuranceContractSchema,
+  InsuranceContractResponseSchema,
+  InsuranceDocumentSchema,
+  InsuranceDocumentResponseSchema,
+} from "./schemas.js";

--- a/packages/core/src/insurance-contracts/schemas.ts
+++ b/packages/core/src/insurance-contracts/schemas.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { InsuranceContract, InsuranceDocument } from "./types.js";
+
+export const InsuranceDocumentSchema = z.object({
+  id: z.string(),
+  file_name: z.string(),
+  file_size: z.coerce.string(),
+  file_content_type: z.string(),
+  url: z.string(),
+  created_at: z.string(),
+}) satisfies z.ZodType<InsuranceDocument>;
+
+export const InsuranceContractSchema = z.object({
+  id: z.string(),
+  insurance_type: z.string(),
+  status: z.string(),
+  provider_name: z.string(),
+  contract_number: z.string().nullable(),
+  start_date: z.string(),
+  end_date: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+}) satisfies z.ZodType<InsuranceContract>;
+
+export const InsuranceContractResponseSchema = z.object({
+  insurance_contract: InsuranceContractSchema,
+});
+
+export const InsuranceDocumentResponseSchema = z.object({
+  insurance_document: InsuranceDocumentSchema,
+});

--- a/packages/core/src/insurance-contracts/service.test.ts
+++ b/packages/core/src/insurance-contracts/service.test.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient } from "../http-client.js";
+import { jsonResponse } from "../testing/json-response.js";
+import {
+  getInsuranceContract,
+  createInsuranceContract,
+  updateInsuranceContract,
+  uploadInsuranceDocument,
+  removeInsuranceDocument,
+} from "./service.js";
+
+const sampleContract = {
+  id: "ic-1",
+  insurance_type: "professional_liability",
+  status: "active",
+  provider_name: "AXA",
+  contract_number: "CNT-12345",
+  start_date: "2026-01-01",
+  end_date: "2027-01-01",
+  created_at: "2026-01-01T10:00:00Z",
+  updated_at: "2026-01-01T10:00:00Z",
+};
+
+const sampleDocument = {
+  id: "doc-1",
+  file_name: "policy.pdf",
+  file_size: "54321",
+  file_content_type: "application/pdf",
+  url: "https://example.com/documents/doc-1",
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+describe("insurance contract service", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getInsuranceContract", () => {
+    it("fetches an insurance contract by ID", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await getInsuranceContract(client, "ic-1");
+
+      expect(result).toEqual(sampleContract);
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
+      expect(opts.method).toBe("GET");
+    });
+  });
+
+  describe("createInsuranceContract", () => {
+    it("creates a new insurance contract", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await createInsuranceContract(client, {
+        insurance_type: "professional_liability",
+        provider_name: "AXA",
+        start_date: "2026-01-01",
+      });
+
+      expect(result).toEqual(sampleContract);
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts");
+      expect(opts.method).toBe("POST");
+
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({
+        insurance_contract: {
+          insurance_type: "professional_liability",
+          provider_name: "AXA",
+          start_date: "2026-01-01",
+        },
+      });
+    });
+
+    it("passes idempotency key when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await createInsuranceContract(
+        client,
+        { insurance_type: "health", provider_name: "MAIF", start_date: "2026-01-01" },
+        { idempotencyKey: "key-123" },
+      );
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["X-Qonto-Idempotency-Key"]).toBe("key-123");
+    });
+  });
+
+  describe("updateInsuranceContract", () => {
+    it("updates an existing insurance contract", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await updateInsuranceContract(client, "ic-1", {
+        provider_name: "Allianz",
+      });
+
+      expect(result).toEqual(sampleContract);
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
+      expect(opts.method).toBe("PUT");
+
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({ insurance_contract: { provider_name: "Allianz" } });
+    });
+
+    it("passes idempotency key when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await updateInsuranceContract(client, "ic-1", { end_date: "2028-01-01" }, { idempotencyKey: "key-456" });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["X-Qonto-Idempotency-Key"]).toBe("key-456");
+    });
+  });
+
+  describe("uploadInsuranceDocument", () => {
+    it("uploads a document via multipart form-data", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+
+      const file = new Blob(["file content"], { type: "application/pdf" });
+      const result = await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf");
+
+      expect(result).toEqual(sampleDocument);
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents");
+      expect(opts.method).toBe("POST");
+      expect(opts.body).toBeInstanceOf(FormData);
+    });
+
+    it("passes idempotency key when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+
+      const file = new Blob(["file content"]);
+      await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf", { idempotencyKey: "key-789" });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["X-Qonto-Idempotency-Key"]).toBe("key-789");
+    });
+  });
+
+  describe("removeInsuranceDocument", () => {
+    it("removes a document from an insurance contract", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+      await removeInsuranceDocument(client, "ic-1", "doc-1");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents/doc-1");
+      expect(opts.method).toBe("DELETE");
+    });
+
+    it("passes idempotency key when provided", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+      await removeInsuranceDocument(client, "ic-1", "doc-1", { idempotencyKey: "key-abc" });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["X-Qonto-Idempotency-Key"]).toBe("key-abc");
+    });
+  });
+});

--- a/packages/core/src/insurance-contracts/service.ts
+++ b/packages/core/src/insurance-contracts/service.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { HttpClient } from "../http-client.js";
+import { parseResponse } from "../response.js";
+import { InsuranceContractResponseSchema, InsuranceDocumentResponseSchema } from "./schemas.js";
+import type { InsuranceContract, InsuranceDocument } from "./types.js";
+
+export interface CreateInsuranceContractParams {
+  readonly insurance_type: string;
+  readonly provider_name: string;
+  readonly contract_number?: string | undefined;
+  readonly start_date: string;
+  readonly end_date?: string | undefined;
+}
+
+export interface UpdateInsuranceContractParams {
+  readonly insurance_type?: string | undefined;
+  readonly provider_name?: string | undefined;
+  readonly contract_number?: string | undefined;
+  readonly start_date?: string | undefined;
+  readonly end_date?: string | undefined;
+}
+
+/**
+ * Fetch an insurance contract by ID.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param id - The insurance contract UUID.
+ * @returns The insurance contract details.
+ */
+export async function getInsuranceContract(client: HttpClient, id: string): Promise<InsuranceContract> {
+  const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(id)}`;
+  const response = await client.get(endpointPath);
+  return parseResponse(InsuranceContractResponseSchema, response, endpointPath).insurance_contract;
+}
+
+/**
+ * Create a new insurance contract.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param params - The insurance contract creation parameters.
+ * @param options - Optional idempotency key and SCA session token.
+ * @returns The created insurance contract.
+ */
+export async function createInsuranceContract(
+  client: HttpClient,
+  params: CreateInsuranceContractParams,
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
+): Promise<InsuranceContract> {
+  const endpointPath = "/v2/insurance_contracts";
+  const response = await client.post(endpointPath, { insurance_contract: params }, options);
+  return parseResponse(InsuranceContractResponseSchema, response, endpointPath).insurance_contract;
+}
+
+/**
+ * Update an existing insurance contract.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param id - The insurance contract UUID.
+ * @param params - The fields to update.
+ * @param options - Optional idempotency key and SCA session token.
+ * @returns The updated insurance contract.
+ */
+export async function updateInsuranceContract(
+  client: HttpClient,
+  id: string,
+  params: UpdateInsuranceContractParams,
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
+): Promise<InsuranceContract> {
+  const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(id)}`;
+  const response = await client.put(endpointPath, { insurance_contract: params }, options);
+  return parseResponse(InsuranceContractResponseSchema, response, endpointPath).insurance_contract;
+}
+
+/**
+ * Upload a document to an insurance contract via multipart form-data.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param contractId - The insurance contract UUID.
+ * @param file - The file content as a Blob.
+ * @param fileName - The file name.
+ * @param options - Optional idempotency key.
+ * @returns The uploaded document details.
+ */
+export async function uploadInsuranceDocument(
+  client: HttpClient,
+  contractId: string,
+  file: Blob,
+  fileName: string,
+  options?: { readonly idempotencyKey?: string },
+): Promise<InsuranceDocument> {
+  const formData = new FormData();
+  formData.append("file", file, fileName);
+
+  const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(contractId)}/documents`;
+  const response = await client.postFormData(endpointPath, formData, options);
+  return parseResponse(InsuranceDocumentResponseSchema, response, endpointPath).insurance_document;
+}
+
+/**
+ * Remove a document from an insurance contract.
+ *
+ * @param client - The HTTP client to use for the request.
+ * @param contractId - The insurance contract UUID.
+ * @param documentId - The document UUID.
+ * @param options - Optional idempotency key.
+ */
+export async function removeInsuranceDocument(
+  client: HttpClient,
+  contractId: string,
+  documentId: string,
+  options?: { readonly idempotencyKey?: string },
+): Promise<void> {
+  await client.delete(
+    `/v2/insurance_contracts/${encodeURIComponent(contractId)}/documents/${encodeURIComponent(documentId)}`,
+    options,
+  );
+}

--- a/packages/core/src/insurance-contracts/types.ts
+++ b/packages/core/src/insurance-contracts/types.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * An insurance contract as returned by the Qonto API.
+ */
+export interface InsuranceContract {
+  readonly id: string;
+  readonly insurance_type: string;
+  readonly status: string;
+  readonly provider_name: string;
+  readonly contract_number: string | null;
+  readonly start_date: string;
+  readonly end_date: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+/**
+ * A document attached to an insurance contract.
+ */
+export interface InsuranceDocument {
+  readonly id: string;
+  readonly file_name: string;
+  readonly file_size: string;
+  readonly file_content_type: string;
+  readonly url: string;
+  readonly created_at: string;
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -119,7 +119,12 @@ describe("createServer", () => {
       expect(toolNames).toContain("intl_beneficiary_remove");
       expect(toolNames).toContain("intl_transfer_requirements");
       expect(toolNames).toContain("intl_transfer_create");
-      expect(tools).toHaveLength(103);
+      expect(toolNames).toContain("insurance_show");
+      expect(toolNames).toContain("insurance_create");
+      expect(toolNames).toContain("insurance_update");
+      expect(toolNames).toContain("insurance_upload_document");
+      expect(toolNames).toContain("insurance_remove_document");
+      expect(tools).toHaveLength(108);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -14,6 +14,7 @@ import {
   registerClientInvoiceTools,
   registerCreditNoteTools,
   registerEInvoicingTools,
+  registerInsuranceTools,
   registerIntlBeneficiaryTools,
   registerIntlTransferTools,
   registerInternalTransferTools,
@@ -59,6 +60,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerClientInvoiceTools(server, getClient);
   registerCreditNoteTools(server, getClient);
   registerEInvoicingTools(server, getClient);
+  registerInsuranceTools(server, getClient);
   registerIntlBeneficiaryTools(server, getClient);
   registerIntlTransferTools(server, getClient);
   registerInternalTransferTools(server, getClient);

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -10,6 +10,7 @@ export { registerClientInvoiceTools } from "./client-invoice.js";
 export { registerBulkTransferTools } from "./bulk-transfer.js";
 export { registerCreditNoteTools } from "./credit-note.js";
 export { registerEInvoicingTools } from "./einvoicing.js";
+export { registerInsuranceTools } from "./insurance.js";
 export { registerIntlBeneficiaryTools } from "./intl-beneficiary.js";
 export { registerIntlTransferTools } from "./intl-transfer.js";
 export { registerInternalTransferTools } from "./internal-transfer.js";

--- a/packages/mcp/src/tools/insurance.test.ts
+++ b/packages/mcp/src/tools/insurance.test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { connectInMemory } from "../testing/mcp-helpers.js";
+
+const sampleContract = {
+  id: "ic-1",
+  insurance_type: "professional_liability",
+  status: "active",
+  provider_name: "AXA",
+  contract_number: "CNT-12345",
+  start_date: "2026-01-01",
+  end_date: "2027-01-01",
+  created_at: "2026-01-01T10:00:00Z",
+  updated_at: "2026-01-01T10:00:00Z",
+};
+
+const sampleDocument = {
+  id: "doc-1",
+  file_name: "policy.pdf",
+  file_size: "54321",
+  file_content_type: "application/pdf",
+  url: "https://example.com/documents/doc-1",
+  created_at: "2026-01-01T10:00:00Z",
+};
+
+describe("insurance MCP tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    ({ mcpClient } = await connectInMemory(fetchSpy));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("insurance_show", () => {
+    it("returns an insurance contract by ID", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await mcpClient.callTool({
+        name: "insurance_show",
+        arguments: { id: "ic-1" },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as { id: string };
+      expect(parsed.id).toBe("ic-1");
+    });
+
+    it("calls the correct API endpoint", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await mcpClient.callTool({
+        name: "insurance_show",
+        arguments: { id: "ic-1" },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
+      expect(opts.method).toBe("GET");
+    });
+  });
+
+  describe("insurance_create", () => {
+    it("creates an insurance contract", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await mcpClient.callTool({
+        name: "insurance_create",
+        arguments: {
+          insurance_type: "professional_liability",
+          provider_name: "AXA",
+          start_date: "2026-01-01",
+        },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as { id: string };
+      expect(parsed.id).toBe("ic-1");
+    });
+
+    it("sends POST to the correct endpoint with body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await mcpClient.callTool({
+        name: "insurance_create",
+        arguments: {
+          insurance_type: "professional_liability",
+          provider_name: "AXA",
+          start_date: "2026-01-01",
+          contract_number: "CNT-12345",
+        },
+      });
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts");
+      expect(opts.method).toBe("POST");
+
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({
+        insurance_contract: {
+          insurance_type: "professional_liability",
+          provider_name: "AXA",
+          start_date: "2026-01-01",
+          contract_number: "CNT-12345",
+        },
+      });
+    });
+  });
+
+  describe("insurance_update", () => {
+    it("updates an insurance contract", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      const result = await mcpClient.callTool({
+        name: "insurance_update",
+        arguments: {
+          id: "ic-1",
+          provider_name: "Allianz",
+        },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as { id: string };
+      expect(parsed.id).toBe("ic-1");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
+      expect(opts.method).toBe("PUT");
+    });
+  });
+
+  describe("insurance_upload_document", () => {
+    it("uploads a document to an insurance contract", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+
+      const result = await mcpClient.callTool({
+        name: "insurance_upload_document",
+        arguments: {
+          contract_id: "ic-1",
+          file_path: "package.json",
+        },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse((content[0] as { type: string; text: string }).text) as { id: string };
+      expect(parsed.id).toBe("doc-1");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents");
+      expect(opts.method).toBe("POST");
+      expect(opts.body).toBeInstanceOf(FormData);
+    });
+  });
+
+  describe("insurance_remove_document", () => {
+    it("removes a document from an insurance contract", async () => {
+      fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+      const result = await mcpClient.callTool({
+        name: "insurance_remove_document",
+        arguments: {
+          contract_id: "ic-1",
+          document_id: "doc-1",
+        },
+      });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      expect((content[0] as { type: string; text: string }).text).toContain("doc-1");
+      expect((content[0] as { type: string; text: string }).text).toContain("removed");
+
+      const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents/doc-1");
+      expect(opts.method).toBe("DELETE");
+    });
+  });
+});

--- a/packages/mcp/src/tools/insurance.ts
+++ b/packages/mcp/src/tools/insurance.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type HttpClient,
+  getInsuranceContract,
+  createInsuranceContract,
+  updateInsuranceContract,
+  uploadInsuranceDocument,
+  removeInsuranceDocument,
+} from "@qontoctl/core";
+import { withClient } from "../errors.js";
+
+export function registerInsuranceTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
+  server.registerTool(
+    "insurance_show",
+    {
+      description: "Show insurance contract details",
+      inputSchema: {
+        id: z.string().describe("Insurance contract ID (UUID)"),
+      },
+    },
+    async ({ id }) =>
+      withClient(getClient, async (client) => {
+        const contract = await getInsuranceContract(client, id);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(contract, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "insurance_create",
+    {
+      description: "Create a new insurance contract",
+      inputSchema: {
+        insurance_type: z.string().describe("Insurance type (e.g. professional_liability, health)"),
+        provider_name: z.string().describe("Insurance provider name"),
+        contract_number: z.string().optional().describe("Contract number"),
+        start_date: z.string().describe("Contract start date (YYYY-MM-DD)"),
+        end_date: z.string().optional().describe("Contract end date (YYYY-MM-DD)"),
+      },
+    },
+    async (args) =>
+      withClient(getClient, async (client) => {
+        const contract = await createInsuranceContract(client, {
+          insurance_type: args.insurance_type,
+          provider_name: args.provider_name,
+          start_date: args.start_date,
+          contract_number: args.contract_number,
+          end_date: args.end_date,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(contract, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "insurance_update",
+    {
+      description: "Update an insurance contract",
+      inputSchema: {
+        id: z.string().describe("Insurance contract ID (UUID)"),
+        insurance_type: z.string().optional().describe("Insurance type"),
+        provider_name: z.string().optional().describe("Insurance provider name"),
+        contract_number: z.string().optional().describe("Contract number"),
+        start_date: z.string().optional().describe("Contract start date (YYYY-MM-DD)"),
+        end_date: z.string().optional().describe("Contract end date (YYYY-MM-DD)"),
+      },
+    },
+    async (args) =>
+      withClient(getClient, async (client) => {
+        const contract = await updateInsuranceContract(client, args.id, {
+          insurance_type: args.insurance_type,
+          provider_name: args.provider_name,
+          contract_number: args.contract_number,
+          start_date: args.start_date,
+          end_date: args.end_date,
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(contract, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "insurance_upload_document",
+    {
+      description: "Upload a document to an insurance contract from the filesystem",
+      inputSchema: {
+        contract_id: z.string().describe("Insurance contract ID (UUID)"),
+        file_path: z.string().describe("Absolute path to the file to upload"),
+      },
+    },
+    async ({ contract_id, file_path }) =>
+      withClient(getClient, async (client) => {
+        const buffer = await readFile(file_path);
+        const fileName = basename(file_path);
+        const doc = await uploadInsuranceDocument(client, contract_id, new Blob([buffer]), fileName);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(doc, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "insurance_remove_document",
+    {
+      description: "Remove a document from an insurance contract",
+      inputSchema: {
+        contract_id: z.string().describe("Insurance contract ID (UUID)"),
+        document_id: z.string().describe("Document ID (UUID)"),
+      },
+    },
+    async ({ contract_id, document_id }) =>
+      withClient(getClient, async (client) => {
+        await removeInsuranceDocument(client, contract_id, document_id);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Document ${document_id} removed from insurance contract ${contract_id}.`,
+            },
+          ],
+        };
+      }),
+  );
+}

--- a/packages/qontoctl/src/cli.test.ts
+++ b/packages/qontoctl/src/cli.test.ts
@@ -95,8 +95,9 @@ describe("qontoctl CLI", () => {
       expect(names).toContain("request");
       expect(names).toContain("statement");
       expect(names).toContain("transfer");
+      expect(names).toContain("insurance");
       expect(names).toContain("mcp");
-      expect(program.commands).toHaveLength(27);
+      expect(program.commands).toHaveLength(28);
     });
 
     it("commands have descriptions", () => {


### PR DESCRIPTION
## Summary

- Add insurance contract management commands across core, CLI, and MCP packages
- Core: `InsuranceContract` and `InsuranceDocument` types/schemas, 5 service functions (get, create, update, uploadDoc, removeDoc)
- CLI: `insurance show|create|update|upload-doc|remove-doc` commands with `--yes` confirmation for destructive operations
- MCP: 5 tools (`insurance_show`, `insurance_create`, `insurance_update`, `insurance_upload_document`, `insurance_remove_document`)

Closes #200

## Test plan

- [x] Core service unit tests pass (endpoint paths, request bodies, response parsing, idempotency keys)
- [x] CLI command unit tests pass (table/JSON output, API endpoint calls, `--yes` confirmation prompt)
- [x] MCP tool unit tests pass (tool invocation, response formatting, file upload)
- [x] Build passes across all packages
- [x] Lint passes across all packages
- [x] Existing tests unaffected (updated command/tool counts in program.test.ts, server.test.ts, cli.test.ts)
- [ ] E2E tests against sandbox (requires OAuth credentials with `insurance.read`/`insurance.write` scopes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)