### PR TITLE
(fix) mock createClient in 6 CLI tests to prevent OAuth RangeError

### DIFF
--- a/packages/cli/src/commands/recurring-transfer/list.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/list.test.ts
@@ -4,6 +4,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
     current_page: 1,

--- a/packages/cli/src/commands/recurring-transfer/show.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/show.test.ts
@@ -4,6 +4,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 describe("recurring-transfer show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let writtenOutput: string[];

--- a/packages/cli/src/commands/transaction/list.test.ts
+++ b/packages/cli/src/commands/transaction/list.test.ts
@@ -5,6 +5,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createProgram } from "../../program.js";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
     current_page: 1,

--- a/packages/cli/src/commands/transaction/show.test.ts
+++ b/packages/cli/src/commands/transaction/show.test.ts
@@ -4,6 +4,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createProgram } from "../../program.js";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 function jsonResponse(body: unknown): Promise<Response> {
   return Promise.resolve(
     new Response(JSON.stringify(body), {

--- a/packages/cli/src/commands/transfer/list.test.ts
+++ b/packages/cli/src/commands/transfer/list.test.ts
@@ -5,6 +5,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { registerTransferCommands } from "./index.js";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
     current_page: 1,

--- a/packages/cli/src/commands/transfer/show.test.ts
+++ b/packages/cli/src/commands/transfer/show.test.ts
@@ -5,6 +5,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { registerTransferCommands } from "./index.js";
 
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
 describe("transfer show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let writtenOutput: string[];


### PR DESCRIPTION
## Summary

- Add `vi.mock("../../client.js")` to 6 CLI test files that were missing it, causing `RangeError: Invalid time value` in the OAuth authorization factory
- The mock returns a real `HttpClient` with simple API key auth so `fetchSpy` interception still works for verifying API calls

**Affected files:**
- `packages/cli/src/commands/transaction/list.test.ts`
- `packages/cli/src/commands/transaction/show.test.ts`
- `packages/cli/src/commands/transfer/list.test.ts`
- `packages/cli/src/commands/transfer/show.test.ts`
- `packages/cli/src/commands/recurring-transfer/list.test.ts`
- `packages/cli/src/commands/recurring-transfer/show.test.ts`

Closes #394

## Test plan

- [x] All 29 previously-failing tests now pass
- [x] Full CLI test suite passes (592 tests, 77 files)
- [x] Full MCP test suite passes (292 tests, 31 files)
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)