### PR TITLE
(test) add E2E tests for 8 domains without end-to-end coverage

### DIFF
--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { CardSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface CardItem {
+  readonly id: string;
+  readonly nickname: string | null;
+  readonly last_digits: string | null;
+  readonly status: string;
+  readonly card_level: string;
+  readonly holder_id: string;
+}
+
+describe.skipIf(!hasCredentials())("card CLI commands (e2e)", () => {
+  describe("card list", () => {
+    it("lists cards with default output", () => {
+      const output = cli("card", "list");
+      expect(output).toBeDefined();
+    });
+
+    it("lists cards as JSON", () => {
+      const cards = cliJson<CardItem[]>("card", "list");
+      expect(Array.isArray(cards)).toBe(true);
+      const first = cards[0];
+      if (first !== undefined) {
+        CardSchema.parse(first);
+        expect(first).toHaveProperty("id");
+        expect(first).toHaveProperty("status");
+        expect(first).toHaveProperty("card_level");
+      }
+    });
+
+    it("supports pagination", () => {
+      const cards = cliJson<CardItem[]>("card", "list", "--per-page", "2", "--page", "1");
+      expect(Array.isArray(cards)).toBe(true);
+      expect(cards.length).toBeLessThanOrEqual(2);
+    });
+
+    it("filters by status", () => {
+      const cards = cliJson<CardItem[]>("card", "list", "--status", "live");
+      expect(Array.isArray(cards)).toBe(true);
+      for (const c of cards) {
+        expect(c.status).toBe("live");
+      }
+    });
+
+    it("filters by card level", () => {
+      const cards = cliJson<CardItem[]>("card", "list", "--card-level", "virtual");
+      expect(Array.isArray(cards)).toBe(true);
+      for (const c of cards) {
+        expect(c.card_level).toBe("virtual");
+      }
+    });
+
+    it("outputs CSV format", () => {
+      const output = cli("card", "list", "--output", "csv", "--per-page", "5");
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const header = lines[0] ?? "";
+      expect(header).toContain("id");
+      expect(header).toContain("status");
+    });
+
+    it("outputs YAML format", () => {
+      const output = cli("card", "list", "--output", "yaml", "--per-page", "2");
+      expect(output).toContain("id:");
+    });
+  });
+});

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CardListResponseSchema, CardSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+interface CardItem {
+  readonly id: string;
+  readonly status: string;
+  readonly card_level: string;
+}
+
+interface CardListResponse {
+  readonly cards: CardItem[];
+  readonly meta: {
+    readonly current_page: number;
+    readonly total_pages: number;
+    readonly total_count: number;
+  };
+}
+
+describe.skipIf(!hasCredentials())("card MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("card_list", () => {
+    it("returns a list of cards with expected structure", async () => {
+      const result = await client.callTool({
+        name: "card_list",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as CardListResponse;
+      CardListResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("cards");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.cards)).toBe(true);
+    });
+
+    it("supports pagination", async () => {
+      const result = await client.callTool({
+        name: "card_list",
+        arguments: { per_page: 2, page: 1 },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as CardListResponse;
+      expect(parsed.cards.length).toBeLessThanOrEqual(2);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+
+    it("filters by status", async () => {
+      const result = await client.callTool({
+        name: "card_list",
+        arguments: { statuses: ["live"] },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as CardListResponse;
+      for (const c of parsed.cards) {
+        expect(c.status).toBe("live");
+      }
+    });
+  });
+
+  describe("card_show", () => {
+    it("shows a card by ID", async () => {
+      const listResult = await client.callTool({
+        name: "card_list",
+        arguments: { per_page: 1 },
+      });
+      if (listResult.isError === true) return;
+
+      const listParsed = JSON.parse(firstText(listResult)) as CardListResponse;
+      const first = listParsed.cards[0];
+      if (first === undefined) return;
+
+      const result = await client.callTool({
+        name: "card_show",
+        arguments: { id: first.id },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as CardItem;
+      CardSchema.parse(parsed);
+      expect(parsed.id).toBe(first.id);
+      expect(parsed).toHaveProperty("status");
+      expect(parsed).toHaveProperty("card_level");
+    });
+  });
+
+  describe("card_appearances", () => {
+    it("returns available card appearances", async () => {
+      const result = await client.callTool({
+        name: "card_appearances",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+    });
+  });
+});

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { InsuranceContractSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+describe.skipIf(!hasCredentials())("insurance CLI commands (e2e)", () => {
+  describe("insurance CRUD lifecycle", () => {
+    let createdId: string | undefined;
+
+    it("creates an insurance contract", () => {
+      const output = cli(
+        "--output",
+        "json",
+        "insurance",
+        "create",
+        "--insurance-type",
+        "professional_liability",
+        "--provider-name",
+        "E2E Test Provider",
+        "--start-date",
+        "2026-01-01",
+      );
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
+      InsuranceContractSchema.parse(parsed);
+      createdId = parsed["id"] as string;
+    });
+
+    it("shows the created insurance contract", () => {
+      if (createdId === undefined) return;
+
+      const output = cli("--output", "json", "insurance", "show", createdId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      InsuranceContractSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id", createdId);
+    });
+
+    it("updates the created insurance contract", () => {
+      if (createdId === undefined) return;
+
+      const output = cli(
+        "--output",
+        "json",
+        "insurance",
+        "update",
+        createdId,
+        "--provider-name",
+        "Updated E2E Provider",
+      );
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("provider_name", "Updated E2E Provider");
+    });
+  });
+});

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { InsuranceContractSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials())("insurance MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("insurance CRUD lifecycle", () => {
+    let createdId: string | undefined;
+
+    it("creates an insurance contract", async () => {
+      const result = await client.callTool({
+        name: "insurance_create",
+        arguments: {
+          insurance_type: "professional_liability",
+          provider_name: "E2E MCP Test Provider",
+          start_date: "2026-01-01",
+        },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      InsuranceContractSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
+      createdId = parsed["id"] as string;
+    });
+
+    it("shows the created insurance contract", async () => {
+      if (createdId === undefined) return;
+
+      const result = await client.callTool({
+        name: "insurance_show",
+        arguments: { id: createdId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      InsuranceContractSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id", createdId);
+    });
+
+    it("updates the created insurance contract", async () => {
+      if (createdId === undefined) return;
+
+      const result = await client.callTool({
+        name: "insurance_update",
+        arguments: {
+          id: createdId,
+          provider_name: "Updated E2E MCP Provider",
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("provider_name", "Updated E2E MCP Provider");
+    });
+  });
+});

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+describe.skipIf(!hasCredentials())("internal-transfer CLI commands (e2e)", () => {
+  describe("internal-transfer create", () => {
+    it("rejects create with missing required options", () => {
+      try {
+        cli("internal-transfer", "create");
+        expect.fail("Expected command to exit with non-zero code");
+      } catch (error: unknown) {
+        const execError = error as { status: number; stderr: Buffer };
+        expect(execError.status).not.toBe(0);
+      }
+    });
+  });
+});

--- a/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+describe.skipIf(!hasCredentials())("internal-transfer MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("internal_transfer_create", () => {
+    it("rejects create with missing required fields", async () => {
+      const result = await client.callTool({
+        name: "internal_transfer_create",
+        arguments: {},
+      });
+
+      expect(result.isError).toBe(true);
+    });
+  });
+});

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface IntlCurrencyItem {
+  readonly code: string;
+  readonly name: string;
+}
+
+describe.skipIf(!hasCredentials())("international CLI commands (e2e)", () => {
+  describe("intl eligibility", () => {
+    it("returns eligibility status with default output", () => {
+      const output = cli("intl", "eligibility");
+      expect(output).toBeDefined();
+    });
+
+    it("returns eligibility as JSON", () => {
+      const parsed = cliJson<{ eligible: boolean; reason?: string }>("intl", "eligibility");
+      IntlEligibilitySchema.parse(parsed);
+      expect(parsed).toHaveProperty("eligible");
+      expect(typeof parsed.eligible).toBe("boolean");
+    });
+  });
+
+  describe("intl currencies", () => {
+    it("lists currencies with default output", () => {
+      const output = cli("intl", "currencies");
+      expect(output).toBeDefined();
+    });
+
+    it("returns currencies as JSON", () => {
+      const parsed = cliJson<IntlCurrencyItem[]>("intl", "currencies");
+      expect(Array.isArray(parsed)).toBe(true);
+      const first = parsed[0];
+      if (first !== undefined) {
+        IntlCurrencySchema.parse(first);
+        expect(first).toHaveProperty("code");
+        expect(first).toHaveProperty("name");
+      }
+    });
+
+    it("supports --search filter", () => {
+      const parsed = cliJson<IntlCurrencyItem[]>("intl", "currencies", "--search", "USD");
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const c of parsed) {
+        const match = c.code.toLowerCase().includes("usd") || c.name.toLowerCase().includes("usd");
+        expect(match).toBe(true);
+      }
+    });
+
+    it("outputs CSV format", () => {
+      const output = cli("intl", "currencies", "--output", "csv");
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const header = lines[0] ?? "";
+      expect(header).toContain("code");
+    });
+  });
+});

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { IntlEligibilityResponseSchema, IntlCurrencySchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials())("international MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("intl_eligibility", () => {
+    it("returns eligibility status", async () => {
+      const result = await client.callTool({
+        name: "intl_eligibility",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      IntlEligibilityResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("eligibility");
+    });
+  });
+
+  describe("intl_currencies", () => {
+    it("returns a list of currencies", async () => {
+      const result = await client.callTool({
+        name: "intl_currencies",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      const first = parsed[0];
+      if (first !== undefined) {
+        IntlCurrencySchema.parse(first);
+      }
+    });
+
+    it("supports search filter", async () => {
+      const result = await client.callTool({
+        name: "intl_currencies",
+        arguments: { search: "EUR" },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as { code: string; name: string }[];
+      expect(Array.isArray(parsed)).toBe(true);
+      for (const c of parsed) {
+        const match = c.code.toLowerCase().includes("eur") || c.name.toLowerCase().includes("eur");
+        expect(match).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { IntlBeneficiarySchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface IntlBeneficiaryItem {
+  readonly id: string;
+  readonly name: string;
+  readonly currency: string;
+  readonly country: string;
+}
+
+describe.skipIf(!hasCredentials())("intl-beneficiary CLI commands (e2e)", () => {
+  describe("intl-beneficiary list", () => {
+    it("lists international beneficiaries with default output", () => {
+      const output = cli("intl-beneficiary", "list");
+      expect(output).toBeDefined();
+    });
+
+    it("produces valid JSON with --output json", () => {
+      const parsed = cliJson<IntlBeneficiaryItem[]>("intl-beneficiary", "list");
+      expect(Array.isArray(parsed)).toBe(true);
+      const first = parsed[0];
+      if (first !== undefined) {
+        IntlBeneficiarySchema.parse(first);
+        expect(first).toHaveProperty("id");
+        expect(first).toHaveProperty("currency");
+      }
+    });
+
+    it("supports pagination", () => {
+      const parsed = cliJson<IntlBeneficiaryItem[]>("intl-beneficiary", "list", "--per-page", "2", "--page", "1");
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBeLessThanOrEqual(2);
+    });
+
+    it("outputs CSV format", () => {
+      const output = cli("intl-beneficiary", "list", "--output", "csv", "--per-page", "5");
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials())("intl-beneficiary MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("intl_beneficiary_list", () => {
+    it("returns a list with expected structure", async () => {
+      const result = await client.callTool({
+        name: "intl_beneficiary_list",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as {
+        international_beneficiaries: unknown[];
+        meta: Record<string, unknown>;
+      };
+      IntlBeneficiaryListResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("international_beneficiaries");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.international_beneficiaries)).toBe(true);
+    });
+
+    it("supports pagination", async () => {
+      const result = await client.callTool({
+        name: "intl_beneficiary_list",
+        arguments: { per_page: 2, page: 1 },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as {
+        international_beneficiaries: unknown[];
+        meta: { current_page: number };
+      };
+      expect(parsed.international_beneficiaries.length).toBeLessThanOrEqual(2);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+  });
+
+  describe("intl_beneficiary_requirements", () => {
+    it("returns requirements for an existing beneficiary", async () => {
+      const listResult = await client.callTool({
+        name: "intl_beneficiary_list",
+        arguments: {},
+      });
+      if (listResult.isError === true) return;
+
+      const listParsed = JSON.parse(firstText(listResult)) as {
+        international_beneficiaries: { id: string }[];
+      };
+      if (listParsed.international_beneficiaries.length === 0) return;
+
+      const id = (listParsed.international_beneficiaries[0] as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "intl_beneficiary_requirements",
+        arguments: { id },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("requirements");
+    });
+  });
+});

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+describe.skipIf(!hasCredentials())("intl-transfer CLI commands (e2e)", () => {
+  describe("intl-transfer requirements", () => {
+    it("returns requirements for a beneficiary", () => {
+      // First list intl beneficiaries to get an ID
+      let beneficiaries: { id: string }[];
+      try {
+        beneficiaries = cliJson<{ id: string }[]>("intl-beneficiary", "list");
+      } catch {
+        return;
+      }
+      if (beneficiaries.length === 0) return;
+
+      const id = (beneficiaries[0] as { id: string }).id;
+      const output = cli("--output", "json", "intl-transfer", "requirements", id);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("requirements");
+    });
+  });
+});

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+describe.skipIf(!hasCredentials())("intl-transfer MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("intl_transfer_requirements", () => {
+    it("returns requirements for a beneficiary", async () => {
+      // First list intl beneficiaries to get an ID
+      const listResult = await client.callTool({
+        name: "intl_beneficiary_list",
+        arguments: {},
+      });
+      if (listResult.isError === true) return;
+
+      const listParsed = JSON.parse(firstText(listResult)) as {
+        international_beneficiaries: { id: string }[];
+      };
+      if (listParsed.international_beneficiaries.length === 0) return;
+
+      const id = (listParsed.international_beneficiaries[0] as { id: string }).id;
+
+      const result = await client.callTool({
+        name: "intl_transfer_requirements",
+        arguments: { id },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      IntlTransferRequirementsResponseSchema.parse(parsed);
+    });
+  });
+});

--- a/packages/e2e/src/teams/cli.e2e.test.ts
+++ b/packages/e2e/src/teams/cli.e2e.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { TeamSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface TeamItem {
+  readonly id: string;
+  readonly name: string;
+}
+
+describe.skipIf(!hasCredentials())("team CLI commands (e2e)", () => {
+  describe("team list", () => {
+    it("lists teams with default output", () => {
+      const output = cli("team", "list");
+      expect(output).toBeDefined();
+    });
+
+    it("lists teams as JSON", () => {
+      const teams = cliJson<TeamItem[]>("team", "list");
+      expect(Array.isArray(teams)).toBe(true);
+      const first = teams[0];
+      if (first !== undefined) {
+        TeamSchema.parse(first);
+        expect(first).toHaveProperty("id");
+        expect(first).toHaveProperty("name");
+      }
+    });
+
+    it("supports pagination", () => {
+      const teams = cliJson<TeamItem[]>("team", "list", "--per-page", "2", "--page", "1");
+      expect(Array.isArray(teams)).toBe(true);
+      expect(teams.length).toBeLessThanOrEqual(2);
+    });
+
+    it("outputs CSV format", () => {
+      const output = cli("team", "list", "--output", "csv");
+      const lines = output.trim().split("\n");
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+      const header = lines[0] ?? "";
+      expect(header).toContain("id");
+    });
+  });
+});

--- a/packages/e2e/src/teams/mcp.e2e.test.ts
+++ b/packages/e2e/src/teams/mcp.e2e.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { TeamListResponseSchema, TeamSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+interface TeamItem {
+  readonly id: string;
+  readonly name: string;
+}
+
+interface TeamListResponse {
+  readonly teams: TeamItem[];
+  readonly meta: {
+    readonly current_page: number;
+    readonly total_pages: number;
+    readonly total_count: number;
+  };
+}
+
+describe.skipIf(!hasCredentials())("team MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("team_list", () => {
+    it("returns a list of teams with expected structure", async () => {
+      const result = await client.callTool({
+        name: "team_list",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as TeamListResponse;
+      TeamListResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("teams");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.teams)).toBe(true);
+    });
+
+    it("supports pagination", async () => {
+      const result = await client.callTool({
+        name: "team_list",
+        arguments: { per_page: 2, page: 1 },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as TeamListResponse;
+      expect(parsed.teams.length).toBeLessThanOrEqual(2);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+
+    it("validates team schema", async () => {
+      const result = await client.callTool({
+        name: "team_list",
+        arguments: { per_page: 1 },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as TeamListResponse;
+      const first = parsed.teams[0];
+      if (first === undefined) return;
+
+      TeamSchema.parse(first);
+      expect(first).toHaveProperty("id");
+      expect(first).toHaveProperty("name");
+    });
+  });
+});

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { WebhookSubscriptionSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    cwd: cliCwd(),
+    timeout: 30_000,
+  });
+}
+
+function cliJson<T>(...args: string[]): T {
+  const output = cli(...args, "--output", "json");
+  return JSON.parse(output) as T;
+}
+
+interface WebhookItem {
+  readonly id: string;
+  readonly callback_url: string;
+  readonly types: string[];
+}
+
+describe.skipIf(!hasCredentials())("webhook CLI commands (e2e)", () => {
+  describe("webhook list", () => {
+    it("lists webhooks with default output", () => {
+      const output = cli("webhook", "list");
+      expect(output).toBeDefined();
+    });
+
+    it("lists webhooks as JSON", () => {
+      const webhooks = cliJson<WebhookItem[]>("webhook", "list");
+      expect(Array.isArray(webhooks)).toBe(true);
+      const first = webhooks[0];
+      if (first !== undefined) {
+        WebhookSubscriptionSchema.parse(first);
+        expect(first).toHaveProperty("id");
+        expect(first).toHaveProperty("callback_url");
+        expect(first).toHaveProperty("types");
+      }
+    });
+
+    it("supports pagination", () => {
+      const webhooks = cliJson<WebhookItem[]>("webhook", "list", "--per-page", "2", "--page", "1");
+      expect(Array.isArray(webhooks)).toBe(true);
+      expect(webhooks.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("webhook show", () => {
+    it("shows a webhook by ID", () => {
+      const webhooks = cliJson<WebhookItem[]>("webhook", "list", "--per-page", "1");
+      const first = webhooks[0];
+      if (first === undefined) return;
+
+      const webhook = cliJson<WebhookItem>("webhook", "show", first.id);
+      WebhookSubscriptionSchema.parse(webhook);
+      expect(webhook.id).toBe(first.id);
+      expect(webhook).toHaveProperty("callback_url");
+      expect(webhook).toHaveProperty("types");
+    });
+  });
+
+  describe("webhook delete without --yes", () => {
+    it("exits with error when --yes is not provided", () => {
+      try {
+        cli("webhook", "delete", "00000000-0000-0000-0000-000000000000");
+        expect.fail("Expected command to exit with non-zero code");
+      } catch (error: unknown) {
+        const execError = error as { status: number };
+        expect(execError.status).toBe(1);
+      }
+    });
+  });
+});

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
+  const content = result.content as { type: string; text: string }[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as { type: string; text: string };
+  expect(entry.type).toBe("text");
+  return entry.text;
+}
+
+interface WebhookItem {
+  readonly id: string;
+  readonly callback_url: string;
+  readonly types: string[];
+}
+
+interface WebhookListResponse {
+  readonly webhook_subscriptions: WebhookItem[];
+  readonly meta: {
+    readonly current_page: number;
+    readonly total_pages: number;
+    readonly total_count: number;
+  };
+}
+
+describe.skipIf(!hasCredentials())("webhook MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      cwd: cliCwd(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("webhook_list", () => {
+    it("returns a list of webhooks with expected structure", async () => {
+      const result = await client.callTool({
+        name: "webhook_list",
+        arguments: {},
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as WebhookListResponse;
+      WebhookSubscriptionListResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("webhook_subscriptions");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.webhook_subscriptions)).toBe(true);
+    });
+
+    it("supports pagination", async () => {
+      const result = await client.callTool({
+        name: "webhook_list",
+        arguments: { per_page: 2, page: 1 },
+      });
+
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstText(result)) as WebhookListResponse;
+      expect(parsed.webhook_subscriptions.length).toBeLessThanOrEqual(2);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+  });
+
+  describe("webhook_show", () => {
+    it("shows a webhook by ID", async () => {
+      const listResult = await client.callTool({
+        name: "webhook_list",
+        arguments: { per_page: 1 },
+      });
+      if (listResult.isError === true) return;
+
+      const listParsed = JSON.parse(firstText(listResult)) as WebhookListResponse;
+      const first = listParsed.webhook_subscriptions[0];
+      if (first === undefined) return;
+
+      const result = await client.callTool({
+        name: "webhook_show",
+        arguments: { id: first.id },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(result)) as WebhookItem;
+      WebhookSubscriptionSchema.parse(parsed);
+      expect(parsed.id).toBe(first.id);
+      expect(parsed).toHaveProperty("callback_url");
+      expect(parsed).toHaveProperty("types");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #378

- Adds CLI + MCP E2E test pairs for 8 domains that had no end-to-end test coverage:
  - **intl-beneficiaries** — list, pagination, schema validation, requirements
  - **intl-transfers** — requirements lookup (depends on intl-beneficiary data)
  - **international** — eligibility check, currencies list with search filter
  - **insurance** — CRUD lifecycle (create, show, update)
  - **cards** — list with pagination/filtering (status, card level), show, appearances
  - **webhooks** — list, show, pagination, delete safety (--yes guard)
  - **teams** — list with pagination, schema validation
  - **internal-transfers** — required-option validation, missing-field rejection

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` — 535 unit tests pass
- [ ] CI gate passes
- [ ] E2E sandbox job validates against Qonto API (non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)