### PR TITLE
(test) add E2E tests for bulk/recurring transfer write operations

### DIFF
--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
@@ -55,6 +57,32 @@ describe.skipIf(!hasCredentials())("bulk-transfer CLI commands (e2e)", () => {
       const bulkTransfers = cliJson<BulkTransferItem[]>("bulk-transfer", "list", "--per-page", "2", "--page", "1");
       expect(Array.isArray(bulkTransfers)).toBe(true);
       expect(bulkTransfers.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("bulk-transfer create", () => {
+    it("creates a bulk transfer from a JSON file", () => {
+      const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
+      if (beneficiaries.length === 0) return;
+
+      const beneficiaryId = (beneficiaries[0] as { id: string }).id;
+
+      const tmpDir = mkdtempSync(join(tmpdir(), "qontoctl-e2e-"));
+      const filePath = join(tmpDir, "transfers.json");
+      writeFileSync(
+        filePath,
+        JSON.stringify([{ beneficiary_id: beneficiaryId, amount: 1.0, currency: "EUR", reference: "e2e-bulk-test" }]),
+      );
+
+      try {
+        const bt = cliJson<BulkTransferItem>("bulk-transfer", "create", "--file", filePath);
+        BulkTransferSchema.parse(bt);
+        expect(bt).toHaveProperty("id");
+        expect(bt).toHaveProperty("total_count");
+        expect(bt.total_count).toBe(1);
+      } finally {
+        rmSync(tmpDir, { recursive: true });
+      }
     });
   });
 

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -53,6 +53,40 @@ describe.skipIf(!hasCredentials())("bulk-transfer MCP tools (e2e)", () => {
     await client.close();
   });
 
+  describe("bulk_transfer_create", () => {
+    it("creates a bulk transfer", async () => {
+      const beneficiaryResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: { per_page: 1 },
+      });
+      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
+      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+        beneficiaries: { id: string }[];
+      };
+      if (beneficiaryParsed.beneficiaries.length === 0) return;
+
+      const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "bulk_transfer_create",
+        arguments: {
+          transfers: [{ beneficiary_id: beneficiaryId, amount: 1.0, currency: "EUR", reference: "e2e-mcp-bulk" }],
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+
+      const textContent = result.content[0] as { type: string; text: string };
+      expect(textContent.type).toBe("text");
+
+      const bt = JSON.parse(textContent.text) as BulkTransferItem;
+      BulkTransferSchema.parse(bt);
+      expect(bt).toHaveProperty("id");
+      expect(bt).toHaveProperty("total_count");
+      expect(bt.total_count).toBe(1);
+    });
+  });
+
   describe("bulk_transfer_list", () => {
     it("lists bulk transfers", async () => {
       const result = await client.callTool({

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -88,4 +88,80 @@ describe.skipIf(!hasCredentials())("recurring-transfer CLI commands (e2e)", () =
       expect(rt).toHaveProperty("status");
     });
   });
+
+  describe("recurring-transfer create", () => {
+    it("creates a recurring transfer", () => {
+      const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
+      if (beneficiaries.length === 0) return;
+      const beneficiaryId = (beneficiaries[0] as { id: string }).id;
+
+      const accounts = cliJson<{ id: string }[]>("account", "list");
+      if (accounts.length === 0) return;
+      const accountId = (accounts[0] as { id: string }).id;
+
+      const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const rt = cliJson<RecurringTransferItem>(
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        beneficiaryId,
+        "--debit-account",
+        accountId,
+        "--amount",
+        "1.00",
+        "--currency",
+        "EUR",
+        "--reference",
+        "e2e-recurring-test",
+        "--start-date",
+        futureDate,
+        "--schedule",
+        "monthly",
+      );
+      RecurringTransferSchema.parse(rt);
+      expect(rt).toHaveProperty("id");
+      expect(rt.frequency).toBe("monthly");
+      expect(rt).toHaveProperty("beneficiary_id", beneficiaryId);
+    });
+  });
+
+  describe("recurring-transfer cancel", () => {
+    it("creates and then cancels a recurring transfer", () => {
+      const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
+      if (beneficiaries.length === 0) return;
+      const beneficiaryId = (beneficiaries[0] as { id: string }).id;
+
+      const accounts = cliJson<{ id: string }[]>("account", "list");
+      if (accounts.length === 0) return;
+      const accountId = (accounts[0] as { id: string }).id;
+
+      const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const rt = cliJson<RecurringTransferItem>(
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        beneficiaryId,
+        "--debit-account",
+        accountId,
+        "--amount",
+        "1.00",
+        "--currency",
+        "EUR",
+        "--reference",
+        "e2e-cancel-test",
+        "--start-date",
+        futureDate,
+        "--schedule",
+        "monthly",
+      );
+      expect(rt).toHaveProperty("id");
+
+      const cancelOutput = cli("recurring-transfer", "cancel", rt.id, "--yes", "--output", "json");
+      const cancelResult = JSON.parse(cancelOutput) as { canceled: boolean; id: string };
+      expect(cancelResult.canceled).toBe(true);
+      expect(cancelResult.id).toBe(rt.id);
+    });
+  });
 });

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -54,6 +54,112 @@ describe.skipIf(!hasCredentials())("recurring-transfer MCP tools (e2e)", () => {
     await client.close();
   });
 
+  describe("recurring_transfer_create", () => {
+    it("creates a recurring transfer", async () => {
+      const beneficiaryResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: { per_page: 1 },
+      });
+      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
+      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+        beneficiaries: { id: string }[];
+      };
+      if (beneficiaryParsed.beneficiaries.length === 0) return;
+      const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
+
+      const accountResult = await client.callTool({
+        name: "account_list",
+        arguments: {},
+      });
+      const accountText = accountResult.content[0] as { type: string; text: string };
+      const accountParsed = JSON.parse(accountText.text) as { id: string }[];
+      if (accountParsed.length === 0) return;
+      const accountId = (accountParsed[0] as { id: string }).id;
+
+      const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const result = await client.callTool({
+        name: "recurring_transfer_create",
+        arguments: {
+          beneficiary_id: beneficiaryId,
+          bank_account_id: accountId,
+          amount: 1.0,
+          currency: "EUR",
+          reference: "e2e-mcp-recurring",
+          first_execution_date: futureDate,
+          frequency: "monthly",
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+
+      const textContent = result.content[0] as { type: string; text: string };
+      expect(textContent.type).toBe("text");
+
+      const rt = JSON.parse(textContent.text) as RecurringTransferItem;
+      RecurringTransferSchema.parse(rt);
+      expect(rt).toHaveProperty("id");
+      expect(rt.frequency).toBe("monthly");
+      expect(rt).toHaveProperty("beneficiary_id", beneficiaryId);
+    });
+  });
+
+  describe("recurring_transfer_cancel", () => {
+    it("creates and then cancels a recurring transfer", async () => {
+      const beneficiaryResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: { per_page: 1 },
+      });
+      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
+      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+        beneficiaries: { id: string }[];
+      };
+      if (beneficiaryParsed.beneficiaries.length === 0) return;
+      const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
+
+      const accountResult = await client.callTool({
+        name: "account_list",
+        arguments: {},
+      });
+      const accountText = accountResult.content[0] as { type: string; text: string };
+      const accountParsed = JSON.parse(accountText.text) as { id: string }[];
+      if (accountParsed.length === 0) return;
+      const accountId = (accountParsed[0] as { id: string }).id;
+
+      const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const createResult = await client.callTool({
+        name: "recurring_transfer_create",
+        arguments: {
+          beneficiary_id: beneficiaryId,
+          bank_account_id: accountId,
+          amount: 1.0,
+          currency: "EUR",
+          reference: "e2e-mcp-cancel",
+          first_execution_date: futureDate,
+          frequency: "monthly",
+        },
+      });
+      expect(createResult.isError).not.toBe(true);
+
+      const createText = createResult.content[0] as { type: string; text: string };
+      const created = JSON.parse(createText.text) as RecurringTransferItem;
+      expect(created).toHaveProperty("id");
+
+      const cancelResult = await client.callTool({
+        name: "recurring_transfer_cancel",
+        arguments: { id: created.id },
+      });
+
+      expect(cancelResult.isError).not.toBe(true);
+
+      const cancelText = cancelResult.content[0] as { type: string; text: string };
+      const canceled = JSON.parse(cancelText.text) as { canceled: boolean; id: string };
+      expect(canceled.canceled).toBe(true);
+      expect(canceled.id).toBe(created.id);
+    });
+  });
+
   describe("recurring_transfer_list", () => {
     it("lists recurring transfers", async () => {
       const result = await client.callTool({


### PR DESCRIPTION
## Summary

Add E2E test coverage for write operations introduced in #195:

- `bulk-transfer create` — CLI test (writes temp JSON file, creates bulk transfer, validates response)
- `bulk_transfer_create` — MCP tool test (calls tool with transfers array, validates response)
- `recurring-transfer create` — CLI test (creates recurring transfer with future date, validates response)
- `recurring_transfer_create` — MCP tool test (calls tool with all required params, validates response)
- `recurring-transfer cancel` — CLI test (creates then cancels, verifies cancel response)
- `recurring_transfer_cancel` — MCP tool test (creates then cancels, verifies cancel response)

All tests follow established E2E patterns: fetch fixture data (beneficiary/account IDs) from the API, perform write operation, validate response with Zod schemas.

Closes #379

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] Unit tests pass (`pnpm test` — 535/535)
- [x] Prettier formatting verified
- [ ] E2E tests pass with sandbox credentials (requires OAuth sandbox)