### PR TITLE
(chore) standardize Zod schema strictness strategy across domains

### DIFF
--- a/packages/core/src/attachments/schemas.ts
+++ b/packages/core/src/attachments/schemas.ts
@@ -7,11 +7,13 @@ import type { Attachment } from "./types.js";
 /**
  * Zod schema for an attachment returned by the Qonto API.
  */
-export const AttachmentSchema = z.object({
-  id: z.string(),
-  file_name: z.string(),
-  file_size: z.coerce.string(),
-  file_content_type: z.string(),
-  url: z.string(),
-  created_at: z.string(),
-}) satisfies z.ZodType<Attachment>;
+export const AttachmentSchema = z
+  .object({
+    id: z.string(),
+    file_name: z.string(),
+    file_size: z.coerce.string(),
+    file_content_type: z.string(),
+    url: z.string(),
+    created_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<Attachment>;

--- a/packages/core/src/beneficiaries/schemas.ts
+++ b/packages/core/src/beneficiaries/schemas.ts
@@ -8,24 +8,30 @@ import type { Beneficiary } from "../types/beneficiary.js";
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/beneficiaries/sepa-beneficiaries/show
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/beneficiaries/sepa-beneficiaries/index
-export const BeneficiarySchema = z.object({
-  id: z.string(),
-  name: z.string(),
-  iban: z.string(),
-  bic: z.string(),
-  email: z.nullable(z.string()).optional().default(null),
-  activity_tag: z.nullable(z.string()).optional().default(null),
-  status: z.enum(["pending", "validated", "declined"]),
-  trusted: z.boolean(),
-  created_at: z.string(),
-  updated_at: z.string(),
-}) satisfies z.ZodType<Beneficiary>;
+export const BeneficiarySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    iban: z.string(),
+    bic: z.string(),
+    email: z.nullable(z.string()).optional().default(null),
+    activity_tag: z.nullable(z.string()).optional().default(null),
+    status: z.enum(["pending", "validated", "declined"]),
+    trusted: z.boolean(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<Beneficiary>;
 
-export const BeneficiaryResponseSchema = z.object({
-  beneficiary: BeneficiarySchema,
-});
+export const BeneficiaryResponseSchema = z
+  .object({
+    beneficiary: BeneficiarySchema,
+  })
+  .strip();
 
-export const BeneficiaryListResponseSchema = z.object({
-  beneficiaries: z.array(BeneficiarySchema),
-  meta: PaginationMetaSchema,
-});
+export const BeneficiaryListResponseSchema = z
+  .object({
+    beneficiaries: z.array(BeneficiarySchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/bulk-transfers/schemas.ts
+++ b/packages/core/src/bulk-transfers/schemas.ts
@@ -45,11 +45,15 @@ export const BulkTransferSchema = z
   })
   .strip() satisfies z.ZodType<BulkTransfer>;
 
-export const BulkTransferResponseSchema = z.object({
-  bulk_transfer: BulkTransferSchema,
-});
+export const BulkTransferResponseSchema = z
+  .object({
+    bulk_transfer: BulkTransferSchema,
+  })
+  .strip();
 
-export const BulkTransferListResponseSchema = z.object({
-  bulk_transfers: z.array(BulkTransferSchema),
-  meta: PaginationMetaSchema,
-});
+export const BulkTransferListResponseSchema = z
+  .object({
+    bulk_transfers: z.array(BulkTransferSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/cards/schemas.ts
+++ b/packages/core/src/cards/schemas.ts
@@ -8,134 +8,150 @@ import { PaginationMetaSchema } from "../api-types.schema.js";
 /**
  * Visual appearance details for a card.
  */
-export const CardAppearanceSchema = z.object({
-  assets: z.object({
-    front_large: z.string(),
-    front_small: z.string(),
-    front_small_wallet: z.string(),
-  }),
-  theme: z.enum(["dark", "light"]),
-  gradient_hex_color: z.string(),
-});
+export const CardAppearanceSchema = z
+  .object({
+    assets: z.object({
+      front_large: z.string(),
+      front_small: z.string(),
+      front_small_wallet: z.string(),
+    }),
+    theme: z.enum(["dark", "light"]),
+    gradient_hex_color: z.string(),
+  })
+  .strip();
 
 /**
  * Summary of the original card when this card is a renewal.
  */
-export const ParentCardSummarySchema = z.object({
-  id: z.string(),
-  last_digits: z.string(),
-});
+export const ParentCardSummarySchema = z
+  .object({
+    id: z.string(),
+    last_digits: z.string(),
+  })
+  .strip();
 
 /**
  * A Qonto card — physical, virtual, flash, or advertising.
  */
-export const CardSchema = z.object({
-  id: z.string(),
-  nickname: z.string(),
-  embossed_name: z.string().nullable(),
-  status: z.enum([
-    "pending",
-    "live",
-    "paused",
-    "stolen",
-    "lost",
-    "pin_blocked",
-    "discarded",
-    "expired",
-    "shipped_lost",
-    "onhold",
-    "order_canceled",
-    "pre_expired",
-    "abusive",
-  ]),
-  pin_set: z.boolean(),
-  mask_pan: z.string().nullable(),
-  exp_month: z.string().nullable(),
-  exp_year: z.string().nullable(),
-  last_activity_at: z.string(),
-  last_digits: z.string().nullable(),
-  ship_to_business: z.boolean(),
-  atm_option: z.boolean(),
-  nfc_option: z.boolean(),
-  online_option: z.boolean(),
-  foreign_option: z.boolean(),
-  atm_monthly_limit: z.number(),
-  atm_monthly_spent: z.number(),
-  atm_daily_limit: z.number(),
-  atm_daily_spent: z.number(),
-  atm_daily_limit_option: z.boolean(),
-  payment_monthly_limit: z.number(),
-  payment_monthly_spent: z.number(),
-  payment_daily_limit: z.number(),
-  payment_daily_spent: z.number(),
-  payment_daily_limit_option: z.boolean(),
-  payment_transaction_limit: z.number(),
-  payment_transaction_limit_option: z.boolean(),
-  active_days: z.array(z.number()),
-  holder_id: z.string(),
-  initiator_id: z.string(),
-  bank_account_id: z.string(),
-  organization_id: z.string(),
-  updated_at: z.string(),
-  created_at: z.string(),
-  shipped_at: z.string().nullable(),
-  card_type: z.enum(["debit", "prepaid"]),
-  card_level: z.enum(["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"]),
-  payment_lifespan_limit: z.number(),
-  payment_lifespan_spent: z.number(),
-  pre_expires_at: z.string().nullable(),
-  categories: z.array(z.string()),
-  renewed: z.boolean(),
-  renewal: z.boolean(),
-  parent_card_summary: ParentCardSummarySchema.nullable(),
-  had_operation: z.boolean(),
-  had_pin_operation: z.boolean(),
-  card_design: z.string(),
-  type_of_print: z.enum(["print", "embossed"]).nullable(),
-  upsold: z.boolean(),
-  upsell: z.boolean(),
-  discard_on: z.string().nullable(),
-  reordered: z.boolean(),
-  appearance: CardAppearanceSchema,
-  has_only_user_liftable_locks: z.boolean(),
-});
+export const CardSchema = z
+  .object({
+    id: z.string(),
+    nickname: z.string(),
+    embossed_name: z.string().nullable(),
+    status: z.enum([
+      "pending",
+      "live",
+      "paused",
+      "stolen",
+      "lost",
+      "pin_blocked",
+      "discarded",
+      "expired",
+      "shipped_lost",
+      "onhold",
+      "order_canceled",
+      "pre_expired",
+      "abusive",
+    ]),
+    pin_set: z.boolean(),
+    mask_pan: z.string().nullable(),
+    exp_month: z.string().nullable(),
+    exp_year: z.string().nullable(),
+    last_activity_at: z.string(),
+    last_digits: z.string().nullable(),
+    ship_to_business: z.boolean(),
+    atm_option: z.boolean(),
+    nfc_option: z.boolean(),
+    online_option: z.boolean(),
+    foreign_option: z.boolean(),
+    atm_monthly_limit: z.number(),
+    atm_monthly_spent: z.number(),
+    atm_daily_limit: z.number(),
+    atm_daily_spent: z.number(),
+    atm_daily_limit_option: z.boolean(),
+    payment_monthly_limit: z.number(),
+    payment_monthly_spent: z.number(),
+    payment_daily_limit: z.number(),
+    payment_daily_spent: z.number(),
+    payment_daily_limit_option: z.boolean(),
+    payment_transaction_limit: z.number(),
+    payment_transaction_limit_option: z.boolean(),
+    active_days: z.array(z.number()),
+    holder_id: z.string(),
+    initiator_id: z.string(),
+    bank_account_id: z.string(),
+    organization_id: z.string(),
+    updated_at: z.string(),
+    created_at: z.string(),
+    shipped_at: z.string().nullable(),
+    card_type: z.enum(["debit", "prepaid"]),
+    card_level: z.enum(["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"]),
+    payment_lifespan_limit: z.number(),
+    payment_lifespan_spent: z.number(),
+    pre_expires_at: z.string().nullable(),
+    categories: z.array(z.string()),
+    renewed: z.boolean(),
+    renewal: z.boolean(),
+    parent_card_summary: ParentCardSummarySchema.nullable(),
+    had_operation: z.boolean(),
+    had_pin_operation: z.boolean(),
+    card_design: z.string(),
+    type_of_print: z.enum(["print", "embossed"]).nullable(),
+    upsold: z.boolean(),
+    upsell: z.boolean(),
+    discard_on: z.string().nullable(),
+    reordered: z.boolean(),
+    appearance: CardAppearanceSchema,
+    has_only_user_liftable_locks: z.boolean(),
+  })
+  .strip();
 
-export const CardResponseSchema = z.object({
-  card: CardSchema,
-});
+export const CardResponseSchema = z
+  .object({
+    card: CardSchema,
+  })
+  .strip();
 
-export const CardListResponseSchema = z.object({
-  cards: z.array(CardSchema),
-  meta: PaginationMetaSchema,
-});
+export const CardListResponseSchema = z
+  .object({
+    cards: z.array(CardSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 /**
  * Appearance data for a specific card level.
  */
-export const CardLevelAppearanceSchema = z.object({
-  design: z.string(),
-  assets: z.object({
-    front_large: z.string(),
-    front_small: z.string(),
-    front_small_wallet: z.string(),
-  }),
-  theme: z.enum(["dark", "light"]),
-  gradient_hex_color: z.string(),
-  is_active: z.boolean(),
-});
+export const CardLevelAppearanceSchema = z
+  .object({
+    design: z.string(),
+    assets: z.object({
+      front_large: z.string(),
+      front_small: z.string(),
+      front_small_wallet: z.string(),
+    }),
+    theme: z.enum(["dark", "light"]),
+    gradient_hex_color: z.string(),
+    is_active: z.boolean(),
+  })
+  .strip();
 
 /**
  * Card appearances grouped by card level.
  */
-export const CardLevelAppearancesSchema = z.object({
-  card_level: z.string(),
-  appearances: z.array(CardLevelAppearanceSchema),
-});
+export const CardLevelAppearancesSchema = z
+  .object({
+    card_level: z.string(),
+    appearances: z.array(CardLevelAppearanceSchema),
+  })
+  .strip();
 
 /**
  * Card appearances grouped by card type.
  */
-export const CardTypeAppearancesSchema = z.object({
-  card_type: z.string(),
-  card_level_appearances: z.array(CardLevelAppearancesSchema),
-});
+export const CardTypeAppearancesSchema = z
+  .object({
+    card_type: z.string(),
+    card_level_appearances: z.array(CardLevelAppearancesSchema),
+  })
+  .strip();

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -14,103 +14,121 @@ import type {
   ClientInvoiceUpload,
 } from "./types.js";
 
-export const ClientInvoiceAmountSchema = z.object({
-  value: z.string(),
-  currency: z.string(),
-}) satisfies z.ZodType<ClientInvoiceAmount>;
+export const ClientInvoiceAmountSchema = z
+  .object({
+    value: z.string(),
+    currency: z.string(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceAmount>;
 
-export const ClientInvoiceDiscountSchema = z.object({
-  type: z.enum(["percentage", "amount"]),
-  value: z.string(),
-  amount: ClientInvoiceAmountSchema,
-  amount_cents: z.number(),
-}) satisfies z.ZodType<ClientInvoiceDiscount>;
+export const ClientInvoiceDiscountSchema = z
+  .object({
+    type: z.enum(["percentage", "amount"]),
+    value: z.string(),
+    amount: ClientInvoiceAmountSchema,
+    amount_cents: z.number(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceDiscount>;
 
-export const ClientInvoiceItemSchema = z.object({
-  title: z.string(),
-  description: z.string().nullable(),
-  quantity: z.string(),
-  unit: z.string().nullable().optional(),
-  vat_rate: z.string(),
-  vat_exemption_reason: z.string().nullable().optional(),
-  unit_price: ClientInvoiceAmountSchema,
-  unit_price_cents: z.number(),
-  total_amount: ClientInvoiceAmountSchema,
-  total_amount_cents: z.number(),
-  total_vat: ClientInvoiceAmountSchema,
-  total_vat_cents: z.number(),
-  subtotal: ClientInvoiceAmountSchema,
-  subtotal_cents: z.number(),
-  discount: ClientInvoiceDiscountSchema.nullable().optional(),
-}) satisfies z.ZodType<ClientInvoiceItem>;
+export const ClientInvoiceItemSchema = z
+  .object({
+    title: z.string(),
+    description: z.string().nullable(),
+    quantity: z.string(),
+    unit: z.string().nullable().optional(),
+    vat_rate: z.string(),
+    vat_exemption_reason: z.string().nullable().optional(),
+    unit_price: ClientInvoiceAmountSchema,
+    unit_price_cents: z.number(),
+    total_amount: ClientInvoiceAmountSchema,
+    total_amount_cents: z.number(),
+    total_vat: ClientInvoiceAmountSchema,
+    total_vat_cents: z.number(),
+    subtotal: ClientInvoiceAmountSchema,
+    subtotal_cents: z.number(),
+    discount: ClientInvoiceDiscountSchema.nullable().optional(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceItem>;
 
-export const ClientInvoiceAddressSchema = z.object({
-  street_address: z.string().nullable(),
-  city: z.string().nullable(),
-  zip_code: z.string().nullable(),
-  province_code: z.string().nullable().optional(),
-  country_code: z.string().nullable(),
-}) satisfies z.ZodType<ClientInvoiceAddress>;
+export const ClientInvoiceAddressSchema = z
+  .object({
+    street_address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable().optional(),
+    country_code: z.string().nullable(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceAddress>;
 
-export const ClientInvoiceClientSchema = z.object({
-  id: z.string(),
-  type: z.enum(["individual", "company", "freelancer"]),
-  name: z.string().nullable(),
-  first_name: z.string().nullable(),
-  last_name: z.string().nullable(),
-  email: z.string().nullable(),
-  vat_number: z.string().nullable(),
-  tax_identification_number: z.string().nullable(),
-  address: z.string().nullable(),
-  city: z.string().nullable(),
-  zip_code: z.string().nullable(),
-  province_code: z.string().nullable().optional(),
-  country_code: z.string().nullable(),
-  recipient_code: z.string().nullable().optional(),
-  locale: z.string().nullable(),
-  billing_address: ClientInvoiceAddressSchema.nullable(),
-  delivery_address: ClientInvoiceAddressSchema.nullable().optional(),
-}) satisfies z.ZodType<ClientInvoiceClient>;
+export const ClientInvoiceClientSchema = z
+  .object({
+    id: z.string(),
+    type: z.enum(["individual", "company", "freelancer"]),
+    name: z.string().nullable(),
+    first_name: z.string().nullable(),
+    last_name: z.string().nullable(),
+    email: z.string().nullable(),
+    vat_number: z.string().nullable(),
+    tax_identification_number: z.string().nullable(),
+    address: z.string().nullable(),
+    city: z.string().nullable(),
+    zip_code: z.string().nullable(),
+    province_code: z.string().nullable().optional(),
+    country_code: z.string().nullable(),
+    recipient_code: z.string().nullable().optional(),
+    locale: z.string().nullable(),
+    billing_address: ClientInvoiceAddressSchema.nullable(),
+    delivery_address: ClientInvoiceAddressSchema.nullable().optional(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceClient>;
 
-export const ClientInvoiceUploadSchema = z.object({
-  id: z.string(),
-  file_name: z.string(),
-  file_size: z.number(),
-  file_content_type: z.string(),
-  url: z.string(),
-  created_at: z.string(),
-}) satisfies z.ZodType<ClientInvoiceUpload>;
+export const ClientInvoiceUploadSchema = z
+  .object({
+    id: z.string(),
+    file_name: z.string(),
+    file_size: z.number(),
+    file_content_type: z.string(),
+    url: z.string(),
+    created_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<ClientInvoiceUpload>;
 
-export const ClientInvoiceSchema = z.object({
-  id: z.string(),
-  organization_id: z.string(),
-  invoice_number: z.string().nullable().optional(),
-  status: z.string(),
-  client_id: z.string().optional(),
-  currency: z.string(),
-  total_amount: ClientInvoiceAmountSchema,
-  total_amount_cents: z.number(),
-  vat_amount: ClientInvoiceAmountSchema,
-  vat_amount_cents: z.number(),
-  issue_date: z.string().nullable(),
-  due_date: z.string().nullable(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  attachment_id: z.string().nullable(),
-  contact_email: z.string().nullable(),
-  terms_and_conditions: z.string().nullable(),
-  header: z.string().nullable(),
-  footer: z.string().nullable(),
-  discount: ClientInvoiceDiscountSchema.nullable().optional(),
-  items: z.array(ClientInvoiceItemSchema),
-  client: ClientInvoiceClientSchema,
-}) satisfies z.ZodType<ClientInvoice>;
+export const ClientInvoiceSchema = z
+  .object({
+    id: z.string(),
+    organization_id: z.string(),
+    invoice_number: z.string().nullable().optional(),
+    status: z.string(),
+    client_id: z.string().optional(),
+    currency: z.string(),
+    total_amount: ClientInvoiceAmountSchema,
+    total_amount_cents: z.number(),
+    vat_amount: ClientInvoiceAmountSchema,
+    vat_amount_cents: z.number(),
+    issue_date: z.string().nullable(),
+    due_date: z.string().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    attachment_id: z.string().nullable(),
+    contact_email: z.string().nullable(),
+    terms_and_conditions: z.string().nullable(),
+    header: z.string().nullable(),
+    footer: z.string().nullable(),
+    discount: ClientInvoiceDiscountSchema.nullable().optional(),
+    items: z.array(ClientInvoiceItemSchema),
+    client: ClientInvoiceClientSchema,
+  })
+  .strip() satisfies z.ZodType<ClientInvoice>;
 
-export const ClientInvoiceResponseSchema = z.object({
-  client_invoice: ClientInvoiceSchema,
-});
+export const ClientInvoiceResponseSchema = z
+  .object({
+    client_invoice: ClientInvoiceSchema,
+  })
+  .strip();
 
-export const ClientInvoiceListResponseSchema = z.object({
-  client_invoices: z.array(ClientInvoiceSchema),
-  meta: PaginationMetaSchema,
-});
+export const ClientInvoiceListResponseSchema = z
+  .object({
+    client_invoices: z.array(ClientInvoiceSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/insurance-contracts/schemas.ts
+++ b/packages/core/src/insurance-contracts/schemas.ts
@@ -4,31 +4,39 @@
 import { z } from "zod";
 import type { InsuranceContract, InsuranceDocument } from "./types.js";
 
-export const InsuranceDocumentSchema = z.object({
-  id: z.string(),
-  file_name: z.string(),
-  file_size: z.coerce.string(),
-  file_content_type: z.string(),
-  url: z.string(),
-  created_at: z.string(),
-}) satisfies z.ZodType<InsuranceDocument>;
+export const InsuranceDocumentSchema = z
+  .object({
+    id: z.string(),
+    file_name: z.string(),
+    file_size: z.coerce.string(),
+    file_content_type: z.string(),
+    url: z.string(),
+    created_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<InsuranceDocument>;
 
-export const InsuranceContractSchema = z.object({
-  id: z.string(),
-  insurance_type: z.string(),
-  status: z.string(),
-  provider_name: z.string(),
-  contract_number: z.string().nullable(),
-  start_date: z.string(),
-  end_date: z.string().nullable(),
-  created_at: z.string(),
-  updated_at: z.string(),
-}) satisfies z.ZodType<InsuranceContract>;
+export const InsuranceContractSchema = z
+  .object({
+    id: z.string(),
+    insurance_type: z.string(),
+    status: z.string(),
+    provider_name: z.string(),
+    contract_number: z.string().nullable(),
+    start_date: z.string(),
+    end_date: z.string().nullable(),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<InsuranceContract>;
 
-export const InsuranceContractResponseSchema = z.object({
-  insurance_contract: InsuranceContractSchema,
-});
+export const InsuranceContractResponseSchema = z
+  .object({
+    insurance_contract: InsuranceContractSchema,
+  })
+  .strip();
 
-export const InsuranceDocumentResponseSchema = z.object({
-  insurance_document: InsuranceDocumentSchema,
-});
+export const InsuranceDocumentResponseSchema = z
+  .object({
+    insurance_document: InsuranceDocumentSchema,
+  })
+  .strip();

--- a/packages/core/src/internal-transfers/schemas.ts
+++ b/packages/core/src/internal-transfers/schemas.ts
@@ -5,20 +5,24 @@ import { z } from "zod";
 
 import type { InternalTransfer } from "./types.js";
 
-export const InternalTransferSchema = z.object({
-  id: z.string(),
-  debit_iban: z.string(),
-  credit_iban: z.string(),
-  debit_bank_account_id: z.string(),
-  credit_bank_account_id: z.string(),
-  reference: z.string(),
-  amount: z.number(),
-  amount_cents: z.number(),
-  currency: z.string(),
-  status: z.string(),
-  created_at: z.string(),
-}) satisfies z.ZodType<InternalTransfer>;
+export const InternalTransferSchema = z
+  .object({
+    id: z.string(),
+    debit_iban: z.string(),
+    credit_iban: z.string(),
+    debit_bank_account_id: z.string(),
+    credit_bank_account_id: z.string(),
+    reference: z.string(),
+    amount: z.number(),
+    amount_cents: z.number(),
+    currency: z.string(),
+    status: z.string(),
+    created_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<InternalTransfer>;
 
-export const InternalTransferResponseSchema = z.object({
-  internal_transfer: InternalTransferSchema,
-});
+export const InternalTransferResponseSchema = z
+  .object({
+    internal_transfer: InternalTransferSchema,
+  })
+  .strip();

--- a/packages/core/src/international-beneficiaries/schemas.ts
+++ b/packages/core/src/international-beneficiaries/schemas.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import { PaginationMetaSchema } from "../api-types.schema.js";
 import type { IntlBeneficiary, IntlBeneficiaryRequirementField, IntlBeneficiaryRequirements } from "./types.js";
 
+// International beneficiary schemas use .loose() to pass through unknown fields.
+// These endpoints are less stable and may return additional undocumented properties.
 export const IntlBeneficiarySchema = z
   .object({
     id: z.string(),
@@ -17,14 +19,18 @@ export const IntlBeneficiarySchema = z
   })
   .loose() satisfies z.ZodType<IntlBeneficiary>;
 
-export const IntlBeneficiaryResponseSchema = z.object({
-  international_beneficiary: IntlBeneficiarySchema,
-});
+export const IntlBeneficiaryResponseSchema = z
+  .object({
+    international_beneficiary: IntlBeneficiarySchema,
+  })
+  .strip();
 
-export const IntlBeneficiaryListResponseSchema = z.object({
-  international_beneficiaries: z.array(IntlBeneficiarySchema),
-  meta: PaginationMetaSchema,
-});
+export const IntlBeneficiaryListResponseSchema = z
+  .object({
+    international_beneficiaries: z.array(IntlBeneficiarySchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 export const IntlBeneficiaryRequirementFieldSchema = z
   .object({
@@ -44,6 +50,8 @@ export const IntlBeneficiaryRequirementsSchema = z
   })
   .loose() satisfies z.ZodType<IntlBeneficiaryRequirements>;
 
-export const IntlBeneficiaryRequirementsResponseSchema = z.object({
-  requirements: IntlBeneficiaryRequirementsSchema,
-});
+export const IntlBeneficiaryRequirementsResponseSchema = z
+  .object({
+    requirements: IntlBeneficiaryRequirementsSchema,
+  })
+  .strip();

--- a/packages/core/src/international-transfers/schemas.ts
+++ b/packages/core/src/international-transfers/schemas.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 
 import type { IntlTransfer, IntlTransferRequirementField, IntlTransferRequirements } from "./types.js";
 
+// International transfer schemas use .loose() to pass through unknown fields.
+// These endpoints are less stable and may return additional undocumented properties.
 export const IntlTransferRequirementFieldSchema = z
   .object({
     key: z.string(),
@@ -23,9 +25,11 @@ export const IntlTransferRequirementsSchema = z
   })
   .loose() satisfies z.ZodType<IntlTransferRequirements>;
 
-export const IntlTransferRequirementsResponseSchema = z.object({
-  requirements: IntlTransferRequirementsSchema,
-});
+export const IntlTransferRequirementsResponseSchema = z
+  .object({
+    requirements: IntlTransferRequirementsSchema,
+  })
+  .strip();
 
 export const IntlTransferSchema = z
   .object({
@@ -33,6 +37,8 @@ export const IntlTransferSchema = z
   })
   .loose() satisfies z.ZodType<IntlTransfer>;
 
-export const IntlTransferResponseSchema = z.object({
-  international_transfer: IntlTransferSchema,
-});
+export const IntlTransferResponseSchema = z
+  .object({
+    international_transfer: IntlTransferSchema,
+  })
+  .strip();

--- a/packages/core/src/international/schemas.ts
+++ b/packages/core/src/international/schemas.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 
 import type { IntlCurrency, IntlEligibility, IntlQuote } from "./types.js";
 
+// International API schemas use .loose() to pass through unknown fields.
+// These endpoints are less stable and may return additional undocumented properties.
 export const IntlEligibilitySchema = z
   .object({
     eligible: z.boolean(),
@@ -12,9 +14,11 @@ export const IntlEligibilitySchema = z
   })
   .loose() satisfies z.ZodType<IntlEligibility>;
 
-export const IntlEligibilityResponseSchema = z.object({
-  eligibility: IntlEligibilitySchema,
-});
+export const IntlEligibilityResponseSchema = z
+  .object({
+    eligibility: IntlEligibilitySchema,
+  })
+  .strip();
 
 export const IntlCurrencySchema = z
   .object({
@@ -25,9 +29,11 @@ export const IntlCurrencySchema = z
   })
   .loose() satisfies z.ZodType<IntlCurrency>;
 
-export const IntlCurrencyListResponseSchema = z.object({
-  currencies: z.array(IntlCurrencySchema),
-});
+export const IntlCurrencyListResponseSchema = z
+  .object({
+    currencies: z.array(IntlCurrencySchema),
+  })
+  .strip();
 
 export const IntlQuoteSchema = z
   .object({
@@ -43,6 +49,8 @@ export const IntlQuoteSchema = z
   })
   .loose() satisfies z.ZodType<IntlQuote>;
 
-export const IntlQuoteResponseSchema = z.object({
-  quote: IntlQuoteSchema,
-});
+export const IntlQuoteResponseSchema = z
+  .object({
+    quote: IntlQuoteSchema,
+  })
+  .strip();

--- a/packages/core/src/recurring-transfers/schemas.ts
+++ b/packages/core/src/recurring-transfers/schemas.ts
@@ -30,11 +30,15 @@ export const RecurringTransferSchema = z
   })
   .strip() satisfies z.ZodType<RecurringTransfer>;
 
-export const RecurringTransferResponseSchema = z.object({
-  recurring_transfer: RecurringTransferSchema,
-});
+export const RecurringTransferResponseSchema = z
+  .object({
+    recurring_transfer: RecurringTransferSchema,
+  })
+  .strip();
 
-export const RecurringTransferListResponseSchema = z.object({
-  recurring_transfers: z.array(RecurringTransferSchema),
-  meta: PaginationMetaSchema,
-});
+export const RecurringTransferListResponseSchema = z
+  .object({
+    recurring_transfers: z.array(RecurringTransferSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/requests/service.ts
+++ b/packages/core/src/requests/service.ts
@@ -19,9 +19,9 @@ import type {
   RequestType,
 } from "./types.js";
 
-const FlashCardResponseSchema = z.object({ request_flash_card: RequestFlashCardSchema });
-const VirtualCardResponseSchema = z.object({ request_virtual_card: RequestVirtualCardSchema });
-const MultiTransferResponseSchema = z.object({ request_multi_transfer: RequestMultiTransferSchema });
+const FlashCardResponseSchema = z.object({ request_flash_card: RequestFlashCardSchema }).strip();
+const VirtualCardResponseSchema = z.object({ request_virtual_card: RequestVirtualCardSchema }).strip();
+const MultiTransferResponseSchema = z.object({ request_multi_transfer: RequestMultiTransferSchema }).strip();
 
 /**
  * Maps request type discriminants to their API path segments (plural forms).

--- a/packages/core/src/sca/schemas.ts
+++ b/packages/core/src/sca/schemas.ts
@@ -15,7 +15,9 @@ export const ScaSessionStatusSchema = z.enum(["waiting", "allow", "deny"]);
  * Note: The API response contains only `status` inside the `sca_session` envelope.
  * The `token` field is added by the service layer from the request parameter.
  */
-export const ScaSessionSchema = z.object({
-  token: z.string(),
-  status: ScaSessionStatusSchema,
-}) satisfies z.ZodType<ScaSession>;
+export const ScaSessionSchema = z
+  .object({
+    token: z.string(),
+    status: ScaSessionStatusSchema,
+  })
+  .strip() satisfies z.ZodType<ScaSession>;

--- a/packages/core/src/services/bank-accounts.ts
+++ b/packages/core/src/services/bank-accounts.ts
@@ -8,10 +8,12 @@ import { BankAccountSchema } from "../api-types.schema.js";
 import type { HttpClient } from "../http-client.js";
 import { parseResponse } from "../response.js";
 
-const BankAccountResponseSchema = z.object({ bank_account: BankAccountSchema });
-const BankAccountListResponseSchema = z.object({
-  bank_accounts: z.array(BankAccountSchema),
-});
+const BankAccountResponseSchema = z.object({ bank_account: BankAccountSchema }).strip();
+const BankAccountListResponseSchema = z
+  .object({
+    bank_accounts: z.array(BankAccountSchema),
+  })
+  .strip();
 
 export interface CreateBankAccountParams {
   readonly name: string;

--- a/packages/core/src/services/organization.ts
+++ b/packages/core/src/services/organization.ts
@@ -8,7 +8,7 @@ import { OrganizationSchema } from "../api-types.schema.js";
 import type { HttpClient } from "../http-client.js";
 import { parseResponse } from "../response.js";
 
-const OrganizationResponseSchema = z.object({ organization: OrganizationSchema });
+const OrganizationResponseSchema = z.object({ organization: OrganizationSchema }).strip();
 
 /**
  * Fetch the authenticated organization details, including its bank accounts.

--- a/packages/core/src/statements/schemas.ts
+++ b/packages/core/src/statements/schemas.ts
@@ -9,28 +9,36 @@ import type { Statement, StatementFile } from "./types.js";
 /**
  * Zod schema for statement file metadata.
  */
-export const StatementFileSchema = z.object({
-  file_name: z.string(),
-  file_content_type: z.string(),
-  file_size: z.coerce.string(),
-  file_url: z.string(),
-}) satisfies z.ZodType<StatementFile>;
+export const StatementFileSchema = z
+  .object({
+    file_name: z.string(),
+    file_content_type: z.string(),
+    file_size: z.coerce.string(),
+    file_url: z.string(),
+  })
+  .strip() satisfies z.ZodType<StatementFile>;
 
 /**
  * Zod schema for a bank statement returned by the Qonto API.
  */
-export const StatementSchema = z.object({
-  id: z.string(),
-  bank_account_id: z.string(),
-  period: z.string(),
-  file: StatementFileSchema,
-}) satisfies z.ZodType<Statement>;
+export const StatementSchema = z
+  .object({
+    id: z.string(),
+    bank_account_id: z.string(),
+    period: z.string(),
+    file: StatementFileSchema,
+  })
+  .strip() satisfies z.ZodType<Statement>;
 
-export const StatementResponseSchema = z.object({
-  statement: StatementSchema,
-});
+export const StatementResponseSchema = z
+  .object({
+    statement: StatementSchema,
+  })
+  .strip();
 
-export const StatementListResponseSchema = z.object({
-  statements: z.array(StatementSchema),
-  meta: PaginationMetaSchema,
-});
+export const StatementListResponseSchema = z
+  .object({
+    statements: z.array(StatementSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/supplier-invoices/schemas.ts
+++ b/packages/core/src/supplier-invoices/schemas.ts
@@ -51,14 +51,18 @@ export const SupplierInvoiceSchema = z
   })
   .strip() satisfies z.ZodType<SupplierInvoice>;
 
-export const SupplierInvoiceResponseSchema = z.object({
-  supplier_invoice: SupplierInvoiceSchema,
-});
+export const SupplierInvoiceResponseSchema = z
+  .object({
+    supplier_invoice: SupplierInvoiceSchema,
+  })
+  .strip();
 
-export const SupplierInvoiceListResponseSchema = z.object({
-  supplier_invoices: z.array(SupplierInvoiceSchema),
-  meta: PaginationMetaSchema,
-});
+export const SupplierInvoiceListResponseSchema = z
+  .object({
+    supplier_invoices: z.array(SupplierInvoiceSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 /**
  * Schema for an error from the bulk create response.

--- a/packages/core/src/transactions/schemas.ts
+++ b/packages/core/src/transactions/schemas.ts
@@ -98,11 +98,15 @@ export const TransactionSchema = z
   >
 >;
 
-export const TransactionResponseSchema = z.object({
-  transaction: TransactionSchema,
-});
+export const TransactionResponseSchema = z
+  .object({
+    transaction: TransactionSchema,
+  })
+  .strip();
 
-export const TransactionListResponseSchema = z.object({
-  transactions: z.array(TransactionSchema),
-  meta: PaginationMetaSchema,
-});
+export const TransactionListResponseSchema = z
+  .object({
+    transactions: z.array(TransactionSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/transfers/schemas.ts
+++ b/packages/core/src/transfers/schemas.ts
@@ -8,35 +8,41 @@ import type { BulkVopResult, BulkVopResultEntry, Transfer, VopMatchResult, VopRe
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/sepa-transfers/show
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/sepa-transfers/index
-export const TransferSchema = z.object({
-  id: z.string(),
-  initiator_id: z.string(),
-  bank_account_id: z.string(),
-  beneficiary_id: z.string(),
-  amount: z.number(),
-  amount_cents: z.number(),
-  amount_currency: z.string(),
-  status: z.enum(["pending", "processing", "canceled", "declined", "settled"]),
-  reference: z.string(),
-  note: z.nullable(z.string()),
-  scheduled_date: z.string(),
-  created_at: z.string(),
-  updated_at: z.string(),
-  processed_at: z.nullable(z.string()),
-  completed_at: z.nullable(z.string()),
-  transaction_id: z.nullable(z.string()),
-  recurring_transfer_id: z.nullable(z.string()),
-  declined_reason: z.nullable(z.string()),
-}) satisfies z.ZodType<Transfer>;
+export const TransferSchema = z
+  .object({
+    id: z.string(),
+    initiator_id: z.string(),
+    bank_account_id: z.string(),
+    beneficiary_id: z.string(),
+    amount: z.number(),
+    amount_cents: z.number(),
+    amount_currency: z.string(),
+    status: z.enum(["pending", "processing", "canceled", "declined", "settled"]),
+    reference: z.string(),
+    note: z.nullable(z.string()),
+    scheduled_date: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    processed_at: z.nullable(z.string()),
+    completed_at: z.nullable(z.string()),
+    transaction_id: z.nullable(z.string()),
+    recurring_transfer_id: z.nullable(z.string()),
+    declined_reason: z.nullable(z.string()),
+  })
+  .strip() satisfies z.ZodType<Transfer>;
 
-export const TransferResponseSchema = z.object({
-  transfer: TransferSchema,
-});
+export const TransferResponseSchema = z
+  .object({
+    transfer: TransferSchema,
+  })
+  .strip();
 
-export const TransferListResponseSchema = z.object({
-  transfers: z.array(TransferSchema),
-  meta: PaginationMetaSchema,
-});
+export const TransferListResponseSchema = z
+  .object({
+    transfers: z.array(TransferSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/verify-payee/index
 export const VopMatchResultSchema = z.enum([
@@ -47,40 +53,48 @@ export const VopMatchResultSchema = z.enum([
   "MATCH_RESULT_UNSPECIFIED",
 ]) satisfies z.ZodType<VopMatchResult>;
 
-const ProofTokenSchema = z.object({
-  token: z.string(),
-});
+const ProofTokenSchema = z
+  .object({
+    token: z.string(),
+  })
+  .strip();
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/verify-payee/index
-export const VopResultSchema = z.object({
-  match_result: VopMatchResultSchema,
-  matched_name: z.nullable(z.string()).optional().default(null),
-  proof_token: ProofTokenSchema,
-}) satisfies z.ZodType<VopResult>;
+export const VopResultSchema = z
+  .object({
+    match_result: VopMatchResultSchema,
+    matched_name: z.nullable(z.string()).optional().default(null),
+    proof_token: ProofTokenSchema,
+  })
+  .strip() satisfies z.ZodType<VopResult>;
 
 export const VopResultResponseSchema = VopResultSchema;
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/verify-payee/bulk-verify-payee
-export const BulkVopResultEntrySchema = z.object({
-  id: z.string(),
-  beneficiary_name: z.string(),
-  iban: z.string(),
-  response: z
-    .object({
-      match_result: VopMatchResultSchema,
-      matched_name: z.nullable(z.string()).optional().default(null),
-    })
-    .optional(),
-  error: z
-    .object({
-      code: z.string(),
-      detail: z.string().optional(),
-    })
-    .optional(),
-}) satisfies z.ZodType<BulkVopResultEntry>;
+export const BulkVopResultEntrySchema = z
+  .object({
+    id: z.string(),
+    beneficiary_name: z.string(),
+    iban: z.string(),
+    response: z
+      .object({
+        match_result: VopMatchResultSchema,
+        matched_name: z.nullable(z.string()).optional().default(null),
+      })
+      .optional(),
+    error: z
+      .object({
+        code: z.string(),
+        detail: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strip() satisfies z.ZodType<BulkVopResultEntry>;
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/verify-payee/bulk-verify-payee
-export const BulkVopResultResponseSchema = z.object({
-  responses: z.array(BulkVopResultEntrySchema),
-  proof_token: ProofTokenSchema,
-}) satisfies z.ZodType<BulkVopResult>;
+export const BulkVopResultResponseSchema = z
+  .object({
+    responses: z.array(BulkVopResultEntrySchema),
+    proof_token: ProofTokenSchema,
+  })
+  .strip() satisfies z.ZodType<BulkVopResult>;

--- a/packages/core/src/types/client.schema.ts
+++ b/packages/core/src/types/client.schema.ts
@@ -41,11 +41,15 @@ export const ClientSchema = z
   })
   .strip() satisfies z.ZodType<Client>;
 
-export const ClientResponseSchema = z.object({
-  client: ClientSchema,
-});
+export const ClientResponseSchema = z
+  .object({
+    client: ClientSchema,
+  })
+  .strip();
 
-export const ClientListResponseSchema = z.object({
-  clients: z.array(ClientSchema),
-  meta: PaginationMetaSchema,
-});
+export const ClientListResponseSchema = z
+  .object({
+    clients: z.array(ClientSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/credit-note.schema.ts
+++ b/packages/core/src/types/credit-note.schema.ts
@@ -76,11 +76,15 @@ export const CreditNoteSchema = z
   })
   .strip() satisfies z.ZodType<CreditNote>;
 
-export const CreditNoteResponseSchema = z.object({
-  credit_note: CreditNoteSchema,
-});
+export const CreditNoteResponseSchema = z
+  .object({
+    credit_note: CreditNoteSchema,
+  })
+  .strip();
 
-export const CreditNoteListResponseSchema = z.object({
-  credit_notes: z.array(CreditNoteSchema),
-  meta: PaginationMetaSchema,
-});
+export const CreditNoteListResponseSchema = z
+  .object({
+    credit_notes: z.array(CreditNoteSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/label.schema.ts
+++ b/packages/core/src/types/label.schema.ts
@@ -14,11 +14,15 @@ export const LabelSchema = z
   })
   .strip() satisfies z.ZodType<Label>;
 
-export const LabelResponseSchema = z.object({
-  label: LabelSchema,
-});
+export const LabelResponseSchema = z
+  .object({
+    label: LabelSchema,
+  })
+  .strip();
 
-export const LabelListResponseSchema = z.object({
-  labels: z.array(LabelSchema),
-  meta: PaginationMetaSchema,
-});
+export const LabelListResponseSchema = z
+  .object({
+    labels: z.array(LabelSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/membership.schema.ts
+++ b/packages/core/src/types/membership.schema.ts
@@ -23,11 +23,15 @@ export const MembershipSchema = z
   })
   .strip() satisfies z.ZodType<Membership>;
 
-export const MembershipResponseSchema = z.object({
-  membership: MembershipSchema,
-});
+export const MembershipResponseSchema = z
+  .object({
+    membership: MembershipSchema,
+  })
+  .strip();
 
-export const MembershipListResponseSchema = z.object({
-  memberships: z.array(MembershipSchema),
-  meta: PaginationMetaSchema,
-});
+export const MembershipListResponseSchema = z
+  .object({
+    memberships: z.array(MembershipSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/payment-link.schema.ts
+++ b/packages/core/src/types/payment-link.schema.ts
@@ -52,14 +52,18 @@ export const PaymentLinkSchema = z
   })
   .strip() satisfies z.ZodType<PaymentLink>;
 
-export const PaymentLinkResponseSchema = z.object({
-  payment_link: PaymentLinkSchema,
-});
+export const PaymentLinkResponseSchema = z
+  .object({
+    payment_link: PaymentLinkSchema,
+  })
+  .strip();
 
-export const PaymentLinkListResponseSchema = z.object({
-  payment_links: z.array(PaymentLinkSchema),
-  meta: PaginationMetaSchema,
-});
+export const PaymentLinkListResponseSchema = z
+  .object({
+    payment_links: z.array(PaymentLinkSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 export const PaymentLinkPaymentSchema = z
   .object({
@@ -73,10 +77,12 @@ export const PaymentLinkPaymentSchema = z
   })
   .strip() satisfies z.ZodType<PaymentLinkPayment>;
 
-export const PaymentLinkPaymentListResponseSchema = z.object({
-  payments: z.array(PaymentLinkPaymentSchema),
-  meta: PaginationMetaSchema,
-});
+export const PaymentLinkPaymentListResponseSchema = z
+  .object({
+    payments: z.array(PaymentLinkPaymentSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();
 
 export const PaymentLinkPaymentMethodSchema = z
   .object({
@@ -85,9 +91,11 @@ export const PaymentLinkPaymentMethodSchema = z
   })
   .strip() satisfies z.ZodType<PaymentLinkPaymentMethod>;
 
-export const PaymentLinkPaymentMethodListResponseSchema = z.object({
-  payment_link_payment_methods: z.array(PaymentLinkPaymentMethodSchema),
-});
+export const PaymentLinkPaymentMethodListResponseSchema = z
+  .object({
+    payment_link_payment_methods: z.array(PaymentLinkPaymentMethodSchema),
+  })
+  .strip();
 
 export const PaymentLinkConnectionSchema = z
   .object({

--- a/packages/core/src/types/quote.schema.ts
+++ b/packages/core/src/types/quote.schema.ts
@@ -103,11 +103,15 @@ export const QuoteSchema = z
   })
   .strip() satisfies z.ZodType<Quote>;
 
-export const QuoteResponseSchema = z.object({
-  quote: QuoteSchema,
-});
+export const QuoteResponseSchema = z
+  .object({
+    quote: QuoteSchema,
+  })
+  .strip();
 
-export const QuoteListResponseSchema = z.object({
-  quotes: z.array(QuoteSchema),
-  meta: PaginationMetaSchema,
-});
+export const QuoteListResponseSchema = z
+  .object({
+    quotes: z.array(QuoteSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/request.schema.ts
+++ b/packages/core/src/types/request.schema.ts
@@ -12,16 +12,18 @@ import type {
   RequestVirtualCard,
 } from "./request.js";
 
-const RequestBaseSchema = z.object({
-  id: z.string(),
-  status: z.enum(["pending", "approved", "declined", "canceled"]),
-  initiator_id: z.string(),
-  approver_id: z.string().nullable(),
-  note: z.string(),
-  declined_note: z.string().nullable(),
-  processed_at: z.string().nullable(),
-  created_at: z.string(),
-});
+const RequestBaseSchema = z
+  .object({
+    id: z.string(),
+    status: z.enum(["pending", "approved", "declined", "canceled"]),
+    initiator_id: z.string(),
+    approver_id: z.string().nullable(),
+    note: z.string(),
+    declined_note: z.string().nullable(),
+    processed_at: z.string().nullable(),
+    created_at: z.string(),
+  })
+  .strip();
 
 export const RequestFlashCardSchema = RequestBaseSchema.extend({
   request_type: z.literal("flash_card"),
@@ -64,7 +66,9 @@ export const RequestSchema = z.discriminatedUnion("request_type", [
   RequestMultiTransferSchema,
 ]) satisfies z.ZodType<Request>;
 
-export const RequestListResponseSchema = z.object({
-  requests: z.array(RequestSchema),
-  meta: PaginationMetaSchema,
-});
+export const RequestListResponseSchema = z
+  .object({
+    requests: z.array(RequestSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/types/team.schema.ts
+++ b/packages/core/src/types/team.schema.ts
@@ -13,11 +13,15 @@ export const TeamSchema = z
   })
   .strip() satisfies z.ZodType<Team>;
 
-export const TeamResponseSchema = z.object({
-  team: TeamSchema,
-});
+export const TeamResponseSchema = z
+  .object({
+    team: TeamSchema,
+  })
+  .strip();
 
-export const TeamListResponseSchema = z.object({
-  teams: z.array(TeamSchema),
-  meta: PaginationMetaSchema,
-});
+export const TeamListResponseSchema = z
+  .object({
+    teams: z.array(TeamSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/webhooks/schemas.ts
+++ b/packages/core/src/webhooks/schemas.ts
@@ -6,23 +6,29 @@ import { z } from "zod";
 import { PaginationMetaSchema } from "../api-types.schema.js";
 import type { WebhookSubscription } from "../types/webhook-subscription.js";
 
-export const WebhookSubscriptionSchema = z.object({
-  id: z.string(),
-  organization_id: z.string(),
-  membership_id: z.string(),
-  callback_url: z.string(),
-  types: z.array(z.string()),
-  description: z.nullable(z.string()),
-  secret: z.nullable(z.string()),
-  created_at: z.string(),
-  updated_at: z.string(),
-}) satisfies z.ZodType<WebhookSubscription>;
+export const WebhookSubscriptionSchema = z
+  .object({
+    id: z.string(),
+    organization_id: z.string(),
+    membership_id: z.string(),
+    callback_url: z.string(),
+    types: z.array(z.string()),
+    description: z.nullable(z.string()),
+    secret: z.nullable(z.string()),
+    created_at: z.string(),
+    updated_at: z.string(),
+  })
+  .strip() satisfies z.ZodType<WebhookSubscription>;
 
-export const WebhookSubscriptionResponseSchema = z.object({
-  webhook_subscription: WebhookSubscriptionSchema,
-});
+export const WebhookSubscriptionResponseSchema = z
+  .object({
+    webhook_subscription: WebhookSubscriptionSchema,
+  })
+  .strip();
 
-export const WebhookSubscriptionListResponseSchema = z.object({
-  webhook_subscriptions: z.array(WebhookSubscriptionSchema),
-  meta: PaginationMetaSchema,
-});
+export const WebhookSubscriptionListResponseSchema = z
+  .object({
+    webhook_subscriptions: z.array(WebhookSubscriptionSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();


### PR DESCRIPTION
## Summary

- Add explicit `.strip()` to all bare domain schemas and response wrapper schemas across 28 files for consistent forward-compatibility behavior
- Document `.loose()` usage on international endpoint schemas (3 files) where the API surface is less stable and may return additional undocumented properties
- Eliminates the inconsistency where consumers got different forward-compatibility behavior depending on which endpoint they called

## Changes

**Domain schemas** — Added `.strip()` to bare schemas in: attachments, beneficiaries, cards (6 schemas), client-invoices (7 schemas), insurance-contracts (2 schemas), internal-transfers, requests, sca, statements (2 schemas), transfers (4 schemas), webhooks

**Response wrappers** — Added `.strip()` to all response/list wrapper schemas across all schema files and service files (organization, bank-accounts, requests)

**International schemas** — Added documenting comments explaining why `.loose()` is used (less stable API surface, undocumented properties)

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All unit tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Prettier formatting verified

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)