### PR TITLE
(fix) use lightweight test programs in 27 CLI test files

### DIFF
--- a/packages/cli/src/commands/attachment.test.ts
+++ b/packages/cli/src/commands/attachment.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createAttachmentCommand } from "./attachment.js";
+import { OUTPUT_FORMATS } from "../options.js";
 
 vi.mock("../client.js", () => ({
   createClient: vi.fn(),
@@ -20,6 +22,22 @@ const sampleAttachment = {
   url: "https://example.com/attachments/att-123",
   created_at: "2026-03-01T10:00:00Z",
 };
+
+/**
+ * Create a lightweight test program with only the global options and attachment
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createAttachmentCommand());
+  program.exitOverride();
+  return program;
+}
 
 describe("attachment commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -46,10 +64,7 @@ describe("attachment commands", () => {
     it("shows attachment details in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createAttachmentCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["attachment", "show", "att-123"], { from: "user" });
 
@@ -62,10 +77,7 @@ describe("attachment commands", () => {
     it("shows attachment details in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createAttachmentCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "attachment", "show", "att-123"], { from: "user" });
 
@@ -81,10 +93,7 @@ describe("attachment commands", () => {
     it("sends GET to the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createAttachmentCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["attachment", "show", "att-123"], { from: "user" });
 
@@ -98,10 +107,7 @@ describe("attachment commands", () => {
     it("uploads a file via multipart form-data", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createAttachmentCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       // Use a real file that exists in the repo
       await program.parseAsync(["attachment", "upload", "package.json"], { from: "user" });
@@ -119,10 +125,7 @@ describe("attachment commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createAttachmentCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["attachment", "upload", "package.json", "--idempotency-key", "key-abc"], {
         from: "user",

--- a/packages/cli/src/commands/beneficiary/add.test.ts
+++ b/packages/cli/src/commands/beneficiary/add.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 const sampleBeneficiary = {
   id: "ben-new",
@@ -48,9 +67,7 @@ describe("beneficiary add command", () => {
   it("creates a beneficiary in table format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "add", "--name", "New Corp", "--iban", "FR7630001007941234567890185"], {
       from: "user",
@@ -65,9 +82,7 @@ describe("beneficiary add command", () => {
   it("creates a beneficiary in json format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(
       ["--output", "json", "beneficiary", "add", "--name", "New Corp", "--iban", "FR7630001007941234567890185"],
@@ -83,9 +98,7 @@ describe("beneficiary add command", () => {
   it("sends POST to the correct endpoint with body", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(
       ["beneficiary", "add", "--name", "New Corp", "--iban", "FR7630001007941234567890185", "--bic", "BNPAFRPP"],

--- a/packages/cli/src/commands/beneficiary/list.test.ts
+++ b/packages/cli/src/commands/beneficiary/list.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 import type { PaginationMeta } from "../../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -23,6 +26,32 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("beneficiary list command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -79,9 +108,7 @@ describe("beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "list"], { from: "user" });
 
@@ -115,9 +142,7 @@ describe("beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "beneficiary", "list"], { from: "user" });
 
@@ -136,9 +161,7 @@ describe("beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "list", "--status", "validated", "--trusted"], { from: "user" });
 
@@ -155,9 +178,7 @@ describe("beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--page", "2", "--per-page", "50", "beneficiary", "list"], { from: "user" });
 
@@ -174,9 +195,7 @@ describe("beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "list"], { from: "user" });
 

--- a/packages/cli/src/commands/beneficiary/show.test.ts
+++ b/packages/cli/src/commands/beneficiary/show.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("beneficiary show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -47,9 +66,7 @@ describe("beneficiary show command", () => {
     };
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "show", "ben-1"], { from: "user" });
 
@@ -74,9 +91,7 @@ describe("beneficiary show command", () => {
     };
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "beneficiary", "show", "ben-1"], { from: "user" });
 
@@ -104,9 +119,7 @@ describe("beneficiary show command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "show", "ben-1"], { from: "user" });
 

--- a/packages/cli/src/commands/beneficiary/trust.test.ts
+++ b/packages/cli/src/commands/beneficiary/trust.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("beneficiary trust command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -35,9 +54,7 @@ describe("beneficiary trust command", () => {
   it("trusts a single beneficiary in text format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "trust", "ben-1"], { from: "user" });
 
@@ -49,9 +66,7 @@ describe("beneficiary trust command", () => {
   it("trusts multiple beneficiaries in text format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "trust", "ben-1", "ben-2"], { from: "user" });
 
@@ -63,9 +78,7 @@ describe("beneficiary trust command", () => {
   it("outputs json confirmation", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "beneficiary", "trust", "ben-1", "ben-2"], { from: "user" });
 
@@ -79,9 +92,7 @@ describe("beneficiary trust command", () => {
   it("sends POST with ids to the correct endpoint", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "trust", "ben-1"], { from: "user" });
 

--- a/packages/cli/src/commands/beneficiary/untrust.test.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("beneficiary untrust command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -35,9 +54,7 @@ describe("beneficiary untrust command", () => {
   it("untrusts a single beneficiary in text format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "untrust", "ben-1"], { from: "user" });
 
@@ -49,9 +66,7 @@ describe("beneficiary untrust command", () => {
   it("untrusts multiple beneficiaries in text format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "untrust", "ben-1", "ben-2"], { from: "user" });
 
@@ -63,9 +78,7 @@ describe("beneficiary untrust command", () => {
   it("outputs json confirmation", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "beneficiary", "untrust", "ben-1", "ben-2"], { from: "user" });
 
@@ -79,9 +92,7 @@ describe("beneficiary untrust command", () => {
   it("sends POST with ids to the correct endpoint", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "untrust", "ben-1"], { from: "user" });
 

--- a/packages/cli/src/commands/beneficiary/update.test.ts
+++ b/packages/cli/src/commands/beneficiary/update.test.ts
@@ -3,6 +3,9 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { Command, Option } from "commander";
+import { registerBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 const sampleBeneficiary = {
   id: "ben-1",
@@ -48,9 +67,7 @@ describe("beneficiary update command", () => {
   it("updates a beneficiary in table format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "update", "ben-1", "--name", "Updated Corp"], { from: "user" });
 
@@ -63,9 +80,7 @@ describe("beneficiary update command", () => {
   it("updates a beneficiary in json format", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "beneficiary", "update", "ben-1", "--name", "Updated Corp"], {
       from: "user",
@@ -80,9 +95,7 @@ describe("beneficiary update command", () => {
   it("sends PUT to the correct endpoint with body", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({ beneficiary: sampleBeneficiary }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["beneficiary", "update", "ben-1", "--name", "Updated Corp"], { from: "user" });
 

--- a/packages/cli/src/commands/bulk-transfer/list.test.ts
+++ b/packages/cli/src/commands/bulk-transfer/list.test.ts
@@ -2,7 +2,26 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerBulkTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * bulk-transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBulkTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
@@ -39,9 +58,7 @@ describe("bulk-transfer list command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "bulk-transfer", "list", ...args]);
   }
 

--- a/packages/cli/src/commands/bulk-transfer/show.test.ts
+++ b/packages/cli/src/commands/bulk-transfer/show.test.ts
@@ -2,7 +2,26 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerBulkTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * bulk-transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerBulkTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("bulk-transfer show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -27,9 +46,7 @@ describe("bulk-transfer show command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "bulk-transfer", "show", ...args]);
   }
 

--- a/packages/cli/src/commands/client.test.ts
+++ b/packages/cli/src/commands/client.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createClientCommand } from "./client.js";
+import { OUTPUT_FORMATS } from "../options.js";
 
 vi.mock("../client.js", () => ({
   createClient: vi.fn(),
@@ -33,6 +35,22 @@ const sampleClient = {
   created_at: "2026-01-15T10:00:00Z",
   updated_at: "2026-01-15T10:00:00Z",
 };
+
+/**
+ * Create a lightweight test program with only the global options and client
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createClientCommand());
+  program.exitOverride();
+  return program;
+}
 
 describe("client commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -74,10 +92,7 @@ describe("client commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "list"], { from: "user" });
 
@@ -102,10 +117,7 @@ describe("client commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "client", "list"], { from: "user" });
 
@@ -125,10 +137,7 @@ describe("client commands", () => {
     it("shows client details in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "client", "show", "cl-123"], { from: "user" });
 
@@ -143,10 +152,7 @@ describe("client commands", () => {
     it("calls the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "show", "cl-123"], { from: "user" });
 
@@ -159,10 +165,7 @@ describe("client commands", () => {
     it("creates a company client in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "create", "--kind", "company", "--name", "Acme Corp"], { from: "user" });
 
@@ -175,10 +178,7 @@ describe("client commands", () => {
     it("creates a client in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "client", "create", "--kind", "company", "--name", "Acme Corp"], {
         from: "user",
@@ -194,10 +194,7 @@ describe("client commands", () => {
     it("sends POST with flat body to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         ["client", "create", "--kind", "company", "--name", "Acme Corp", "--email", "contact@acme.com"],
@@ -218,10 +215,7 @@ describe("client commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         ["client", "create", "--kind", "company", "--name", "Acme Corp", "--idempotency-key", "key-abc-123"],
@@ -238,10 +232,7 @@ describe("client commands", () => {
     it("updates a client in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: { ...sampleClient, name: "Acme Inc" } }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "client", "update", "cl-123", "--name", "Acme Inc"], {
         from: "user",
@@ -257,10 +248,7 @@ describe("client commands", () => {
     it("sends PATCH with flat body to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ client: sampleClient }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "update", "cl-123", "--name", "Acme Inc", "--email", "new@acme.com"], {
         from: "user",
@@ -281,10 +269,7 @@ describe("client commands", () => {
     it("deletes a client with --yes flag", async () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "client", "delete", "cl-123", "--yes"], { from: "user" });
 
@@ -298,10 +283,7 @@ describe("client commands", () => {
     it("sends DELETE to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "delete", "cl-123", "--yes"], { from: "user" });
 
@@ -311,10 +293,7 @@ describe("client commands", () => {
     });
 
     it("exits with error when --yes is not provided", async () => {
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createClientCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["client", "delete", "cl-123"], { from: "user" });
 

--- a/packages/cli/src/commands/credit-note.test.ts
+++ b/packages/cli/src/commands/credit-note.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createCreditNoteCommand } from "./credit-note.js";
+import { OUTPUT_FORMATS } from "../options.js";
 import type { PaginationMeta } from "../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -67,6 +69,32 @@ vi.mock("../client.js", () => ({
 import { createClient } from "../client.js";
 import { HttpClient } from "@qontoctl/core";
 
+/**
+ * Create a lightweight test program with only the global options and credit-note
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createCreditNoteCommand());
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
+
 describe("credit-note commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let client: HttpClient;
@@ -98,10 +126,7 @@ describe("credit-note commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["credit-note", "list"], { from: "user" });
 
@@ -123,10 +148,7 @@ describe("credit-note commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "credit-note", "list"], {
         from: "user",
@@ -148,10 +170,7 @@ describe("credit-note commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "2", "--per-page", "50", "credit-note", "list"], { from: "user" });
 
@@ -166,10 +185,7 @@ describe("credit-note commands", () => {
       const creditNote = makeCreditNote();
       fetchSpy.mockImplementation(() => jsonResponse({ credit_note: creditNote }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["credit-note", "show", "cn-001"], {
         from: "user",
@@ -186,10 +202,7 @@ describe("credit-note commands", () => {
       const creditNote = makeCreditNote();
       fetchSpy.mockImplementation(() => jsonResponse({ credit_note: creditNote }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "credit-note", "show", "cn-001"], { from: "user" });
 
@@ -207,10 +220,7 @@ describe("credit-note commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createCreditNoteCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["credit-note", "show", "cn-001"], {
         from: "user",

--- a/packages/cli/src/commands/insurance.test.ts
+++ b/packages/cli/src/commands/insurance.test.ts
@@ -2,10 +2,11 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { HttpClient } from "@qontoctl/core";
 import { registerInsuranceCommands } from "./insurance.js";
+import { OUTPUT_FORMATS } from "../options.js";
 
 vi.mock("../client.js", () => ({
   createClient: vi.fn(),
@@ -33,6 +34,22 @@ const sampleDocument = {
   url: "https://example.com/documents/doc-123",
   created_at: "2026-01-01T10:00:00Z",
 };
+
+/**
+ * Create a lightweight test program with only the global options and insurance
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerInsuranceCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("insurance commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -70,9 +87,7 @@ describe("insurance commands", () => {
     it("shows contract details in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "show", "ic-123"], { from: "user" });
 
@@ -85,9 +100,7 @@ describe("insurance commands", () => {
     it("shows contract details in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "insurance", "show", "ic-123"], { from: "user" });
 
@@ -102,9 +115,7 @@ describe("insurance commands", () => {
     it("sends GET to the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "show", "ic-123"], { from: "user" });
 
@@ -118,9 +129,7 @@ describe("insurance commands", () => {
     it("creates a contract in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -145,9 +154,7 @@ describe("insurance commands", () => {
     it("sends POST with correct body", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -185,9 +192,7 @@ describe("insurance commands", () => {
     it("updates a contract", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "update", "ic-123", "--provider-name", "Allianz"], { from: "user" });
 
@@ -204,9 +209,7 @@ describe("insurance commands", () => {
     it("uploads a document via multipart form-data", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_document: sampleDocument }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "upload-doc", "ic-123", "package.json"], { from: "user" });
 
@@ -223,9 +226,7 @@ describe("insurance commands", () => {
 
   describe("insurance remove-doc", () => {
     it("requires --yes confirmation", async () => {
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "remove-doc", "ic-123", "doc-123"], { from: "user" });
 
@@ -239,9 +240,7 @@ describe("insurance commands", () => {
     it("removes a document when --yes is provided", async () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["insurance", "remove-doc", "ic-123", "doc-123", "--yes"], { from: "user" });
 

--- a/packages/cli/src/commands/internal-transfer.test.ts
+++ b/packages/cli/src/commands/internal-transfer.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createInternalTransferCommand } from "./internal-transfer.js";
+import { OUTPUT_FORMATS } from "../options.js";
 
 vi.mock("../client.js", () => ({
   createClient: vi.fn(),
@@ -25,6 +27,22 @@ const sampleInternalTransfer = {
   status: "processing",
   created_at: "2026-03-01T10:00:00Z",
 };
+
+/**
+ * Create a lightweight test program with only the global options and internal-transfer
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createInternalTransferCommand());
+  program.exitOverride();
+  return program;
+}
 
 describe("internal-transfer commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -51,10 +69,7 @@ describe("internal-transfer commands", () => {
     it("creates an internal transfer in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createInternalTransferCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -81,10 +96,7 @@ describe("internal-transfer commands", () => {
     it("creates an internal transfer in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createInternalTransferCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -118,10 +130,7 @@ describe("internal-transfer commands", () => {
     it("sends POST to the correct API endpoint with body", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createInternalTransferCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -157,10 +166,7 @@ describe("internal-transfer commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createInternalTransferCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -188,10 +194,7 @@ describe("internal-transfer commands", () => {
     it("defaults currency to EUR", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ internal_transfer: sampleInternalTransfer }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createInternalTransferCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [

--- a/packages/cli/src/commands/intl-beneficiary/list.test.ts
+++ b/packages/cli/src/commands/intl-beneficiary/list.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerIntlBeneficiaryCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 import type { PaginationMeta } from "../../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -23,6 +26,32 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * intl-beneficiary commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerIntlBeneficiaryCommands(program);
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("intl beneficiary list command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -57,9 +86,7 @@ describe("intl beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["intl", "beneficiary", "list"], { from: "user" });
 
@@ -80,9 +107,7 @@ describe("intl beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "intl", "beneficiary", "list"], { from: "user" });
 
@@ -101,9 +126,7 @@ describe("intl beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--page", "2", "--per-page", "50", "intl", "beneficiary", "list"], { from: "user" });
 
@@ -120,9 +143,7 @@ describe("intl beneficiary list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["intl", "beneficiary", "list"], { from: "user" });
 

--- a/packages/cli/src/commands/label.test.ts
+++ b/packages/cli/src/commands/label.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createLabelCommand } from "./label.js";
+import { OUTPUT_FORMATS } from "../options.js";
 import type { PaginationMeta } from "../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -24,6 +26,32 @@ vi.mock("../client.js", () => ({
 
 import { createClient } from "../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and label
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createLabelCommand());
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("label commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -59,10 +87,7 @@ describe("label commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["label", "list"], { from: "user" });
 
@@ -83,10 +108,7 @@ describe("label commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "label", "list"], {
         from: "user",
@@ -111,10 +133,7 @@ describe("label commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "2", "--per-page", "50", "label", "list"], { from: "user" });
 
@@ -133,10 +152,7 @@ describe("label commands", () => {
       };
       fetchSpy.mockImplementation(() => jsonResponse({ label }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["label", "show", "abc-123"], {
         from: "user",
@@ -157,10 +173,7 @@ describe("label commands", () => {
       };
       fetchSpy.mockImplementation(() => jsonResponse({ label }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "label", "show", "abc-123"], { from: "user" });
 
@@ -181,10 +194,7 @@ describe("label commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createLabelCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["label", "show", "abc-123"], {
         from: "user",

--- a/packages/cli/src/commands/membership.test.ts
+++ b/packages/cli/src/commands/membership.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createMembershipCommand } from "./membership.js";
+import { OUTPUT_FORMATS } from "../options.js";
 import type { PaginationMeta } from "../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -24,6 +26,32 @@ vi.mock("../client.js", () => ({
 
 import { createClient } from "../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and membership
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createMembershipCommand());
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("membership commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -85,10 +113,7 @@ describe("membership commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["membership", "list"], { from: "user" });
 
@@ -126,10 +151,7 @@ describe("membership commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "membership", "list"], {
         from: "user",
@@ -163,10 +185,7 @@ describe("membership commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "3", "--per-page", "25", "membership", "list"], { from: "user" });
 
@@ -183,10 +202,7 @@ describe("membership commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["membership", "list"], { from: "user" });
 
@@ -214,10 +230,7 @@ describe("membership commands", () => {
     it("shows current user's membership in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "membership", "show"], { from: "user" });
 
@@ -233,10 +246,7 @@ describe("membership commands", () => {
     it("shows current user's membership in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["membership", "show"], { from: "user" });
 
@@ -251,10 +261,7 @@ describe("membership commands", () => {
     it("calls the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: sampleMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["membership", "show"], { from: "user" });
 
@@ -282,10 +289,7 @@ describe("membership commands", () => {
     it("invites a new member in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         ["--output", "json", "membership", "invite", "--email", "charlie@example.com", "--role", "employee"],
@@ -304,10 +308,7 @@ describe("membership commands", () => {
     it("invites a new member in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["membership", "invite", "--email", "charlie@example.com", "--role", "employee"], {
         from: "user",
@@ -323,10 +324,7 @@ describe("membership commands", () => {
     it("sends POST with nested membership body to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -362,10 +360,7 @@ describe("membership commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ membership: invitedMembership }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createMembershipCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [

--- a/packages/cli/src/commands/recurring-transfer/list.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/list.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerRecurringTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", async () => {
   const { HttpClient } = await import("@qontoctl/core");
@@ -15,6 +18,22 @@ vi.mock("../../client.js", async () => {
     ),
   };
 });
+
+/**
+ * Create a lightweight test program with only the global options and
+ * recurring-transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerRecurringTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
@@ -51,9 +70,7 @@ describe("recurring-transfer list command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "recurring-transfer", "list", ...args]);
   }
 

--- a/packages/cli/src/commands/recurring-transfer/show.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/show.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerRecurringTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", async () => {
   const { HttpClient } = await import("@qontoctl/core");
@@ -15,6 +18,22 @@ vi.mock("../../client.js", async () => {
     ),
   };
 });
+
+/**
+ * Create a lightweight test program with only the global options and
+ * recurring-transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerRecurringTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("recurring-transfer show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -39,9 +58,7 @@ describe("recurring-transfer show command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "recurring-transfer", "show", ...args]);
   }
 

--- a/packages/cli/src/commands/request/list.test.ts
+++ b/packages/cli/src/commands/request/list.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { registerRequestCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 import type { PaginationMeta } from "../../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -24,6 +26,32 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * request commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerRequestCommands(program);
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("request commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -89,10 +117,7 @@ describe("request commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      registerRequestCommands(program);
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["request", "list"], { from: "user" });
 
@@ -132,10 +157,7 @@ describe("request commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      registerRequestCommands(program);
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "request", "list"], {
         from: "user",
@@ -170,10 +192,7 @@ describe("request commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      registerRequestCommands(program);
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "3", "--per-page", "25", "request", "list"], { from: "user" });
 
@@ -190,10 +209,7 @@ describe("request commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      registerRequestCommands(program);
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["request", "list"], { from: "user" });
 

--- a/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/bulk-create.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerSupplierInvoiceCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -14,6 +17,22 @@ vi.mock("node:fs/promises", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * supplier-invoice commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerSupplierInvoiceCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("supplier-invoice bulk-create command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -74,9 +93,7 @@ describe("supplier-invoice bulk-create command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], { from: "user" });
 
@@ -118,9 +135,7 @@ describe("supplier-invoice bulk-create command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], {
       from: "user",
@@ -145,9 +160,7 @@ describe("supplier-invoice bulk-create command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/bad.txt"], { from: "user" });
 
@@ -165,9 +178,7 @@ describe("supplier-invoice bulk-create command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "bulk-create", "/tmp/invoice.pdf"], { from: "user" });
 

--- a/packages/cli/src/commands/supplier-invoice/list.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/list.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerSupplierInvoiceCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 import type { PaginationMeta } from "../../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -23,6 +26,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * supplier-invoice commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerSupplierInvoiceCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("supplier-invoice list command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -78,9 +97,7 @@ describe("supplier-invoice list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "list"], { from: "user" });
 
@@ -125,9 +142,7 @@ describe("supplier-invoice list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "supplier-invoice", "list"], { from: "user" });
 
@@ -172,9 +187,7 @@ describe("supplier-invoice list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "list"], { from: "user" });
 
@@ -189,9 +202,7 @@ describe("supplier-invoice list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "list", "--status", "paid"], { from: "user" });
 
@@ -207,9 +218,7 @@ describe("supplier-invoice list command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "list", "--query", "acme", "--sort-by", "created_at:desc"], {
       from: "user",

--- a/packages/cli/src/commands/supplier-invoice/show.test.ts
+++ b/packages/cli/src/commands/supplier-invoice/show.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerSupplierInvoiceCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -10,6 +13,22 @@ vi.mock("../../client.js", () => ({
 
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * supplier-invoice commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerSupplierInvoiceCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("supplier-invoice show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -62,9 +81,7 @@ describe("supplier-invoice show command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "show", "inv-1"], { from: "user" });
 
@@ -102,9 +119,7 @@ describe("supplier-invoice show command", () => {
     };
     fetchSpy.mockImplementation(() => jsonResponse({ supplier_invoice: invoice }));
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["--output", "json", "supplier-invoice", "show", "inv-1"], { from: "user" });
 
@@ -145,9 +160,7 @@ describe("supplier-invoice show command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "show", "inv-2"], { from: "user" });
 
@@ -184,9 +197,7 @@ describe("supplier-invoice show command", () => {
       }),
     );
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    program.exitOverride();
+    const program = createTestProgram();
 
     await program.parseAsync(["supplier-invoice", "show", "inv-1"], { from: "user" });
 

--- a/packages/cli/src/commands/team.test.ts
+++ b/packages/cli/src/commands/team.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { createTeamCommand } from "./team.js";
+import { OUTPUT_FORMATS } from "../options.js";
 import type { PaginationMeta } from "../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -23,6 +26,32 @@ vi.mock("../client.js", () => ({
 
 import { createClient } from "../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and team
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createTeamCommand());
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("team commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -58,9 +87,7 @@ describe("team commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["team", "list"], { from: "user" });
 
@@ -81,9 +108,7 @@ describe("team commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "team", "list"], {
         from: "user",
@@ -107,9 +132,7 @@ describe("team commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "3", "--per-page", "25", "team", "list"], { from: "user" });
 
@@ -126,9 +149,7 @@ describe("team commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["team", "list"], { from: "user" });
 
@@ -146,9 +167,7 @@ describe("team commands", () => {
     it("creates a team in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "team", "create", "--name", "Design"], { from: "user" });
 
@@ -162,9 +181,7 @@ describe("team commands", () => {
     it("creates a team in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["team", "create", "--name", "Design"], { from: "user" });
 
@@ -177,9 +194,7 @@ describe("team commands", () => {
     it("sends POST with name body to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["team", "create", "--name", "Design"], { from: "user" });
 
@@ -193,9 +208,7 @@ describe("team commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ team: createdTeam }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["team", "create", "--name", "Design", "--idempotency-key", "key-abc-123"], {
         from: "user",

--- a/packages/cli/src/commands/transaction/attachment.test.ts
+++ b/packages/cli/src/commands/transaction/attachment.test.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
+import { registerTransactionCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", () => ({
   createClient: vi.fn(),
@@ -16,6 +19,22 @@ vi.mock("@clack/prompts", () => ({
 import { confirm, isCancel } from "@clack/prompts";
 import { createClient } from "../../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and
+ * transaction commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerTransactionCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 const sampleAttachment = {
   id: "att-123",
@@ -51,9 +70,7 @@ describe("transaction attachment commands", () => {
     it("lists attachments for a transaction in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "list", "tx-1"], { from: "user" });
 
@@ -66,9 +83,7 @@ describe("transaction attachment commands", () => {
     it("lists attachments in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "transaction", "attachment", "list", "tx-1"], { from: "user" });
 
@@ -82,9 +97,7 @@ describe("transaction attachment commands", () => {
     it("sends GET to the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachments: [sampleAttachment] }));
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "list", "tx-1"], { from: "user" });
 
@@ -98,9 +111,7 @@ describe("transaction attachment commands", () => {
     it("attaches a file to a transaction via multipart form-data", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ attachment: sampleAttachment }));
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "add", "tx-1", "package.json"], { from: "user" });
 
@@ -118,9 +129,7 @@ describe("transaction attachment commands", () => {
       fetchSpy.mockImplementation(() => jsonResponse({}));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "add", "tx-1", "package.json"], { from: "user" });
 
@@ -135,9 +144,7 @@ describe("transaction attachment commands", () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "remove", "tx-1", "att-123"], { from: "user" });
 
@@ -157,9 +164,7 @@ describe("transaction attachment commands", () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "remove", "tx-1"], { from: "user" });
 
@@ -180,9 +185,7 @@ describe("transaction attachment commands", () => {
       vi.mocked(isCancel).mockReturnValue(false);
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "remove", "tx-1"], { from: "user" });
 
@@ -197,9 +200,7 @@ describe("transaction attachment commands", () => {
       vi.mocked(isCancel).mockReturnValue(true);
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
 
-      const { createProgram } = await import("../../program.js");
-      const program = createProgram();
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["transaction", "attachment", "remove", "tx-1"], { from: "user" });
 

--- a/packages/cli/src/commands/transfer/list.test.ts
+++ b/packages/cli/src/commands/transfer/list.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { registerTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", async () => {
   const { HttpClient } = await import("@qontoctl/core");
@@ -16,6 +18,22 @@ vi.mock("../../client.js", async () => {
     ),
   };
 });
+
+/**
+ * Create a lightweight test program with only the global options and
+ * transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 function makeMeta(overrides: Record<string, unknown> = {}) {
   return {
@@ -52,10 +70,7 @@ describe("transfer list command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    registerTransferCommands(program);
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "transfer", "list", ...args]);
   }
 

--- a/packages/cli/src/commands/transfer/show.test.ts
+++ b/packages/cli/src/commands/transfer/show.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { registerTransferCommands } from "./index.js";
+import { OUTPUT_FORMATS } from "../../options.js";
 
 vi.mock("../../client.js", async () => {
   const { HttpClient } = await import("@qontoctl/core");
@@ -16,6 +18,22 @@ vi.mock("../../client.js", async () => {
     ),
   };
 });
+
+/**
+ * Create a lightweight test program with only the global options and
+ * transfer commands registered.  This avoids the expensive dynamic
+ * import of the full program module (which loads every command module)
+ * that can exceed the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  registerTransferCommands(program);
+  program.exitOverride();
+  return program;
+}
 
 describe("transfer show command", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -40,10 +58,7 @@ describe("transfer show command", () => {
     vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
     vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
 
-    const { createProgram } = await import("../../program.js");
-    const program = createProgram();
-    registerTransferCommands(program);
-    program.exitOverride();
+    const program = createTestProgram();
     await program.parseAsync(["node", "qontoctl", "transfer", "show", ...args]);
   }
 

--- a/packages/cli/src/commands/webhook.test.ts
+++ b/packages/cli/src/commands/webhook.test.ts
@@ -2,8 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command, Option } from "commander";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { createWebhookCommand } from "./webhook.js";
+import { OUTPUT_FORMATS } from "../options.js";
 import type { PaginationMeta } from "../pagination.js";
 
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
@@ -24,6 +26,32 @@ vi.mock("../client.js", () => ({
 
 import { createClient } from "../client.js";
 import { HttpClient } from "@qontoctl/core";
+
+/**
+ * Create a lightweight test program with only the global options and webhook
+ * commands registered.  This avoids the expensive dynamic import of the
+ * full program module (which loads every command module) that can exceed
+ * the per-test timeout on slower CI runners (e.g. Windows).
+ */
+function createTestProgram(): Command {
+  const program = new Command();
+  program
+    .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
+    .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
+    .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
+    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+  program.addCommand(createWebhookCommand());
+  program.exitOverride();
+  return program;
+}
+
+function parsePositiveInt(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    throw new Error(`Expected a positive integer, got "${value}".`);
+  }
+  return parsed;
+}
 
 describe("webhook commands", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -82,10 +110,7 @@ describe("webhook commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "list"], { from: "user" });
 
@@ -118,10 +143,7 @@ describe("webhook commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "webhook", "list"], {
         from: "user",
@@ -152,10 +174,7 @@ describe("webhook commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--page", "2", "--per-page", "50", "webhook", "list"], { from: "user" });
 
@@ -172,10 +191,7 @@ describe("webhook commands", () => {
         }),
       );
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "list"], { from: "user" });
 
@@ -200,10 +216,7 @@ describe("webhook commands", () => {
     it("shows webhook details in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "webhook", "show", "wh-1"], { from: "user" });
 
@@ -218,10 +231,7 @@ describe("webhook commands", () => {
     it("shows webhook details in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "show", "wh-1"], { from: "user" });
 
@@ -235,10 +245,7 @@ describe("webhook commands", () => {
     it("calls the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "show", "wh-1"], { from: "user" });
 
@@ -263,10 +270,7 @@ describe("webhook commands", () => {
     it("creates a webhook in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -294,10 +298,7 @@ describe("webhook commands", () => {
     it("sends POST to the correct endpoint with body", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         ["webhook", "create", "--url", "https://example.com/hook", "--events", "transactions.created"],
@@ -317,10 +318,7 @@ describe("webhook commands", () => {
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -358,10 +356,7 @@ describe("webhook commands", () => {
     it("updates a webhook in json format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         ["--output", "json", "webhook", "update", "wh-1", "--url", "https://example.com/new-hook"],
@@ -378,10 +373,7 @@ describe("webhook commands", () => {
     it("sends PUT to the correct endpoint with body", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(
         [
@@ -412,10 +404,7 @@ describe("webhook commands", () => {
     it("deletes a webhook with --yes flag", async () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["--output", "json", "webhook", "delete", "wh-1", "--yes"], {
         from: "user",
@@ -431,10 +420,7 @@ describe("webhook commands", () => {
     it("sends DELETE to the correct endpoint", async () => {
       fetchSpy.mockImplementation(() => Promise.resolve(new Response(null, { status: 204 })));
 
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "delete", "wh-1", "--yes"], { from: "user" });
 
@@ -444,10 +430,7 @@ describe("webhook commands", () => {
     });
 
     it("exits with error when --yes is not provided", async () => {
-      const { createProgram } = await import("../program.js");
-      const program = createProgram();
-      program.addCommand(createWebhookCommand());
-      program.exitOverride();
+      const program = createTestProgram();
 
       await program.parseAsync(["webhook", "delete", "wh-1"], { from: "user" });
 


### PR DESCRIPTION
## Summary

Closes #418

- Replaced expensive `await import("../program.js")` full-program imports with per-file `createTestProgram()` helpers across all 27 remaining CLI test files
- Each test program now registers only the command under test, avoiding loading the entire module graph (~25 command modules)
- Files that test pagination pass `--page`/`--per-page` options; others use the minimal `--output`/`--no-paginate` set
- Follows the pattern established in commit 95473c7 (card.test.ts, client-invoice.test.ts)

## Test plan

- [x] `pnpm test` — 624 tests pass (81 files)
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] Zero remaining `await import("../program.js")` or `await import("../../program.js")` patterns in test files
- [ ] CI passes on all 3 OS (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)