### PR TITLE
(chore) replace stale E2E coverage list with directory pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ pnpm test:e2e                       # Full E2E suite
 - Tests run sequentially (`--concurrency=1`) to avoid API race conditions
 - Per-test timeout: 30 seconds
 
-**What's covered:** organization/account listing, transactions (filtering, pagination), bank statements, labels (CRUD), memberships, MCP server initialization, and MCP tool invocations.
+**What's covered:** Each domain has its own directory under `packages/e2e/src/` with CLI and MCP test files. Check the directory structure for current coverage — do not rely on a hardcoded list.
 
 ### TypeScript
 


### PR DESCRIPTION
## Summary

- Replace hardcoded E2E domain list in CLAUDE.md (6 domains) with a pointer to `packages/e2e/src/` (25 domains)
- The stale enumeration directly caused a false claim during #420 investigation — an agent read the outdated list and reported no webhook E2E tests when they exist

Principle: **discover, don't cache** — point to the source of truth instead of maintaining a stale copy.

## Test plan

- [x] Lint passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)