### PR TITLE
(fix) wrap JSON.parse in CLI commands with user-friendly errors

### DIFF
--- a/packages/cli/src/commands/bulk-transfer/create.ts
+++ b/packages/cli/src/commands/bulk-transfer/create.ts
@@ -9,6 +9,7 @@ import { createClient } from "../../client.js";
 import { formatOutput } from "../../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions, WriteOptions } from "../../options.js";
+import { parseJson } from "../../parse-json.js";
 import { executeWithCliSca } from "../../sca.js";
 
 interface BulkTransferCreateOptions extends GlobalOptions, WriteOptions {
@@ -38,7 +39,7 @@ export function registerBulkTransferCreateCommand(parent: Command): void {
     const httpClient = await createClient(opts);
 
     const fileContent = await readFile(opts.file, "utf-8");
-    const transfers = JSON.parse(fileContent) as readonly BulkTransferItem[];
+    const transfers = parseJson(fileContent, `--file ${opts.file}`) as readonly BulkTransferItem[];
 
     const bulkTransfer = await executeWithCliSca(
       httpClient,

--- a/packages/cli/src/commands/card/create.ts
+++ b/packages/cli/src/commands/card/create.ts
@@ -9,6 +9,7 @@ import { createClient } from "../../client.js";
 import { formatOutput } from "../../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions, WriteOptions } from "../../options.js";
+import { parseJson } from "../../parse-json.js";
 import { executeWithCliSca } from "../../sca.js";
 
 interface CardCreateOptions extends GlobalOptions, WriteOptions {
@@ -151,7 +152,7 @@ export function registerCardBulkCreateCommand(parent: Command): void {
     const client = await createClient(opts);
 
     const content = await readFile(opts.file, "utf-8");
-    const cards = JSON.parse(content) as CreateCardParams[];
+    const cards = parseJson(content, `--file ${opts.file}`) as CreateCardParams[];
 
     const { bulkCreateCards } = await import("@qontoctl/core");
 

--- a/packages/cli/src/commands/client-invoice.ts
+++ b/packages/cli/src/commands/client-invoice.ts
@@ -23,6 +23,7 @@ import { fetchPaginated } from "../pagination.js";
 import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, PaginationOptions, WriteOptions } from "../options.js";
+import { parseJson } from "../parse-json.js";
 
 interface ClientInvoiceListOptions extends GlobalOptions, PaginationOptions {
   readonly status?: string | undefined;
@@ -159,7 +160,7 @@ export function createClientInvoiceCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const inv = await createClientInvoice(
       client,
       body,
@@ -182,7 +183,7 @@ export function createClientInvoiceCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const inv = await updateClientInvoice(
       client,
       id,

--- a/packages/cli/src/commands/payment-link.ts
+++ b/packages/cli/src/commands/payment-link.ts
@@ -8,6 +8,7 @@ import { fetchPaginated } from "../pagination.js";
 import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, PaginationOptions, WriteOptions } from "../options.js";
+import { parseJson } from "../parse-json.js";
 
 interface PaymentLinkListOptions extends GlobalOptions, PaginationOptions {
   readonly status?: string | undefined;
@@ -114,7 +115,7 @@ export function createPaymentLinkCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const response = await client.post<{ payment_link: PaymentLink }>(
       "/v2/payment_links",
       body,
@@ -210,7 +211,7 @@ export function createPaymentLinkCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const response = await client.post<{
       connection_location: string;
       status: string;

--- a/packages/cli/src/commands/quote.ts
+++ b/packages/cli/src/commands/quote.ts
@@ -8,6 +8,7 @@ import { fetchPaginated } from "../pagination.js";
 import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, PaginationOptions, WriteOptions } from "../options.js";
+import { parseJson } from "../parse-json.js";
 
 interface QuoteListOptions extends GlobalOptions, PaginationOptions {
   readonly status?: string | undefined;
@@ -107,7 +108,7 @@ export function createQuoteCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const response = await client.post<{ quote: Quote }>(
       "/v2/quotes",
       body,
@@ -131,7 +132,7 @@ export function createQuoteCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { body: string }>(cmd);
     const client = await createClient(opts);
 
-    const body: unknown = JSON.parse(opts.body);
+    const body: unknown = parseJson(opts.body, "--body");
     const response = await client.patch<{ quote: Quote }>(
       `/v2/quotes/${encodeURIComponent(id)}`,
       body,

--- a/packages/cli/src/commands/request/create-multi-transfer.ts
+++ b/packages/cli/src/commands/request/create-multi-transfer.ts
@@ -14,6 +14,7 @@ import { createClient } from "../../client.js";
 import { formatOutput } from "../../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions, WriteOptions } from "../../options.js";
+import { parseJson } from "../../parse-json.js";
 import { executeWithCliSca } from "../../sca.js";
 
 interface CreateMultiTransferOptions extends GlobalOptions, WriteOptions {
@@ -49,7 +50,7 @@ export function registerRequestCreateMultiTransferCommand(parent: Command): void
     const httpClient = await createClient(opts);
 
     const fileContent = await readFile(opts.file, "utf-8");
-    const transfers = JSON.parse(fileContent) as readonly MultiTransferItem[];
+    const transfers = parseJson(fileContent, `--file ${opts.file}`) as readonly MultiTransferItem[];
 
     const params: CreateMultiTransferRequestParams = {
       note: opts.note,

--- a/packages/cli/src/parse-json.test.ts
+++ b/packages/cli/src/parse-json.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { parseJson } from "./parse-json.js";
+
+describe("parseJson", () => {
+  it("parses valid JSON", () => {
+    expect(parseJson('{"key":"value"}', "--body")).toEqual({ key: "value" });
+  });
+
+  it("parses valid JSON array", () => {
+    expect(parseJson("[1,2,3]", "--body")).toEqual([1, 2, 3]);
+  });
+
+  it("throws user-friendly error for malformed JSON", () => {
+    expect(() => parseJson("{invalid}", "--body")).toThrow("Invalid JSON for --body");
+  });
+
+  it("includes SyntaxError detail in error message", () => {
+    try {
+      parseJson("{invalid}", "--body");
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/^Invalid JSON for --body: /);
+    }
+  });
+
+  it("includes the context label in error message", () => {
+    expect(() => parseJson("not-json", "--file data.json")).toThrow("Invalid JSON for --file data.json");
+  });
+
+  it("parses null, numbers, and strings", () => {
+    expect(parseJson("null", "--body")).toBeNull();
+    expect(parseJson("42", "--body")).toBe(42);
+    expect(parseJson('"hello"', "--body")).toBe("hello");
+  });
+});

--- a/packages/cli/src/parse-json.ts
+++ b/packages/cli/src/parse-json.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Parses a JSON string, throwing a user-friendly error on failure.
+ *
+ * @param input - The raw JSON string to parse
+ * @param context - A label for the option or source (e.g. "--body", "--file path.json")
+ * @returns The parsed value
+ */
+export function parseJson(input: string, context: string): unknown {
+  try {
+    return JSON.parse(input);
+  } catch (error) {
+    const detail = error instanceof SyntaxError ? `: ${error.message}` : "";
+    throw new Error(`Invalid JSON for ${context}${detail}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add shared `parseJson(input, context)` utility in `packages/cli/src/parse-json.ts` that wraps `JSON.parse` and produces user-friendly error messages instead of raw `SyntaxError` stack traces
- Replace all 9 raw `JSON.parse` calls across 6 CLI command files with the new utility
- Add unit tests for the `parseJson` utility (6 test cases)

**Affected commands**: `quote create/update`, `client-invoice create/update`, `payment-link create/connect`, `card bulk-create`, `bulk-transfer create`, `request create-multi-transfer`

Closes #402

## Test plan

- [x] All 598 existing unit tests pass
- [x] 6 new `parseJson` tests pass (valid JSON, malformed JSON, context labels, primitives)
- [x] Build passes across all packages
- [x] Lint and prettier checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)