### PR TITLE
(test) add missing schema tests for new domains

### DIFF
--- a/packages/core/src/insurance-contracts/schemas.test.ts
+++ b/packages/core/src/insurance-contracts/schemas.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  InsuranceContractSchema,
+  InsuranceContractResponseSchema,
+  InsuranceDocumentSchema,
+  InsuranceDocumentResponseSchema,
+} from "./schemas.js";
+
+describe("InsuranceDocumentSchema", () => {
+  const validDocument = {
+    id: "doc-1",
+    file_name: "policy.pdf",
+    file_size: "12345",
+    file_content_type: "application/pdf",
+    url: "https://example.com/policy.pdf",
+    created_at: "2025-06-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid document", () => {
+    const result = InsuranceDocumentSchema.parse(validDocument);
+    expect(result).toEqual(validDocument);
+  });
+
+  it("coerces file_size to string", () => {
+    const result = InsuranceDocumentSchema.parse({ ...validDocument, file_size: 12345 });
+    expect(result.file_size).toBe("12345");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, id: undefined })).toThrow();
+    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, file_name: undefined })).toThrow();
+    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, url: undefined })).toThrow();
+  });
+});
+
+describe("InsuranceDocumentResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      insurance_document: {
+        id: "doc-1",
+        file_name: "policy.pdf",
+        file_size: "12345",
+        file_content_type: "application/pdf",
+        url: "https://example.com/policy.pdf",
+        created_at: "2025-06-01T00:00:00.000Z",
+      },
+    };
+    const result = InsuranceDocumentResponseSchema.parse(response);
+    expect(result.insurance_document.id).toBe("doc-1");
+  });
+});
+
+describe("InsuranceContractSchema", () => {
+  const validContract = {
+    id: "contract-1",
+    insurance_type: "health",
+    status: "active",
+    provider_name: "Allianz",
+    contract_number: "POL-12345",
+    start_date: "2025-01-01",
+    end_date: "2026-01-01",
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-06-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid contract", () => {
+    const result = InsuranceContractSchema.parse(validContract);
+    expect(result).toEqual(validContract);
+  });
+
+  it("accepts null for nullable fields", () => {
+    const result = InsuranceContractSchema.parse({
+      ...validContract,
+      contract_number: null,
+      end_date: null,
+    });
+    expect(result.contract_number).toBeNull();
+    expect(result.end_date).toBeNull();
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => InsuranceContractSchema.parse({ ...validContract, id: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, insurance_type: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, start_date: undefined })).toThrow();
+  });
+});
+
+describe("InsuranceContractResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      insurance_contract: {
+        id: "contract-1",
+        insurance_type: "health",
+        status: "active",
+        provider_name: "Allianz",
+        contract_number: null,
+        start_date: "2025-01-01",
+        end_date: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-06-01T00:00:00.000Z",
+      },
+    };
+    const result = InsuranceContractResponseSchema.parse(response);
+    expect(result.insurance_contract.id).toBe("contract-1");
+  });
+});

--- a/packages/core/src/international-beneficiaries/schemas.test.ts
+++ b/packages/core/src/international-beneficiaries/schemas.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  IntlBeneficiarySchema,
+  IntlBeneficiaryResponseSchema,
+  IntlBeneficiaryListResponseSchema,
+  IntlBeneficiaryRequirementFieldSchema,
+  IntlBeneficiaryRequirementsSchema,
+  IntlBeneficiaryRequirementsResponseSchema,
+} from "./schemas.js";
+
+describe("IntlBeneficiarySchema", () => {
+  const validBeneficiary = {
+    id: "intl-ben-1",
+    name: "Acme Corp",
+    country: "US",
+    currency: "USD",
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-06-01T00:00:00.000Z",
+  };
+
+  it("accepts a valid beneficiary", () => {
+    const result = IntlBeneficiarySchema.parse(validBeneficiary);
+    expect(result.id).toBe("intl-ben-1");
+    expect(result.country).toBe("US");
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlBeneficiarySchema.parse({ ...validBeneficiary, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlBeneficiarySchema.parse({ ...validBeneficiary, id: undefined })).toThrow();
+    expect(() => IntlBeneficiarySchema.parse({ ...validBeneficiary, name: undefined })).toThrow();
+    expect(() => IntlBeneficiarySchema.parse({ ...validBeneficiary, country: undefined })).toThrow();
+  });
+});
+
+describe("IntlBeneficiaryResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      international_beneficiary: {
+        id: "intl-ben-1",
+        name: "Acme Corp",
+        country: "US",
+        currency: "USD",
+        created_at: "2025-01-01T00:00:00.000Z",
+        updated_at: "2025-06-01T00:00:00.000Z",
+      },
+    };
+    const result = IntlBeneficiaryResponseSchema.parse(response);
+    expect(result.international_beneficiary.id).toBe("intl-ben-1");
+  });
+});
+
+describe("IntlBeneficiaryListResponseSchema", () => {
+  it("validates list response with pagination", () => {
+    const response = {
+      international_beneficiaries: [
+        {
+          id: "intl-ben-1",
+          name: "Acme Corp",
+          country: "US",
+          currency: "USD",
+          created_at: "2025-01-01T00:00:00.000Z",
+          updated_at: "2025-06-01T00:00:00.000Z",
+        },
+      ],
+      meta: { current_page: 1, total_pages: 1, total_count: 1, per_page: 25, next_page: null, prev_page: null },
+    };
+    const result = IntlBeneficiaryListResponseSchema.parse(response);
+    expect(result.international_beneficiaries).toHaveLength(1);
+  });
+});
+
+describe("IntlBeneficiaryRequirementFieldSchema", () => {
+  const validField = {
+    key: "account_number",
+    name: "Account Number",
+    type: "text",
+  };
+
+  it("accepts a valid requirement field", () => {
+    const result = IntlBeneficiaryRequirementFieldSchema.parse(validField);
+    expect(result.key).toBe("account_number");
+  });
+
+  it("accepts optional fields", () => {
+    const result = IntlBeneficiaryRequirementFieldSchema.parse({
+      ...validField,
+      example: "123456789",
+      validation_regexp: "^[0-9]+$",
+      min_length: 5,
+      max_length: 20,
+    });
+    expect(result.example).toBe("123456789");
+    expect(result.min_length).toBe(5);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlBeneficiaryRequirementFieldSchema.parse({ ...validField, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlBeneficiaryRequirementFieldSchema.parse({ key: "k", name: "n" })).toThrow();
+  });
+});
+
+describe("IntlBeneficiaryRequirementsSchema", () => {
+  it("accepts valid requirements", () => {
+    const result = IntlBeneficiaryRequirementsSchema.parse({
+      fields: [{ key: "account_number", name: "Account Number", type: "text" }],
+    });
+    expect(result.fields).toHaveLength(1);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlBeneficiaryRequirementsSchema.parse({
+      fields: [],
+      extra: "field",
+    });
+    expect(result).toHaveProperty("extra", "field");
+  });
+});
+
+describe("IntlBeneficiaryRequirementsResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      requirements: {
+        fields: [{ key: "iban", name: "IBAN", type: "text" }],
+      },
+    };
+    const result = IntlBeneficiaryRequirementsResponseSchema.parse(response);
+    expect(result.requirements.fields).toHaveLength(1);
+  });
+});

--- a/packages/core/src/international-transfers/schemas.test.ts
+++ b/packages/core/src/international-transfers/schemas.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  IntlTransferRequirementFieldSchema,
+  IntlTransferRequirementsSchema,
+  IntlTransferRequirementsResponseSchema,
+  IntlTransferSchema,
+  IntlTransferResponseSchema,
+} from "./schemas.js";
+
+describe("IntlTransferRequirementFieldSchema", () => {
+  const validField = {
+    key: "reference",
+    name: "Reference",
+    type: "text",
+  };
+
+  it("accepts a valid requirement field", () => {
+    const result = IntlTransferRequirementFieldSchema.parse(validField);
+    expect(result.key).toBe("reference");
+  });
+
+  it("accepts optional fields", () => {
+    const result = IntlTransferRequirementFieldSchema.parse({
+      ...validField,
+      example: "INV-001",
+      validation_regexp: "^[A-Z0-9-]+$",
+      min_length: 1,
+      max_length: 50,
+    });
+    expect(result.example).toBe("INV-001");
+    expect(result.max_length).toBe(50);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlTransferRequirementFieldSchema.parse({ ...validField, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlTransferRequirementFieldSchema.parse({ key: "k", name: "n" })).toThrow();
+  });
+});
+
+describe("IntlTransferRequirementsSchema", () => {
+  it("accepts valid requirements", () => {
+    const result = IntlTransferRequirementsSchema.parse({
+      fields: [{ key: "reference", name: "Reference", type: "text" }],
+    });
+    expect(result.fields).toHaveLength(1);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlTransferRequirementsSchema.parse({
+      fields: [],
+      extra: "field",
+    });
+    expect(result).toHaveProperty("extra", "field");
+  });
+});
+
+describe("IntlTransferRequirementsResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      requirements: {
+        fields: [{ key: "reference", name: "Payment Reference", type: "text" }],
+      },
+    };
+    const result = IntlTransferRequirementsResponseSchema.parse(response);
+    expect(result.requirements.fields).toHaveLength(1);
+  });
+});
+
+describe("IntlTransferSchema", () => {
+  const validTransfer = {
+    id: "intl-txn-1",
+  };
+
+  it("accepts a valid transfer", () => {
+    const result = IntlTransferSchema.parse(validTransfer);
+    expect(result.id).toBe("intl-txn-1");
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlTransferSchema.parse({ ...validTransfer, status: "pending", extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+    expect(result).toHaveProperty("status", "pending");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlTransferSchema.parse({})).toThrow();
+  });
+});
+
+describe("IntlTransferResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      international_transfer: { id: "intl-txn-1" },
+    };
+    const result = IntlTransferResponseSchema.parse(response);
+    expect(result.international_transfer.id).toBe("intl-txn-1");
+  });
+});

--- a/packages/core/src/international/schemas.test.ts
+++ b/packages/core/src/international/schemas.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  IntlEligibilitySchema,
+  IntlEligibilityResponseSchema,
+  IntlCurrencySchema,
+  IntlCurrencyListResponseSchema,
+  IntlQuoteSchema,
+  IntlQuoteResponseSchema,
+} from "./schemas.js";
+
+describe("IntlEligibilitySchema", () => {
+  const validEligibility = {
+    eligible: true,
+  };
+
+  it("accepts a valid eligibility", () => {
+    const result = IntlEligibilitySchema.parse(validEligibility);
+    expect(result.eligible).toBe(true);
+  });
+
+  it("accepts optional reason", () => {
+    const result = IntlEligibilitySchema.parse({ ...validEligibility, reason: "account verified" });
+    expect(result.reason).toBe("account verified");
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlEligibilitySchema.parse({ ...validEligibility, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlEligibilitySchema.parse({})).toThrow();
+  });
+});
+
+describe("IntlEligibilityResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = { eligibility: { eligible: false, reason: "not verified" } };
+    const result = IntlEligibilityResponseSchema.parse(response);
+    expect(result.eligibility.eligible).toBe(false);
+  });
+});
+
+describe("IntlCurrencySchema", () => {
+  const validCurrency = {
+    code: "USD",
+    name: "US Dollar",
+  };
+
+  it("accepts a valid currency", () => {
+    const result = IntlCurrencySchema.parse(validCurrency);
+    expect(result.code).toBe("USD");
+    expect(result.name).toBe("US Dollar");
+  });
+
+  it("accepts optional min/max amounts", () => {
+    const result = IntlCurrencySchema.parse({ ...validCurrency, min_amount: 10, max_amount: 100000 });
+    expect(result.min_amount).toBe(10);
+    expect(result.max_amount).toBe(100000);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlCurrencySchema.parse({ ...validCurrency, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlCurrencySchema.parse({ code: "USD" })).toThrow();
+    expect(() => IntlCurrencySchema.parse({ name: "US Dollar" })).toThrow();
+  });
+});
+
+describe("IntlCurrencyListResponseSchema", () => {
+  it("validates response wrapper with array", () => {
+    const response = {
+      currencies: [
+        { code: "USD", name: "US Dollar" },
+        { code: "GBP", name: "British Pound" },
+      ],
+    };
+    const result = IntlCurrencyListResponseSchema.parse(response);
+    expect(result.currencies).toHaveLength(2);
+  });
+});
+
+describe("IntlQuoteSchema", () => {
+  const validQuote = {
+    id: "quote-1",
+    source_currency: "EUR",
+    target_currency: "USD",
+    source_amount: 1000,
+    target_amount: 1085.5,
+    rate: 1.0855,
+    fee_amount: 5.0,
+    fee_currency: "EUR",
+    expires_at: "2025-06-01T01:00:00.000Z",
+  };
+
+  it("accepts a valid quote", () => {
+    const result = IntlQuoteSchema.parse(validQuote);
+    expect(result.id).toBe("quote-1");
+    expect(result.rate).toBe(1.0855);
+  });
+
+  it("preserves extra fields (loose schema)", () => {
+    const result = IntlQuoteSchema.parse({ ...validQuote, extra: "field" });
+    expect(result).toHaveProperty("extra", "field");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => IntlQuoteSchema.parse({ ...validQuote, id: undefined })).toThrow();
+    expect(() => IntlQuoteSchema.parse({ ...validQuote, rate: undefined })).toThrow();
+  });
+
+  it("rejects non-numeric amounts", () => {
+    expect(() => IntlQuoteSchema.parse({ ...validQuote, source_amount: "not-a-number" })).toThrow();
+  });
+});
+
+describe("IntlQuoteResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      quote: {
+        id: "quote-1",
+        source_currency: "EUR",
+        target_currency: "USD",
+        source_amount: 1000,
+        target_amount: 1085.5,
+        rate: 1.0855,
+        fee_amount: 5.0,
+        fee_currency: "EUR",
+        expires_at: "2025-06-01T01:00:00.000Z",
+      },
+    };
+    const result = IntlQuoteResponseSchema.parse(response);
+    expect(result.quote.id).toBe("quote-1");
+  });
+});

--- a/packages/core/src/types/payment-link.schema.test.ts
+++ b/packages/core/src/types/payment-link.schema.test.ts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import {
+  PaymentLinkAmountSchema,
+  PaymentLinkItemSchema,
+  PaymentLinkSchema,
+  PaymentLinkResponseSchema,
+  PaymentLinkListResponseSchema,
+  PaymentLinkPaymentSchema,
+  PaymentLinkPaymentListResponseSchema,
+  PaymentLinkPaymentMethodSchema,
+  PaymentLinkPaymentMethodListResponseSchema,
+  PaymentLinkConnectionSchema,
+} from "./payment-link.schema.js";
+
+describe("PaymentLinkAmountSchema", () => {
+  it("accepts a valid amount", () => {
+    const result = PaymentLinkAmountSchema.parse({ value: "100.00", currency: "EUR" });
+    expect(result.value).toBe("100.00");
+    expect(result.currency).toBe("EUR");
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkAmountSchema.parse({ value: "100.00", currency: "EUR", extra: "field" });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkAmountSchema.parse({ value: "100.00" })).toThrow();
+    expect(() => PaymentLinkAmountSchema.parse({ currency: "EUR" })).toThrow();
+  });
+});
+
+describe("PaymentLinkItemSchema", () => {
+  const validItem = {
+    title: "Widget",
+    quantity: 2,
+    unit_price: { value: "10.00", currency: "EUR" },
+    vat_rate: "20.0",
+  };
+
+  it("accepts a valid item", () => {
+    const result = PaymentLinkItemSchema.parse(validItem);
+    expect(result.title).toBe("Widget");
+    expect(result.quantity).toBe(2);
+  });
+
+  it("accepts optional fields", () => {
+    const result = PaymentLinkItemSchema.parse({
+      ...validItem,
+      type: "product",
+      description: "A fine widget",
+      measure_unit: "piece",
+    });
+    expect(result.type).toBe("product");
+    expect(result.description).toBe("A fine widget");
+    expect(result.measure_unit).toBe("piece");
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkItemSchema.parse({ ...validItem, extra: "field" });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkItemSchema.parse({ ...validItem, title: undefined })).toThrow();
+    expect(() => PaymentLinkItemSchema.parse({ ...validItem, quantity: undefined })).toThrow();
+    expect(() => PaymentLinkItemSchema.parse({ ...validItem, vat_rate: undefined })).toThrow();
+  });
+});
+
+describe("PaymentLinkSchema", () => {
+  const validPaymentLink = {
+    id: "pl-1",
+    status: "open",
+    expiration_date: "2025-12-31T23:59:59.000Z",
+    potential_payment_methods: ["card", "transfer"],
+    amount: { value: "100.00", currency: "EUR" },
+    resource_type: "payment_link",
+    items: null,
+    reusable: false,
+    invoice_id: null,
+    invoice_number: null,
+    debitor_name: null,
+    created_at: "2025-01-01T00:00:00.000Z",
+    url: "https://pay.qonto.com/pl-1",
+  };
+
+  it("accepts a valid payment link", () => {
+    const result = PaymentLinkSchema.parse(validPaymentLink);
+    expect(result.id).toBe("pl-1");
+    expect(result.status).toBe("open");
+  });
+
+  it("accepts null for nullable fields", () => {
+    const result = PaymentLinkSchema.parse(validPaymentLink);
+    expect(result.items).toBeNull();
+    expect(result.invoice_id).toBeNull();
+    expect(result.invoice_number).toBeNull();
+    expect(result.debitor_name).toBeNull();
+  });
+
+  it("accepts items array when present", () => {
+    const result = PaymentLinkSchema.parse({
+      ...validPaymentLink,
+      items: [
+        {
+          title: "Widget",
+          quantity: 1,
+          unit_price: { value: "100.00", currency: "EUR" },
+          vat_rate: "20.0",
+        },
+      ],
+    });
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkSchema.parse({ ...validPaymentLink, extra: "field" });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkSchema.parse({ ...validPaymentLink, id: undefined })).toThrow();
+    expect(() => PaymentLinkSchema.parse({ ...validPaymentLink, status: undefined })).toThrow();
+    expect(() => PaymentLinkSchema.parse({ ...validPaymentLink, url: undefined })).toThrow();
+  });
+});
+
+describe("PaymentLinkResponseSchema", () => {
+  it("validates response wrapper", () => {
+    const response = {
+      payment_link: {
+        id: "pl-1",
+        status: "open",
+        expiration_date: "2025-12-31T23:59:59.000Z",
+        potential_payment_methods: ["card"],
+        amount: { value: "50.00", currency: "EUR" },
+        resource_type: "payment_link",
+        items: null,
+        reusable: false,
+        invoice_id: null,
+        invoice_number: null,
+        debitor_name: null,
+        created_at: "2025-01-01T00:00:00.000Z",
+        url: "https://pay.qonto.com/pl-1",
+      },
+    };
+    const result = PaymentLinkResponseSchema.parse(response);
+    expect(result.payment_link.id).toBe("pl-1");
+  });
+});
+
+describe("PaymentLinkListResponseSchema", () => {
+  it("validates list response with pagination", () => {
+    const response = {
+      payment_links: [
+        {
+          id: "pl-1",
+          status: "open",
+          expiration_date: "2025-12-31T23:59:59.000Z",
+          potential_payment_methods: [],
+          amount: { value: "100.00", currency: "EUR" },
+          resource_type: "payment_link",
+          items: null,
+          reusable: false,
+          invoice_id: null,
+          invoice_number: null,
+          debitor_name: null,
+          created_at: "2025-01-01T00:00:00.000Z",
+          url: "https://pay.qonto.com/pl-1",
+        },
+      ],
+      meta: { current_page: 1, total_pages: 1, total_count: 1, per_page: 25, next_page: null, prev_page: null },
+    };
+    const result = PaymentLinkListResponseSchema.parse(response);
+    expect(result.payment_links).toHaveLength(1);
+  });
+});
+
+describe("PaymentLinkPaymentSchema", () => {
+  const validPayment = {
+    id: "pay-1",
+    amount: { value: "100.00", currency: "EUR" },
+    status: "completed",
+    created_at: "2025-01-01T00:00:00.000Z",
+    payment_method: "card",
+    paid_at: "2025-01-01T00:05:00.000Z",
+    debitor_email: "customer@example.com",
+  };
+
+  it("accepts a valid payment", () => {
+    const result = PaymentLinkPaymentSchema.parse(validPayment);
+    expect(result.id).toBe("pay-1");
+    expect(result.status).toBe("completed");
+  });
+
+  it("accepts null for paid_at", () => {
+    const result = PaymentLinkPaymentSchema.parse({ ...validPayment, paid_at: null });
+    expect(result.paid_at).toBeNull();
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkPaymentSchema.parse({ ...validPayment, extra: "field" });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkPaymentSchema.parse({ ...validPayment, id: undefined })).toThrow();
+    expect(() => PaymentLinkPaymentSchema.parse({ ...validPayment, debitor_email: undefined })).toThrow();
+  });
+});
+
+describe("PaymentLinkPaymentListResponseSchema", () => {
+  it("validates list response with pagination", () => {
+    const response = {
+      payments: [
+        {
+          id: "pay-1",
+          amount: { value: "100.00", currency: "EUR" },
+          status: "completed",
+          created_at: "2025-01-01T00:00:00.000Z",
+          payment_method: "card",
+          paid_at: "2025-01-01T00:05:00.000Z",
+          debitor_email: "customer@example.com",
+        },
+      ],
+      meta: { current_page: 1, total_pages: 1, total_count: 1, per_page: 25, next_page: null, prev_page: null },
+    };
+    const result = PaymentLinkPaymentListResponseSchema.parse(response);
+    expect(result.payments).toHaveLength(1);
+  });
+});
+
+describe("PaymentLinkPaymentMethodSchema", () => {
+  it("accepts a valid payment method", () => {
+    const result = PaymentLinkPaymentMethodSchema.parse({ name: "card", enabled: true });
+    expect(result.name).toBe("card");
+    expect(result.enabled).toBe(true);
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkPaymentMethodSchema.parse({ name: "card", enabled: true, extra: "field" });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkPaymentMethodSchema.parse({ name: "card" })).toThrow();
+    expect(() => PaymentLinkPaymentMethodSchema.parse({ enabled: true })).toThrow();
+  });
+});
+
+describe("PaymentLinkPaymentMethodListResponseSchema", () => {
+  it("validates response wrapper with array", () => {
+    const response = {
+      payment_link_payment_methods: [
+        { name: "card", enabled: true },
+        { name: "transfer", enabled: false },
+      ],
+    };
+    const result = PaymentLinkPaymentMethodListResponseSchema.parse(response);
+    expect(result.payment_link_payment_methods).toHaveLength(2);
+  });
+});
+
+describe("PaymentLinkConnectionSchema", () => {
+  it("accepts a valid connection", () => {
+    const result = PaymentLinkConnectionSchema.parse({
+      connection_location: "FR",
+      status: "connected",
+      bank_account_id: "ba-1",
+    });
+    expect(result.connection_location).toBe("FR");
+    expect(result.status).toBe("connected");
+  });
+
+  it("strips extra fields", () => {
+    const result = PaymentLinkConnectionSchema.parse({
+      connection_location: "FR",
+      status: "connected",
+      bank_account_id: "ba-1",
+      extra: "field",
+    });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => PaymentLinkConnectionSchema.parse({ connection_location: "FR" })).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add schema test coverage for 5 domains that were missing dedicated `*.schema.test.ts` files (audit finding TEST-007)
- Insurance contracts: `InsuranceContractSchema`, `InsuranceDocumentSchema` (nullable fields, coercion)
- International: `IntlEligibilitySchema`, `IntlCurrencySchema`, `IntlQuoteSchema` (loose/passthrough behavior)
- International beneficiaries: `IntlBeneficiarySchema`, `IntlBeneficiaryRequirementFieldSchema`, `IntlBeneficiaryRequirementsSchema` (loose behavior, optional fields)
- International transfers: `IntlTransferSchema`, `IntlTransferRequirementFieldSchema`, `IntlTransferRequirementsSchema` (loose behavior)
- Payment links: `PaymentLinkSchema`, `PaymentLinkPaymentSchema`, `PaymentLinkPaymentMethodSchema`, `PaymentLinkConnectionSchema`, etc. (strip behavior, nullable fields, nested schemas)
- 72 new tests total, following established patterns from `beneficiaries/schemas.test.ts`

Closes #373

## Test plan

- [x] All 72 new schema tests pass locally
- [x] Full core test suite passes (778 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)