### PR TITLE
(fix) pass --debug flag through to SCA verbose in 7 commands

### DIFF
--- a/packages/cli/src/commands/beneficiary/add.ts
+++ b/packages/cli/src/commands/beneficiary/add.ts
@@ -59,7 +59,7 @@ export function registerBeneficiaryAddCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/beneficiary/trust.ts
+++ b/packages/cli/src/commands/beneficiary/trust.ts
@@ -24,7 +24,7 @@ export function registerBeneficiaryTrustCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/untrust.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.ts
@@ -24,7 +24,7 @@ export function registerBeneficiaryUntrustCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/update.ts
+++ b/packages/cli/src/commands/beneficiary/update.ts
@@ -58,7 +58,7 @@ export function registerBeneficiaryUpdateCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-beneficiary/add.ts
+++ b/packages/cli/src/commands/intl-beneficiary/add.ts
@@ -65,7 +65,7 @@ export function registerIntlBeneficiaryAddCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-beneficiary/update.ts
+++ b/packages/cli/src/commands/intl-beneficiary/update.ts
@@ -56,7 +56,7 @@ export function registerIntlBeneficiaryUpdateCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-transfer/create.ts
+++ b/packages/cli/src/commands/intl-transfer/create.ts
@@ -62,7 +62,7 @@ export function registerIntlTransferCreateCommand(parent: Command): void {
           ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose },
+      { verbose: opts.verbose === true || opts.debug === true },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? transfer : [toTableRow(transfer)];


### PR DESCRIPTION
## Summary

- Fix 7 SCA commands that pass `{ verbose: opts.verbose }` instead of `{ verbose: opts.verbose === true || opts.debug === true }`, making `--debug` properly enable SCA verbose output

## Affected Commands

- `beneficiary add`, `beneficiary update`, `beneficiary trust`, `beneficiary untrust`
- `intl-beneficiary add`, `intl-beneficiary update`
- `intl-transfer create`

Closes #400

## Test plan

- [x] All 45 tests across 13 affected test files pass
- [x] Build succeeds
- [x] No remaining instances of `{ verbose: opts.verbose }` in CLI commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)