### PR TITLE
(test) add CLI recurring-transfer command tests

### DIFF
--- a/packages/cli/src/commands/recurring-transfer/cancel.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/cancel.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerRecurringTransferCommands } from "./index.js";
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@qontoctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@qontoctl/core")>();
+  return {
+    ...actual,
+    cancelRecurringTransfer: vi.fn(),
+  };
+});
+
+vi.mock("../../sca.js", () => ({
+  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
+    operation(undefined),
+  ),
+}));
+
+const { createClient } = await import("../../client.js");
+const createClientMock = vi.mocked(createClient);
+
+const { cancelRecurringTransfer } = await import("@qontoctl/core");
+const cancelRecurringTransferMock = vi.mocked(cancelRecurringTransfer);
+
+describe("recurring-transfer cancel command", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+    createClientMock.mockResolvedValue({} as never);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it("cancels a recurring transfer with --yes flag", async () => {
+    cancelRecurringTransferMock.mockResolvedValue(undefined);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(["recurring-transfer", "cancel", "rt-1", "--yes"], { from: "user" });
+
+    expect(cancelRecurringTransferMock).toHaveBeenCalledWith(expect.anything(), "rt-1", expect.anything());
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Recurring transfer rt-1 canceled.");
+  });
+
+  it("cancels a recurring transfer in json format", async () => {
+    cancelRecurringTransferMock.mockResolvedValue(undefined);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "json");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(["recurring-transfer", "cancel", "rt-1", "--yes"], { from: "user" });
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as { canceled: boolean; id: string };
+    expect(parsed.canceled).toBe(true);
+    expect(parsed.id).toBe("rt-1");
+  });
+
+  it("exits with error when --yes is not provided", async () => {
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(["recurring-transfer", "cancel", "rt-1"], { from: "user" });
+
+    expect(stderrSpy).toHaveBeenCalled();
+    const errorOutput = stderrSpy.mock.calls[0]?.[0] as string;
+    expect(errorOutput).toContain("About to cancel recurring transfer rt-1");
+    expect(errorOutput).toContain("--yes");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/recurring-transfer/create.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/create.test.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerRecurringTransferCommands } from "./index.js";
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@qontoctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@qontoctl/core")>();
+  return {
+    ...actual,
+    createRecurringTransfer: vi.fn(),
+  };
+});
+
+vi.mock("../../sca.js", () => ({
+  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
+    operation(undefined),
+  ),
+}));
+
+const { createClient } = await import("../../client.js");
+const createClientMock = vi.mocked(createClient);
+
+const { createRecurringTransfer } = await import("@qontoctl/core");
+const createRecurringTransferMock = vi.mocked(createRecurringTransfer);
+
+const sampleRecurringTransfer = {
+  id: "rt-1",
+  initiator_id: "user-1",
+  bank_account_id: "acc-1",
+  amount: 200,
+  amount_cents: 20000,
+  amount_currency: "EUR",
+  beneficiary_id: "ben-1",
+  reference: "Monthly rent",
+  note: "",
+  first_execution_date: "2026-04-01",
+  last_execution_date: null,
+  next_execution_date: "2026-04-01",
+  frequency: "monthly" as const,
+  status: "active",
+  created_at: "2026-03-25T00:00:00.000Z",
+  updated_at: "2026-03-25T00:00:00.000Z",
+};
+
+describe("recurring-transfer create command", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    createClientMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a recurring transfer in table format", async () => {
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "200",
+        "--reference",
+        "Monthly rent",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "monthly",
+      ],
+      { from: "user" },
+    );
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("rt-1");
+    expect(output).toContain("monthly");
+  });
+
+  it("creates a recurring transfer in json format", async () => {
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "json");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "200",
+        "--reference",
+        "Monthly rent",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "monthly",
+      ],
+      { from: "user" },
+    );
+
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = stdoutSpy.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(output) as typeof sampleRecurringTransfer;
+    expect(parsed.id).toBe("rt-1");
+    expect(parsed.amount).toBe(200);
+    expect(parsed.frequency).toBe("monthly");
+  });
+
+  it("passes parsed parameters to createRecurringTransfer", async () => {
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "500",
+        "--currency",
+        "USD",
+        "--reference",
+        "Quarterly fee",
+        "--note",
+        "Service contract",
+        "--start-date",
+        "2026-07-01",
+        "--schedule",
+        "quarterly",
+      ],
+      { from: "user" },
+    );
+
+    expect(createRecurringTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        beneficiary_id: "ben-1",
+        bank_account_id: "acc-1",
+        amount: 500,
+        currency: "USD",
+        reference: "Quarterly fee",
+        note: "Service contract",
+        first_execution_date: "2026-07-01",
+        frequency: "quarterly",
+      },
+      expect.anything(),
+    );
+  });
+
+  it("defaults currency to EUR when not specified", async () => {
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "100",
+        "--reference",
+        "Test",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "weekly",
+      ],
+      { from: "user" },
+    );
+
+    expect(createRecurringTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ currency: "EUR" }),
+      expect.anything(),
+    );
+  });
+
+  it("omits note when not provided", async () => {
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "100",
+        "--reference",
+        "Test",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "monthly",
+      ],
+      { from: "user" },
+    );
+
+    const callArgs = createRecurringTransferMock.mock.calls[0]?.[1];
+    expect(callArgs).not.toHaveProperty("note");
+  });
+});

--- a/packages/cli/src/commands/recurring-transfer/list.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/list.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+
+function makeMeta(overrides: Record<string, unknown> = {}) {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+describe("recurring-transfer list command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let writtenOutput: string[];
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    writtenOutput = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+      writtenOutput.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runCommand(...args: string[]) {
+    vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
+    vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync(["node", "qontoctl", "recurring-transfer", "list", ...args]);
+  }
+
+  it("sends request to /v2/sepa/recurring_transfers", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ recurring_transfers: [], meta: makeMeta() }));
+
+    await runCommand();
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/sepa/recurring_transfers");
+  });
+
+  it("outputs JSON when --output json", async () => {
+    const recurringTransfers = [
+      {
+        id: "rt-1",
+        initiator_id: "user-1",
+        bank_account_id: "acc-1",
+        amount: 200,
+        amount_cents: 20000,
+        amount_currency: "EUR",
+        beneficiary_id: "ben-1",
+        reference: "Monthly rent",
+        note: "",
+        first_execution_date: "2026-04-01",
+        last_execution_date: null,
+        next_execution_date: "2026-04-01",
+        frequency: "monthly",
+        status: "active",
+        created_at: "2026-03-25T00:00:00.000Z",
+        updated_at: "2026-03-25T00:00:00.000Z",
+      },
+    ];
+    fetchSpy.mockImplementation(() =>
+      jsonResponse({ recurring_transfers: recurringTransfers, meta: makeMeta({ total_count: 1 }) }),
+    );
+
+    await runCommand("--output", "json");
+
+    expect(writtenOutput.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(writtenOutput.join(""));
+    expect(parsed).toEqual(recurringTransfers);
+  });
+
+  it("outputs table rows with selected columns", async () => {
+    const recurringTransfers = [
+      {
+        id: "rt-1",
+        initiator_id: "user-1",
+        bank_account_id: "acc-1",
+        amount: 200,
+        amount_cents: 20000,
+        amount_currency: "EUR",
+        beneficiary_id: "ben-1",
+        reference: "Monthly rent",
+        note: "should-not-appear-in-table",
+        first_execution_date: "2026-04-01",
+        last_execution_date: null,
+        next_execution_date: "2026-04-01",
+        frequency: "monthly",
+        status: "active",
+        created_at: "2026-03-25T00:00:00.000Z",
+        updated_at: "2026-03-25T00:00:00.000Z",
+      },
+    ];
+    fetchSpy.mockImplementation(() =>
+      jsonResponse({ recurring_transfers: recurringTransfers, meta: makeMeta({ total_count: 1 }) }),
+    );
+
+    await runCommand("--output", "table");
+
+    const output = writtenOutput.join("");
+    expect(output).toContain("rt-1");
+    expect(output).toContain("ben-1");
+    expect(output).toContain("monthly");
+    expect(output).not.toContain("should-not-appear-in-table");
+  });
+});

--- a/packages/cli/src/commands/recurring-transfer/show.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/show.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+
+describe("recurring-transfer show command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let writtenOutput: string[];
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    writtenOutput = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+      writtenOutput.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runCommand(...args: string[]) {
+    vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
+    vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync(["node", "qontoctl", "recurring-transfer", "show", ...args]);
+  }
+
+  const completeRecurringTransfer = {
+    id: "rt-123",
+    initiator_id: "user-1",
+    bank_account_id: "acc-1",
+    amount: 500,
+    amount_cents: 50000,
+    amount_currency: "EUR",
+    beneficiary_id: "ben-1",
+    reference: "Quarterly payment",
+    note: "Office lease",
+    first_execution_date: "2026-01-01",
+    last_execution_date: null,
+    next_execution_date: "2026-04-01",
+    frequency: "quarterly",
+    status: "active",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+
+  it("fetches a recurring transfer by ID", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ recurring_transfer: completeRecurringTransfer }));
+
+    await runCommand("rt-123", "--output", "json");
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/sepa/recurring_transfers/rt-123");
+
+    const parsed = JSON.parse(writtenOutput.join(""));
+    expect(parsed).toEqual(completeRecurringTransfer);
+  });
+
+  it("outputs yaml format for single recurring transfer", async () => {
+    const rt = { ...completeRecurringTransfer, id: "rt-1", amount: 1500, reference: "Office Rent" };
+    fetchSpy.mockImplementation(() => jsonResponse({ recurring_transfer: rt }));
+
+    await runCommand("rt-1", "--output", "yaml");
+
+    const output = writtenOutput.join("");
+    expect(output).toContain("Office Rent");
+    expect(output).toContain("1500");
+  });
+
+  it("calls the correct API endpoint with encoded ID", async () => {
+    fetchSpy.mockImplementation(() =>
+      jsonResponse({ recurring_transfer: { ...completeRecurringTransfer, id: "a/b" } }),
+    );
+
+    await runCommand("a/b", "--output", "json");
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/sepa/recurring_transfers/a%2Fb");
+  });
+});


### PR DESCRIPTION
## Summary

Adds dedicated unit tests for all four `recurring-transfer` CLI subcommands, which previously had no test coverage (~40% from barrel import only).

**14 tests across 4 files:**

- **create.test.ts** (5 tests): table/json output formats, parameter passing to core API, EUR currency default, optional note omission
- **cancel.test.ts** (3 tests): `--yes` confirmation flow, json output format, exit code 1 when `--yes` missing
- **list.test.ts** (3 tests): correct API endpoint, json output, table column filtering (excludes non-table fields)
- **show.test.ts** (3 tests): fetch by ID, yaml output, URL-encoded ID handling

Follows existing patterns from `transfer/*.test.ts` — SCA-gated operations use mock-based approach, read operations use fetch-spy with `@qontoctl/core/testing`.

Closes #370

## Test plan

- [x] All 14 new tests pass
- [x] Full test suite passes (549 tests)
- [x] Lint clean
- [x] Prettier formatting verified