### PR TITLE
(test) add core payment-links service tests

### DIFF
--- a/packages/core/src/services/payment-links.test.ts
+++ b/packages/core/src/services/payment-links.test.ts
@@ -235,11 +235,7 @@ describe("createPaymentLink", () => {
   it("passes idempotency key in headers when provided", async () => {
     fetchSpy.mockReturnValue(jsonResponse({ payment_link: paymentLink }));
 
-    await createPaymentLink(
-      client,
-      { potential_payment_methods: ["card"], items: [] },
-      { idempotencyKey: "idem-123" },
-    );
+    await createPaymentLink(client, { potential_payment_methods: ["card"], items: [] }, { idempotencyKey: "idem-123" });
 
     const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     const headers = init.headers as Record<string, string>;


### PR DESCRIPTION
## Summary

- Add `packages/core/src/services/payment-links.test.ts` with 24 unit tests covering all 9 exported functions
- Tests follow the established pattern from `bank-accounts.test.ts` (fetch spy, HttpClient mock, endpoint/param verification)
- Covers: `buildPaymentLinkQueryParams`, `listPaymentLinks`, `getPaymentLink`, `createPaymentLink` (basket + invoice), `deactivatePaymentLink`, `listPaymentLinkPayments`, `listPaymentMethods`, `connectPaymentLinks`, `getConnectionStatus`

Closes #372

## Test plan

- [x] `pnpm test --filter=@qontoctl/core` — 730 tests pass (24 new)
- [x] `pnpm lint --filter=@qontoctl/core` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)