### PR TITLE
(test) add core package test coverage for critical gaps

### DIFF
--- a/packages/core/src/beneficiaries/service.test.ts
+++ b/packages/core/src/beneficiaries/service.test.ts
@@ -4,7 +4,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HttpClient } from "../http-client.js";
 import { jsonResponse } from "../testing/json-response.js";
-import { buildBeneficiaryQueryParams, createBeneficiary, getBeneficiary, updateBeneficiary } from "./service.js";
+import {
+  buildBeneficiaryQueryParams,
+  createBeneficiary,
+  getBeneficiary,
+  listBeneficiaries,
+  trustBeneficiaries,
+  untrustBeneficiaries,
+  updateBeneficiary,
+} from "./service.js";
 import type { ListBeneficiariesParams } from "./types.js";
 
 describe("buildBeneficiaryQueryParams", () => {
@@ -215,5 +223,119 @@ describe("updateBeneficiary", () => {
         name: "Updated Corp",
       },
     });
+  });
+});
+
+describe("listBeneficiaries", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  const MOCK_BENEFICIARY = {
+    id: "ben-1",
+    name: "Acme Corp",
+    iban: "FR7630001007941234567890185",
+    bic: "BNPAFRPP",
+    email: null,
+    activity_tag: null,
+    status: "validated",
+    trusted: true,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+  };
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists beneficiaries without params", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        beneficiaries: [MOCK_BENEFICIARY],
+        meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 1, per_page: 25 },
+      }),
+    );
+    const result = await listBeneficiaries(client);
+    expect(result.beneficiaries).toHaveLength(1);
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/sepa/beneficiaries");
+  });
+
+  it("passes filter and pagination params", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        beneficiaries: [],
+        meta: { current_page: 2, next_page: 3, prev_page: 1, total_pages: 3, total_count: 50, per_page: 10 },
+      }),
+    );
+    await listBeneficiaries(client, { page: 2, per_page: 10, status: ["validated"] });
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("page")).toBe("2");
+    expect(url.searchParams.get("per_page")).toBe("10");
+    expect(url.searchParams.getAll("status[]")).toEqual(["validated"]);
+  });
+});
+
+describe("trustBeneficiaries", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends POST to /trust with ids", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({}));
+    await trustBeneficiaries(client, ["ben-1", "ben-2"]);
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sepa/beneficiaries/trust");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ ids: ["ben-1", "ben-2"] });
+  });
+});
+
+describe("untrustBeneficiaries", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends POST to /untrust with ids", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({}));
+    await untrustBeneficiaries(client, ["ben-1"]);
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sepa/beneficiaries/untrust");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ ids: ["ben-1"] });
   });
 });

--- a/packages/core/src/cards/service.test.ts
+++ b/packages/core/src/cards/service.test.ts
@@ -4,7 +4,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { HttpClient } from "../http-client.js";
 import { jsonResponse } from "../testing/json-response.js";
-import { createCard } from "./service.js";
+import {
+  buildCardQueryParams,
+  bulkCreateCards,
+  createCard,
+  discardCard,
+  getCard,
+  getCardIframeUrl,
+  listCardAppearances,
+  listCards,
+  lockCard,
+  reportCardLost,
+  reportCardStolen,
+  unlockCard,
+  updateCardLimits,
+  updateCardNickname,
+  updateCardOptions,
+  updateCardRestrictions,
+} from "./service.js";
 
 const MOCK_CARD = {
   id: "card-1",
@@ -112,5 +129,338 @@ describe("createCard", () => {
         card_level: "standard",
       },
     });
+  });
+});
+
+describe("buildCardQueryParams", () => {
+  it("returns empty object for empty params", () => {
+    expect(buildCardQueryParams({})).toEqual({});
+  });
+
+  it("maps scalar params", () => {
+    expect(buildCardQueryParams({ query: "test", sort_by: "created_at:desc" })).toEqual({
+      query: "test",
+      sort_by: "created_at:desc",
+    });
+  });
+
+  it("maps array params with [] suffix", () => {
+    expect(
+      buildCardQueryParams({
+        holder_ids: ["h1"],
+        statuses: ["active"],
+        bank_account_ids: ["ba1"],
+        card_levels: ["standard"],
+        ids: ["id1"],
+      }),
+    ).toEqual({
+      "holder_ids[]": ["h1"],
+      "statuses[]": ["active"],
+      "bank_account_ids[]": ["ba1"],
+      "card_levels[]": ["standard"],
+      "ids[]": ["id1"],
+    });
+  });
+
+  it("omits empty arrays", () => {
+    expect(
+      buildCardQueryParams({
+        holder_ids: [],
+        statuses: [],
+        bank_account_ids: [],
+        card_levels: [],
+        ids: [],
+      }),
+    ).toEqual({});
+  });
+});
+
+describe("getCard", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches a card by ID", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+
+    const result = await getCard(client, "card-1");
+    expect(result.id).toBe("card-1");
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/cards/card-1");
+  });
+
+  it("encodes special characters in ID", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await getCard(client, "a/b");
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/cards/a%2Fb");
+  });
+});
+
+describe("listCards", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists cards without params", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        cards: [MOCK_CARD],
+        meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 1, per_page: 25 },
+      }),
+    );
+    const result = await listCards(client);
+    expect(result.cards).toHaveLength(1);
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/cards");
+  });
+
+  it("passes filter and pagination params", async () => {
+    fetchSpy.mockReturnValue(
+      jsonResponse({
+        cards: [],
+        meta: { current_page: 2, next_page: 3, prev_page: 1, total_pages: 3, total_count: 50, per_page: 10 },
+      }),
+    );
+    await listCards(client, { page: 2, per_page: 10, statuses: ["active"] });
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("page")).toBe("2");
+    expect(url.searchParams.get("per_page")).toBe("10");
+    expect(url.searchParams.getAll("statuses[]")).toEqual(["active"]);
+  });
+});
+
+describe("bulkCreateCards", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends cards array in request body", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ cards: [MOCK_CARD] }));
+
+    const params = {
+      holder_id: "holder-1",
+      initiator_id: "init-1",
+      organization_id: "org-1",
+      bank_account_id: "ba-1",
+      card_level: "standard" as const,
+    };
+    const result = await bulkCreateCards(client, [params]);
+    expect(result).toHaveLength(1);
+
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/bulk");
+    expect(opts.method).toBe("POST");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toHaveProperty("cards");
+  });
+});
+
+describe("card state actions", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lockCard sends PUT to /lock", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await lockCard(client, "card-1");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/lock");
+    expect(opts.method).toBe("PUT");
+  });
+
+  it("unlockCard sends PUT to /unlock", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await unlockCard(client, "card-1");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/unlock");
+    expect(opts.method).toBe("PUT");
+  });
+
+  it("reportCardLost sends PUT to /lost", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await reportCardLost(client, "card-1");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/lost");
+    expect(opts.method).toBe("PUT");
+  });
+
+  it("reportCardStolen sends PUT to /stolen", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await reportCardStolen(client, "card-1");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/stolen");
+    expect(opts.method).toBe("PUT");
+  });
+
+  it("discardCard sends PUT to /discard", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await discardCard(client, "card-1");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/discard");
+    expect(opts.method).toBe("PUT");
+  });
+});
+
+describe("card update actions", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("updateCardLimits sends PATCH to /limits", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await updateCardLimits(client, "card-1", { payment_monthly_limit: 10000 });
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/limits");
+    expect(opts.method).toBe("PATCH");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ card: { payment_monthly_limit: 10000 } });
+  });
+
+  it("updateCardNickname sends PATCH to /nickname", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await updateCardNickname(client, "card-1", "New Name");
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/nickname");
+    expect(opts.method).toBe("PATCH");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ card: { nickname: "New Name" } });
+  });
+
+  it("updateCardOptions sends PATCH to /options", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await updateCardOptions(client, "card-1", { atm_option: false });
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/options");
+    expect(opts.method).toBe("PATCH");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ card: { atm_option: false } });
+  });
+
+  it("updateCardRestrictions sends PATCH to /restrictions", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ card: MOCK_CARD }));
+    await updateCardRestrictions(client, "card-1", { active_days: [1, 2, 3] });
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/cards/card-1/restrictions");
+    expect(opts.method).toBe("PATCH");
+    const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ card: { active_days: [1, 2, 3] } });
+  });
+});
+
+describe("getCardIframeUrl", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the iframe URL", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ iframe_url: "https://example.com/iframe" }));
+    const url = await getCardIframeUrl(client, "card-1");
+    expect(url).toBe("https://example.com/iframe");
+    const [reqUrl] = fetchSpy.mock.calls[0] as [URL];
+    expect(reqUrl.pathname).toBe("/v2/cards/card-1/data_view");
+  });
+});
+
+describe("listCardAppearances", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({ baseUrl: "https://thirdparty.qonto.com", authorization: "slug:secret" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns card type appearances", async () => {
+    const appearances = [
+      {
+        card_type: "debit",
+        card_level_appearances: [
+          {
+            card_level: "standard",
+            appearances: [
+              {
+                design: "default",
+                assets: {
+                  front_large: "https://example.com/large.png",
+                  front_small: "https://example.com/small.png",
+                  front_small_wallet: "https://example.com/wallet.png",
+                },
+                theme: "light",
+                gradient_hex_color: "#FFFFFF",
+                is_active: true,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    fetchSpy.mockReturnValue(jsonResponse({ card_type_appearances: appearances }));
+    const result = await listCardAppearances(client);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeDefined();
+    expect(result[0]?.card_type).toBe("debit");
+    const [reqUrl] = fetchSpy.mock.calls[0] as [URL];
+    expect(reqUrl.pathname).toBe("/v2/cards/appearances");
   });
 });

--- a/packages/core/src/response.test.ts
+++ b/packages/core/src/response.test.ts
@@ -33,4 +33,12 @@ describe("parseResponse", () => {
     expect(result).not.toHaveProperty("bonus");
     expect(result.transfer).not.toHaveProperty("extra");
   });
+
+  it("re-throws non-ZodError errors unchanged", () => {
+    const throwingSchema = z.unknown().transform(() => {
+      throw new TypeError("unexpected");
+    });
+    expect(() => parseResponse(throwingSchema, {}, "/v2/test")).toThrow(TypeError);
+    expect(() => parseResponse(throwingSchema, {}, "/v2/test")).toThrow("unexpected");
+  });
 });

--- a/packages/core/src/sca/sca-service.test.ts
+++ b/packages/core/src/sca/sca-service.test.ts
@@ -188,6 +188,22 @@ describe("SCA service", () => {
       expect(sleepCalls).toEqual([5000]);
     });
 
+    it("uses default sleep when none provided", async () => {
+      vi.useFakeTimers();
+      try {
+        fetchSpy
+          .mockReturnValueOnce(jsonResponse({ sca_session: { status: "waiting" } }))
+          .mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+
+        const promise = pollScaSession(client, "tok-default", { intervalMs: 100 });
+        await vi.advanceTimersByTimeAsync(200);
+        const session = await promise;
+        expect(session.status).toBe("allow");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("throws ScaDeniedError after polling when deny comes", async () => {
       fetchSpy
         .mockReturnValueOnce(jsonResponse({ sca_session: { status: "waiting" } }))


### PR DESCRIPTION
## Summary

- Add comprehensive tests for `cards/service.ts` (was 4% → now ~100%): `buildCardQueryParams`, `getCard`, `listCards`, `bulkCreateCards`, `lockCard`, `unlockCard`, `reportCardLost`, `reportCardStolen`, `discardCard`, `updateCardLimits`, `updateCardNickname`, `updateCardOptions`, `updateCardRestrictions`, `getCardIframeUrl`, `listCardAppearances`
- Add tests for `beneficiaries/service.ts` missing functions: `listBeneficiaries`, `trustBeneficiaries`, `untrustBeneficiaries`
- Add test for `response.ts` non-ZodError re-throw branch (was 50% branch → 100%)
- Add test for `sca/sca-service.ts` default sleep path (was 60% funcs → ~100%)

Core package coverage: **91% → 98% stmts**, **86% → 91% branches**, **88% → 99% funcs**

## Test plan

- [x] `pnpm test --filter @qontoctl/core` — 828 tests passing
- [x] `pnpm lint` — clean
- [x] Full suite `pnpm test` — 1730 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)