### PR TITLE
(chore) validate OAuth token response with Zod schema

### DIFF
--- a/packages/core/src/auth/oauth-service.test.ts
+++ b/packages/core/src/auth/oauth-service.test.ts
@@ -112,6 +112,20 @@ describe("exchangeCode", () => {
       ),
     ).rejects.toThrow(/400/);
   });
+
+  it("throws on invalid token response shape", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ unexpected: "data" }));
+
+    await expect(
+      exchangeCode(
+        "https://oauth.example.com/token",
+        "client-id",
+        "client-secret",
+        "auth-code",
+        "http://localhost:8080/callback",
+      ),
+    ).rejects.toThrow(/Invalid API response/);
+  });
 });
 
 describe("refreshAccessToken", () => {

--- a/packages/core/src/auth/oauth-service.ts
+++ b/packages/core/src/auth/oauth-service.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { z } from "zod";
+
+import { parseResponse } from "../response.js";
 import { AuthError } from "./api-key.js";
 
 /**
@@ -112,10 +115,19 @@ export async function revokeToken(
 
 interface TokenResponse {
   readonly access_token: string;
-  readonly refresh_token?: string;
+  readonly refresh_token?: string | undefined;
   readonly expires_in: number;
   readonly token_type: string;
 }
+
+const TokenResponseSchema = z
+  .object({
+    access_token: z.string(),
+    refresh_token: z.string().optional(),
+    expires_in: z.number(),
+    token_type: z.string(),
+  })
+  .strip() satisfies z.ZodType<TokenResponse>;
 
 async function requestTokens(tokenUrl: string, body: URLSearchParams, stagingToken?: string): Promise<OAuthTokens> {
   const headers: Record<string, string> = {
@@ -134,7 +146,7 @@ async function requestTokens(tokenUrl: string, body: URLSearchParams, stagingTok
     throw new AuthError(`OAuth token request failed (${response.status}): ${text}`);
   }
 
-  const data = (await response.json()) as TokenResponse;
+  const data = parseResponse(TokenResponseSchema, await response.json(), tokenUrl);
 
   return {
     accessToken: data.access_token,


### PR DESCRIPTION
## Summary

- Replace `as TokenResponse` type cast with Zod schema validation via `parseResponse()`, matching the pattern used for all other API responses
- Add `TokenResponseSchema` with `.strip()` per the established convention from #399
- Add test for invalid token response shape rejection

Closes #401

## Test plan

- [x] Build passes
- [x] All unit tests pass (including new invalid-response test)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)