### PR TITLE
(fix) use spread-conditional pattern in insurance_update MCP tool

### DIFF
--- a/packages/mcp/src/tools/insurance.test.ts
+++ b/packages/mcp/src/tools/insurance.test.ts
@@ -139,6 +139,26 @@ describe("insurance MCP tools", () => {
       expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
       expect(opts.method).toBe("PUT");
     });
+
+    it("omits undefined optional fields from the request body", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await mcpClient.callTool({
+        name: "insurance_update",
+        arguments: {
+          id: "ic-1",
+          provider_name: "Allianz",
+        },
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const body = JSON.parse(opts.body as string) as Record<string, unknown>;
+      expect(body).toEqual({
+        insurance_contract: {
+          provider_name: "Allianz",
+        },
+      });
+    });
   });
 
   describe("insurance_upload_document", () => {

--- a/packages/mcp/src/tools/insurance.ts
+++ b/packages/mcp/src/tools/insurance.ts
@@ -87,12 +87,13 @@ export function registerInsuranceTools(server: McpServer, getClient: () => Promi
     },
     async (args) =>
       withClient(getClient, async (client) => {
-        const contract = await updateInsuranceContract(client, args.id, {
-          insurance_type: args.insurance_type,
-          provider_name: args.provider_name,
-          contract_number: args.contract_number,
-          start_date: args.start_date,
-          end_date: args.end_date,
+        const { id, ...fields } = args;
+        const contract = await updateInsuranceContract(client, id, {
+          ...(fields.insurance_type !== undefined ? { insurance_type: fields.insurance_type } : {}),
+          ...(fields.provider_name !== undefined ? { provider_name: fields.provider_name } : {}),
+          ...(fields.contract_number !== undefined ? { contract_number: fields.contract_number } : {}),
+          ...(fields.start_date !== undefined ? { start_date: fields.start_date } : {}),
+          ...(fields.end_date !== undefined ? { end_date: fields.end_date } : {}),
         });
 
         return {


### PR DESCRIPTION
## Summary

- Fix `insurance_update` MCP tool passing all optional fields unconditionally to core, unlike every other update tool
- Apply the standard spread-conditional pattern (`...(field !== undefined ? { field } : {})`) to omit undefined values
- Add test verifying undefined optional fields are excluded from the request body

Fixes #396

## Test plan

- [x] Existing insurance MCP tool tests pass (8/8)
- [x] New test confirms only provided fields appear in request body
- [x] Full test suite passes (592 CLI + MCP tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)