### PR TITLE
(feat) add CLI sca-session show and mock-decision subcommands (#431)

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -12,6 +12,7 @@ export { createMembershipCommand } from "./membership.js";
 export { createPaymentLinkCommand } from "./payment-link.js";
 export { createQuoteCommand } from "./quote.js";
 export { registerRequestCommands } from "./request/index.js";
+export { registerScaSessionCommands } from "./sca-session/index.js";
 export { registerStatementCommands } from "./statement.js";
 export { registerOrgCommands } from "./org.js";
 export { registerAccountCommands } from "./account.js";

--- a/packages/cli/src/commands/sca-session/index.test.ts
+++ b/packages/cli/src/commands/sca-session/index.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { Command } from "commander";
+import { registerScaSessionCommands } from "./index.js";
+
+describe("registerScaSessionCommands", () => {
+  it("registers the sca-session command group with show and mock-decision subcommands", () => {
+    const program = new Command();
+    registerScaSessionCommands(program);
+
+    const scaSession = program.commands.find((c) => c.name() === "sca-session");
+    expect(scaSession).toBeDefined();
+
+    const subcommands = scaSession?.commands.map((c) => c.name());
+    expect(subcommands).toContain("show");
+    expect(subcommands).toContain("mock-decision");
+  });
+
+  it("show subcommand has token argument and SCA-related description", () => {
+    const program = new Command();
+    registerScaSessionCommands(program);
+
+    const scaSession = program.commands.find((c) => c.name() === "sca-session");
+    const show = scaSession?.commands.find((c) => c.name() === "show");
+    expect(show).toBeDefined();
+    expect(show?.description()).toMatch(/SCA session/i);
+
+    const usage = show?.usage() ?? "";
+    expect(usage).toContain("<token>");
+  });
+
+  it("mock-decision subcommand documents sandbox-only restriction in help", () => {
+    const program = new Command();
+    registerScaSessionCommands(program);
+
+    const scaSession = program.commands.find((c) => c.name() === "sca-session");
+    const mockDecision = scaSession?.commands.find((c) => c.name() === "mock-decision");
+    expect(mockDecision).toBeDefined();
+    expect(mockDecision?.description()).toMatch(/sandbox/i);
+
+    const usage = mockDecision?.usage() ?? "";
+    expect(usage).toContain("<token>");
+    expect(usage).toContain("<decision>");
+
+    // The configured "after" help text references the staging-token requirement.
+    // Capture rendered help output (which includes addHelpText) via a Help instance.
+    let helpOutput = "";
+    mockDecision?.configureOutput({
+      writeOut: (str) => {
+        helpOutput += str;
+      },
+      writeErr: (str) => {
+        helpOutput += str;
+      },
+    });
+    mockDecision?.outputHelp();
+    expect(helpOutput).toMatch(/staging-token|QONTOCTL_STAGING_TOKEN/);
+  });
+});

--- a/packages/cli/src/commands/sca-session/index.ts
+++ b/packages/cli/src/commands/sca-session/index.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { registerScaSessionMockDecisionCommand } from "./mock-decision.js";
+import { registerScaSessionShowCommand } from "./show.js";
+
+/**
+ * Register the `sca-session` command group with `show` and `mock-decision` subcommands.
+ *
+ * SCA (Strong Customer Authentication) sessions are issued when a write operation
+ * requires user approval on the Qonto mobile app. Use `show` to poll session status,
+ * and `mock-decision` to simulate user approval/denial in sandbox.
+ */
+export function registerScaSessionCommands(program: Command): void {
+  const scaSession = program.command("sca-session").description("Manage SCA (Strong Customer Authentication) sessions");
+
+  registerScaSessionShowCommand(scaSession);
+  registerScaSessionMockDecisionCommand(scaSession);
+}

--- a/packages/cli/src/commands/sca-session/mock-decision.test.ts
+++ b/packages/cli/src/commands/sca-session/mock-decision.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+
+vi.mock("../../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock("@qontoctl/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@qontoctl/core")>();
+  return {
+    ...actual,
+    resolveConfig: vi.fn(),
+    mockScaDecision: vi.fn(),
+  };
+});
+
+const { createClient } = await import("../../client.js");
+const createClientMock = vi.mocked(createClient);
+
+const { resolveConfig, mockScaDecision } = await import("@qontoctl/core");
+const resolveConfigMock = vi.mocked(resolveConfig);
+const mockScaDecisionMock = vi.mocked(mockScaDecision);
+
+const { registerScaSessionCommands } = await import("./index.js");
+
+function buildSandboxConfig() {
+  return {
+    config: {
+      apiKey: { organizationSlug: "test-org", secretKey: "test-secret" },
+      oauth: {
+        clientId: "client-id",
+        clientSecret: "client-secret",
+        stagingToken: "stg-token",
+      },
+    },
+    endpoint: "https://thirdparty-sandbox.staging.qonto.co",
+    warnings: [],
+  };
+}
+
+function buildProductionConfig() {
+  return {
+    config: {
+      apiKey: { organizationSlug: "test-org", secretKey: "test-secret" },
+    },
+    endpoint: "https://thirdparty.qonto.com",
+    warnings: [],
+  };
+}
+
+describe("sca-session mock-decision command", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    // createClient is treated as a return-anything stub; the SDK call is mocked separately.
+    createClientMock.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("applies allow decision in sandbox", async () => {
+    resolveConfigMock.mockResolvedValue(buildSandboxConfig());
+    mockScaDecisionMock.mockResolvedValue(undefined);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await program.parseAsync(["sca-session", "mock-decision", "tok-1", "allow"], { from: "user" });
+
+    expect(mockScaDecisionMock).toHaveBeenCalledWith(expect.anything(), "tok-1", "allow");
+    expect(stdoutSpy).toHaveBeenCalled();
+    const output = (stdoutSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(output).toContain('SCA mock decision "allow" applied to session tok-1.');
+  });
+
+  it("applies deny decision in sandbox", async () => {
+    resolveConfigMock.mockResolvedValue(buildSandboxConfig());
+    mockScaDecisionMock.mockResolvedValue(undefined);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await program.parseAsync(["sca-session", "mock-decision", "tok-2", "deny"], { from: "user" });
+
+    expect(mockScaDecisionMock).toHaveBeenCalledWith(expect.anything(), "tok-2", "deny");
+    const output = (stdoutSpy.mock.calls[0]?.[0] as string) ?? "";
+    expect(output).toContain('"deny"');
+  });
+
+  it("outputs json format when requested", async () => {
+    resolveConfigMock.mockResolvedValue(buildSandboxConfig());
+    mockScaDecisionMock.mockResolvedValue(undefined);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "json");
+    registerScaSessionCommands(program);
+
+    await program.parseAsync(["sca-session", "mock-decision", "tok-3", "allow"], { from: "user" });
+
+    const output = (stdoutSpy.mock.calls[0]?.[0] as string) ?? "";
+    const parsed = JSON.parse(output) as { token: string; decision: string; applied: boolean };
+    expect(parsed).toEqual({ token: "tok-3", decision: "allow", applied: true });
+  });
+
+  it("errors clearly when not in sandbox (no staging token)", async () => {
+    resolveConfigMock.mockResolvedValue(buildProductionConfig());
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await expect(
+      program.parseAsync(["sca-session", "mock-decision", "tok-4", "allow"], { from: "user" }),
+    ).rejects.toThrow(/sandbox/i);
+
+    expect(mockScaDecisionMock).not.toHaveBeenCalled();
+  });
+
+  it("errors clearly when oauth section has no staging token", async () => {
+    resolveConfigMock.mockResolvedValue({
+      config: {
+        oauth: { clientId: "id", clientSecret: "secret", accessToken: "tok" },
+      },
+      endpoint: "https://thirdparty.qonto.com",
+      warnings: [],
+    });
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await expect(
+      program.parseAsync(["sca-session", "mock-decision", "tok-5", "allow"], { from: "user" }),
+    ).rejects.toThrow(/staging-token|QONTOCTL_STAGING_TOKEN/);
+
+    expect(mockScaDecisionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid decision argument", async () => {
+    resolveConfigMock.mockResolvedValue(buildSandboxConfig());
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await expect(
+      program.parseAsync(["sca-session", "mock-decision", "tok-6", "maybe"], { from: "user" }),
+    ).rejects.toThrow(/Invalid decision/);
+
+    expect(mockScaDecisionMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates network/API errors from mockScaDecision", async () => {
+    resolveConfigMock.mockResolvedValue(buildSandboxConfig());
+    const apiError = new Error("API request failed: 500 Internal Server Error");
+    mockScaDecisionMock.mockRejectedValue(apiError);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerScaSessionCommands(program);
+
+    await expect(
+      program.parseAsync(["sca-session", "mock-decision", "tok-7", "allow"], { from: "user" }),
+    ).rejects.toThrow("API request failed");
+  });
+});

--- a/packages/cli/src/commands/sca-session/mock-decision.ts
+++ b/packages/cli/src/commands/sca-session/mock-decision.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { mockScaDecision, resolveConfig } from "@qontoctl/core";
+import { createClient } from "../../client.js";
+import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import type { GlobalOptions } from "../../options.js";
+
+const VALID_DECISIONS = ["allow", "deny"] as const;
+type ScaMockDecision = (typeof VALID_DECISIONS)[number];
+
+function isScaMockDecision(value: string): value is ScaMockDecision {
+  return (VALID_DECISIONS as readonly string[]).includes(value);
+}
+
+export function registerScaSessionMockDecisionCommand(parent: Command): void {
+  const cmd = parent
+    .command("mock-decision <token> <decision>")
+    .description("Simulate an SCA decision (sandbox only)")
+    .addHelpText(
+      "after",
+      "\nDecision must be one of: allow, deny.\n" +
+        "Only available in the sandbox environment. Configure a staging token via\n" +
+        "`oauth.staging-token` in your config or the `QONTOCTL_STAGING_TOKEN` env var.",
+    );
+  addInheritableOptions(cmd);
+  cmd.action(async (token: string, decision: string, _opts: unknown, action: Command) => {
+    if (!isScaMockDecision(decision)) {
+      throw new Error(`Invalid decision "${decision}". Must be one of: ${VALID_DECISIONS.join(", ")}.`);
+    }
+
+    const opts = resolveGlobalOptions<GlobalOptions>(action);
+
+    const { config } = await resolveConfig({ profile: opts.profile });
+    if (config.oauth?.stagingToken === undefined) {
+      throw new Error(
+        "sca-session mock-decision is only available in the sandbox environment. " +
+          "Configure `oauth.staging-token` in your config or set `QONTOCTL_STAGING_TOKEN`.",
+      );
+    }
+
+    const client = await createClient(opts);
+    await mockScaDecision(client, token, decision);
+
+    if (opts.output === "json" || opts.output === "yaml") {
+      process.stdout.write(formatOutput({ token, decision, applied: true }, opts.output) + "\n");
+    } else {
+      process.stdout.write(`SCA mock decision "${decision}" applied to session ${token}.\n`);
+    }
+  });
+}

--- a/packages/cli/src/commands/sca-session/show.test.ts
+++ b/packages/cli/src/commands/sca-session/show.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+
+vi.mock("../../client.js", async () => {
+  const { HttpClient } = await import("@qontoctl/core");
+  return {
+    createClient: vi.fn().mockResolvedValue(
+      new HttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "test-org:test-secret",
+      }),
+    ),
+  };
+});
+
+describe("sca-session show command", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let writtenOutput: string[];
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+
+    writtenOutput = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk: string | Uint8Array): boolean => {
+      writtenOutput.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runCommand(...args: string[]) {
+    vi.stubEnv("QONTOCTL_ORGANIZATION_SLUG", "test-org");
+    vi.stubEnv("QONTOCTL_SECRET_KEY", "test-secret");
+
+    const { createProgram } = await import("../../program.js");
+    const program = createProgram();
+    program.exitOverride();
+    await program.parseAsync(["node", "qontoctl", "sca-session", "show", ...args]);
+  }
+
+  it("fetches an SCA session by token (waiting status)", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "waiting" } }));
+
+    await runCommand("tok-abc", "--output", "json");
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sca/sessions/tok-abc");
+    expect(init.method).toBe("GET");
+
+    const parsed = JSON.parse(writtenOutput.join("")) as { token: string; status: string };
+    expect(parsed).toEqual({ token: "tok-abc", status: "waiting" });
+  });
+
+  it("returns allow status", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
+
+    await runCommand("tok-allow", "--output", "json");
+
+    const parsed = JSON.parse(writtenOutput.join("")) as { token: string; status: string };
+    expect(parsed.status).toBe("allow");
+  });
+
+  it("returns deny status", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "deny" } }));
+
+    await runCommand("tok-deny", "--output", "json");
+
+    const parsed = JSON.parse(writtenOutput.join("")) as { token: string; status: string };
+    expect(parsed.status).toBe("deny");
+  });
+
+  it("outputs yaml format", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "waiting" } }));
+
+    await runCommand("tok-yaml", "--output", "yaml");
+
+    const output = writtenOutput.join("");
+    expect(output).toContain("token: tok-yaml");
+    expect(output).toContain("status: waiting");
+  });
+
+  it("outputs table format with token and status columns", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "waiting" } }));
+
+    await runCommand("tok-table");
+
+    const output = writtenOutput.join("");
+    expect(output).toContain("tok-table");
+    expect(output).toContain("waiting");
+  });
+
+  it("encodes the token in the URL", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "waiting" } }));
+
+    await runCommand("tok/with&chars", "--output", "json");
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/sca/sessions/tok%2Fwith%26chars");
+  });
+
+  it("propagates network/API errors", async () => {
+    fetchSpy.mockImplementation(() =>
+      jsonResponse(
+        {
+          errors: [{ status: "404", code: "not_found", title: "Not Found", detail: "session not found" }],
+        },
+        { status: 404 },
+      ),
+    );
+
+    await expect(runCommand("tok-missing", "--output", "json")).rejects.toThrow();
+  });
+});

--- a/packages/cli/src/commands/sca-session/show.ts
+++ b/packages/cli/src/commands/sca-session/show.ts
@@ -25,9 +25,7 @@ export function registerScaSessionShowCommand(parent: Command): void {
     const session = await getScaSession(client, token);
 
     const data =
-      opts.output === "json" || opts.output === "yaml"
-        ? session
-        : [{ token: session.token, status: session.status }];
+      opts.output === "json" || opts.output === "yaml" ? session : [{ token: session.token, status: session.status }];
 
     process.stdout.write(formatOutput(data, opts.output) + "\n");
   });

--- a/packages/cli/src/commands/sca-session/show.ts
+++ b/packages/cli/src/commands/sca-session/show.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { Command } from "commander";
+import { getScaSession } from "@qontoctl/core";
+import { createClient } from "../../client.js";
+import { formatOutput } from "../../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import type { GlobalOptions } from "../../options.js";
+
+export function registerScaSessionShowCommand(parent: Command): void {
+  const show = parent
+    .command("show <token>")
+    .description("Show the current status of an SCA session")
+    .addHelpText(
+      "after",
+      "\nUse this after a 428 SCA-required response to poll the session token until status becomes\n" +
+        '"allow" or "deny". Token validity: 15 minutes.',
+    );
+  addInheritableOptions(show);
+  show.action(async (token: string, _opts: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<GlobalOptions>(cmd);
+    const client = await createClient(opts);
+
+    const session = await getScaSession(client, token);
+
+    const data =
+      opts.output === "json" || opts.output === "yaml"
+        ? session
+        : [{ token: session.token, status: session.status }];
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -54,13 +54,14 @@ describe("createProgram", () => {
       expect(names).toContain("recurring-transfer");
       expect(names).toContain("org");
       expect(names).toContain("account");
+      expect(names).toContain("sca-session");
       expect(names).toContain("supplier-invoice");
       expect(names).toContain("team");
       expect(names).toContain("insurance");
       expect(names).toContain("intl");
       expect(names).toContain("payment-link");
       expect(names).toContain("profile");
-      expect(program.commands).toHaveLength(16);
+      expect(program.commands).toHaveLength(17);
     });
 
     it("commands have descriptions", () => {
@@ -207,6 +208,16 @@ describe("createProgram", () => {
       expect(names).toContain("update");
       expect(names).toContain("close");
       expect(account.commands).toHaveLength(6);
+    });
+
+    it("registers expected sca-session subcommands", () => {
+      const program = createProgram();
+      const scaSession = findCommand(program, "sca-session");
+      const names = scaSession.commands.map((c) => c.name());
+
+      expect(names).toContain("show");
+      expect(names).toContain("mock-decision");
+      expect(scaSession.commands).toHaveLength(2);
     });
 
     it("registers expected supplier-invoice subcommands", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -19,6 +19,7 @@ import { registerRecurringTransferCommands } from "./commands/recurring-transfer
 import { registerOrgCommands } from "./commands/org.js";
 import { createPaymentLinkCommand } from "./commands/payment-link.js";
 import { registerAccountCommands } from "./commands/account.js";
+import { registerScaSessionCommands } from "./commands/sca-session/index.js";
 import { registerSupplierInvoiceCommands } from "./commands/supplier-invoice/index.js";
 import { createTeamCommand } from "./commands/team.js";
 import { registerAuthCommands } from "./commands/auth.js";
@@ -52,6 +53,7 @@ export function createProgram(): Command {
   registerRecurringTransferCommands(program);
   registerOrgCommands(program);
   registerAccountCommands(program);
+  registerScaSessionCommands(program);
   registerSupplierInvoiceCommands(program);
   program.addCommand(createTeamCommand());
   registerInsuranceCommands(program);

--- a/packages/qontoctl/src/cli.test.ts
+++ b/packages/qontoctl/src/cli.test.ts
@@ -77,6 +77,7 @@ describe("qontoctl CLI", () => {
       expect(names).toContain("recurring-transfer");
       expect(names).toContain("org");
       expect(names).toContain("account");
+      expect(names).toContain("sca-session");
       expect(names).toContain("supplier-invoice");
       expect(names).toContain("team");
       expect(names).toContain("intl");
@@ -98,7 +99,7 @@ describe("qontoctl CLI", () => {
       expect(names).toContain("insurance");
       expect(names).toContain("payment-link");
       expect(names).toContain("mcp");
-      expect(program.commands).toHaveLength(29);
+      expect(program.commands).toHaveLength(30);
     });
 
     it("commands have descriptions", () => {


### PR DESCRIPTION
## Summary

Expose the existing `@qontoctl/core` SCA session APIs (`getScaSession`, `mockScaDecision`) through the CLI:

- `qontoctl sca-session show <token>` — wraps `getScaSession`; outputs status (`waiting` / `allow` / `deny`) in the chosen output format (`table` / `json` / `yaml` / `csv`).
- `qontoctl sca-session mock-decision <token> <allow|deny>` — wraps `mockScaDecision`; **errors clearly when not in sandbox** (no `oauth.staging-token` config / no `QONTOCTL_STAGING_TOKEN` env var). Validates the decision argument before any network call.
- Both subcommands respect the global `--profile`, `--output`, `--verbose`, `--debug` options via the inherited-options pattern.
- Help text references the SCA flow context and the sandbox-only restriction.

Closes #431.

## Acceptance criteria

- [x] `sca-session show <token>` wraps `getScaSession`; outputs status in chosen format
- [x] `sca-session mock-decision <token> <allow|deny>` wraps `mockScaDecision`; errors clearly when not in sandbox
- [x] Subcommands registered in `packages/cli/src/commands/index.ts` and `packages/cli/src/program.ts`
- [x] Unit tests: happy path, sandbox-detection error path, network/API error path
- [x] Help text references usage in SCA flow

## Test plan

- [x] `pnpm build` — green (5/5 packages)
- [x] `pnpm lint` — green (5/5 packages)
- [x] `pnpm test` — green (642 passing in `@qontoctl/cli`, including 16 new tests across `show`, `mock-decision`, `index`)
- [x] `pnpm license-check` — green
- [ ] `pnpm test:e2e` — **could not run locally**: the worktree's `.qontoctl.yaml` has an expired OAuth refresh token (server returned `invalid_grant: refresh token expired`); 147 tests across all unrelated domains hit the same auth error. Issue #434 (E2E coverage) is intentionally blocked on this PR per the umbrella scope. The CI `e2e-sandbox` job runs against the sandbox with fresh secrets after merge.

## Notes

- This issue is **independent** in the SCA-continuation umbrella (#428); used by #434 (E2E coverage) and #438 (PSD2 verification) but does not depend on them.
- Scope follows AC literally: only `getScaSession` and `mockScaDecision` are wrapped. `pollScaSession` is exposed by the existing `executeWithCliSca` wrapper used by transfer/recurring-transfer cancel; a standalone `wait` subcommand is not in scope here.
- Sandbox detection delegates to `resolveConfig` so the same env-var precedence as the rest of the CLI applies (file `oauth.staging-token` or `QONTOCTL_STAGING_TOKEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)