### PR TITLE
(fix) transfer_create MCP tool should return errors, not throw

### DIFF
--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -161,6 +161,42 @@ describe("transfer MCP tools", () => {
       });
     }
 
+    it("returns error when both beneficiary_id and beneficiary are provided", async () => {
+      const result = await mcpClient.callTool({
+        name: "transfer_create",
+        arguments: {
+          beneficiary_id: "ben-1",
+          beneficiary: { name: "Jane Doe", iban: "DE89370400440532013000" },
+          bank_account_id: "acc-1",
+          reference: "Test",
+          amount: 100,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as { type: string; text: string }[];
+      expect((content[0] as { type: string; text: string }).text).toBe(
+        "Cannot specify both beneficiary_id and beneficiary",
+      );
+    });
+
+    it("returns error when neither beneficiary_id nor beneficiary is provided", async () => {
+      const result = await mcpClient.callTool({
+        name: "transfer_create",
+        arguments: {
+          bank_account_id: "acc-1",
+          reference: "Test",
+          amount: 100,
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as { type: string; text: string }[];
+      expect((content[0] as { type: string; text: string }).text).toBe(
+        "Either beneficiary_id or beneficiary must be provided",
+      );
+    });
+
     it("uses provided vop_proof_token directly without auto-resolve", async () => {
       fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
         if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -118,10 +118,16 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
     async (args) =>
       withClient(getClient, async (client) => {
         if (args.beneficiary_id !== undefined && args.beneficiary !== undefined) {
-          throw new Error("Cannot specify both beneficiary_id and beneficiary");
+          return {
+            content: [{ type: "text" as const, text: "Cannot specify both beneficiary_id and beneficiary" }],
+            isError: true,
+          };
         }
         if (args.beneficiary_id === undefined && args.beneficiary === undefined) {
-          throw new Error("Either beneficiary_id or beneficiary must be provided");
+          return {
+            content: [{ type: "text" as const, text: "Either beneficiary_id or beneficiary must be provided" }],
+            isError: true,
+          };
         }
 
         let vopProofToken = args.vop_proof_token;
@@ -146,7 +152,10 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
         }
 
         if (vopProofToken === undefined) {
-          throw new Error("Could not resolve VoP proof token");
+          return {
+            content: [{ type: "text" as const, text: "Could not resolve VoP proof token" }],
+            isError: true,
+          };
         }
 
         const params: CreateTransferParams = {


### PR DESCRIPTION
## Summary

- Replace `throw new Error(...)` with `{ content, isError: true }` returns for three validation failures in `transfer_create` MCP tool: mutual exclusion check, missing beneficiary check, and unresolved VoP proof token
- Previously these threw raw `Error` instances caught by `withClient`'s generic handler, producing misleading "Unexpected error: ..." messages
- Now returns proper MCP protocol error responses matching the convention used by `textError()` in `errors.ts`

Closes #403

## Test plan

- [x] Added test: returns `isError: true` when both `beneficiary_id` and `beneficiary` are provided
- [x] Added test: returns `isError: true` when neither `beneficiary_id` nor `beneficiary` is provided
- [x] All existing transfer_create tests pass (VoP auto-resolve, inline beneficiary, attachments, etc.)
- [x] Full test suite passes (294 MCP tests, 592 CLI tests, 18 umbrella tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)