### PR TITLE
(feat) add MCP sca_session_show and sca_session_mock_decision tools

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -292,6 +292,56 @@ describe("HttpClient", () => {
     });
   });
 
+  describe("staging token", () => {
+    it("isSandbox is false when no staging token is configured", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      expect(client.isSandbox).toBe(false);
+    });
+
+    it("isSandbox is true when a staging token is configured", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+      });
+
+      expect(client.isSandbox).toBe(true);
+    });
+
+    it("sends the staging token header when configured", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Qonto-Staging-Token"]).toBe("tok-staging");
+    });
+
+    it("omits the staging token header when not configured", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      await client.get("/v2/organizations");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["X-Qonto-Staging-Token"]).toBeUndefined();
+    });
+  });
+
   describe("idempotency keys", () => {
     const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -222,6 +222,17 @@ export class HttpClient {
   }
 
   /**
+   * Whether this client is configured for the Qonto sandbox environment.
+   *
+   * True when a staging token is set, which routes requests through the
+   * sandbox host via the `X-Qonto-Staging-Token` header. Sandbox-only
+   * operations (e.g. `mockScaDecision`) should gate on this flag.
+   */
+  get isSandbox(): boolean {
+    return this.stagingToken !== undefined;
+  }
+
+  /**
    * Sends an HTTP request and parses the response as JSON.
    *
    * **Trust boundary**: The parsed JSON is cast to `T` without runtime validation.

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -89,6 +89,8 @@ const EXPECTED_TOOLS = [
   "request_create_flash_card",
   "request_create_virtual_card",
   "request_create_multi_transfer",
+  "sca_session_show",
+  "sca_session_mock_decision",
   "supplier_invoice_list",
   "supplier_invoice_show",
   "supplier_invoice_bulk_create",

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -138,7 +138,9 @@ describe("createServer", () => {
       expect(toolNames).toContain("payment_link_methods");
       expect(toolNames).toContain("payment_link_connect");
       expect(toolNames).toContain("payment_link_connection_status");
-      expect(tools).toHaveLength(122);
+      expect(toolNames).toContain("sca_session_show");
+      expect(toolNames).toContain("sca_session_mock_decision");
+      expect(tools).toHaveLength(124);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -26,6 +26,7 @@ import {
   registerQuoteTools,
   registerRecurringTransferTools,
   registerRequestTools,
+  registerScaSessionTools,
   registerStatementTools,
   registerSupplierInvoiceTools,
   registerTeamTools,
@@ -74,6 +75,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerQuoteTools(server, getClient);
   registerRecurringTransferTools(server, getClient);
   registerRequestTools(server, getClient);
+  registerScaSessionTools(server, getClient);
   registerStatementTools(server, getClient);
   registerSupplierInvoiceTools(server, getClient);
   registerTeamTools(server, getClient);

--- a/packages/mcp/src/testing/mcp-helpers.ts
+++ b/packages/mcp/src/testing/mcp-helpers.ts
@@ -16,13 +16,19 @@ export interface McpTestContext {
 /**
  * Set up an in-memory MCP client + server pair for integration testing.
  * Stubs global `fetch` with the provided spy.
+ *
+ * Pass `stagingToken` to construct the underlying HttpClient in sandbox mode,
+ * which flips `client.isSandbox` and routes requests through the sandbox host.
  */
 export async function connectInMemory(
   fetchSpy: ReturnType<typeof import("vitest").vi.fn>,
-  options?: { maxRetries?: number },
+  options?: { maxRetries?: number; stagingToken?: string },
 ): Promise<McpTestContext> {
   const httpClient = new HttpClient({
-    baseUrl: "https://thirdparty.qonto.com",
+    baseUrl:
+      options?.stagingToken !== undefined
+        ? "https://thirdparty-sandbox.staging.qonto.co"
+        : "https://thirdparty.qonto.com",
     authorization: "slug:secret",
     ...options,
   });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -22,6 +22,7 @@ export { registerPaymentLinkTools } from "./payment-link.js";
 export { registerQuoteTools } from "./quote.js";
 export { registerRecurringTransferTools } from "./recurring-transfer.js";
 export { registerRequestTools } from "./request.js";
+export { registerScaSessionTools } from "./sca-session.js";
 export { registerStatementTools } from "./statement.js";
 export { registerSupplierInvoiceTools } from "./supplier-invoice.js";
 export { registerTransactionTools } from "./transactions.js";

--- a/packages/mcp/src/tools/sca-session.test.ts
+++ b/packages/mcp/src/tools/sca-session.test.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { connectInMemory } from "../testing/mcp-helpers.js";
+
+describe("SCA session MCP tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("sca_session_show", () => {
+    let mcpClient: Client;
+
+    beforeEach(async () => {
+      ({ mcpClient } = await connectInMemory(fetchSpy));
+    });
+
+    it("returns the session status as JSON text content", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "waiting" } }));
+
+      const result = await mcpClient.callTool({
+        name: "sca_session_show",
+        arguments: { token: "tok-123" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const first = content[0] as { type: string; text: string };
+      expect(first.type).toBe("text");
+      const parsed = JSON.parse(first.text) as { token: string; status: string };
+      expect(parsed).toEqual({ token: "tok-123", status: "waiting" });
+    });
+
+    it("calls GET /v2/sca/sessions/<token>", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+
+      await mcpClient.callTool({
+        name: "sca_session_show",
+        arguments: { token: "tok-456" },
+      });
+
+      const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/sca/sessions/tok-456");
+      expect(init.method).toBe("GET");
+    });
+
+    it("propagates each session status (waiting/allow/deny)", async () => {
+      const statuses = ["waiting", "allow", "deny"] as const;
+      for (const status of statuses) {
+        fetchSpy.mockReturnValueOnce(jsonResponse({ sca_session: { status } }));
+
+        const result = await mcpClient.callTool({
+          name: "sca_session_show",
+          arguments: { token: `tok-${status}` },
+        });
+
+        const content = result.content as { type: string; text: string }[];
+        const first = content[0] as { type: string; text: string };
+        const parsed = JSON.parse(first.text) as { status: string };
+        expect(parsed.status).toBe(status);
+      }
+    });
+
+    it("formats Qonto API errors via the shared error wrapper", async () => {
+      fetchSpy.mockReturnValue(
+        jsonResponse({ errors: [{ code: "not_found", detail: "SCA session not found" }] }, { status: 404 }),
+      );
+
+      const result = await mcpClient.callTool({
+        name: "sca_session_show",
+        arguments: { token: "tok-missing" },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as { type: string; text: string }[];
+      const first = content[0] as { type: string; text: string };
+      expect(first.text).toContain("Qonto API error (HTTP 404)");
+      expect(first.text).toContain("not_found");
+    });
+  });
+
+  describe("sca_session_mock_decision", () => {
+    describe("in sandbox mode", () => {
+      let mcpClient: Client;
+
+      beforeEach(async () => {
+        ({ mcpClient } = await connectInMemory(fetchSpy, { stagingToken: "tok-staging" }));
+      });
+
+      it("posts the decision and returns a confirmation payload", async () => {
+        fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+
+        const result = await mcpClient.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token: "tok-mock", decision: "allow" },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const content = result.content as { type: string; text: string }[];
+        const first = content[0] as { type: string; text: string };
+        const parsed = JSON.parse(first.text) as { token: string; decision: string; mocked: boolean };
+        expect(parsed).toEqual({ token: "tok-mock", decision: "allow", mocked: true });
+      });
+
+      it("calls POST /v2/sca/sessions/mock/<token>/decision with the decision body", async () => {
+        fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+
+        await mcpClient.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token: "tok-mock", decision: "deny" },
+        });
+
+        const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+        expect(url.pathname).toBe("/v2/sca/sessions/mock/tok-mock/decision");
+        expect(init.method).toBe("POST");
+        const body = JSON.parse(init.body as string) as Record<string, unknown>;
+        expect(body).toEqual({ decision: "deny" });
+      });
+
+      it("formats Qonto API errors via the shared error wrapper", async () => {
+        fetchSpy.mockReturnValue(
+          jsonResponse({ errors: [{ code: "expired", detail: "SCA session expired" }] }, { status: 410 }),
+        );
+
+        const result = await mcpClient.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token: "tok-expired", decision: "allow" },
+        });
+
+        expect(result.isError).toBe(true);
+        const content = result.content as { type: string; text: string }[];
+        const first = content[0] as { type: string; text: string };
+        expect(first.text).toContain("Qonto API error (HTTP 410)");
+        expect(first.text).toContain("expired");
+      });
+    });
+
+    describe("outside sandbox mode", () => {
+      let mcpClient: Client;
+
+      beforeEach(async () => {
+        ({ mcpClient } = await connectInMemory(fetchSpy));
+      });
+
+      it("returns an error result without calling the API", async () => {
+        const result = await mcpClient.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token: "tok-mock", decision: "allow" },
+        });
+
+        expect(result.isError).toBe(true);
+        const content = result.content as { type: string; text: string }[];
+        const first = content[0] as { type: string; text: string };
+        expect(first.text).toContain("only available in the Qonto sandbox environment");
+        expect(first.text).toContain("QONTOCTL_STAGING_TOKEN");
+        expect(fetchSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/mcp/src/tools/sca-session.ts
+++ b/packages/mcp/src/tools/sca-session.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { HttpClient } from "@qontoctl/core";
+import { getScaSession, mockScaDecision } from "@qontoctl/core";
+import { withClient } from "../errors.js";
+
+export function registerScaSessionTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
+  server.registerTool(
+    "sca_session_show",
+    {
+      description:
+        "Show the status of a Strong Customer Authentication (SCA) session. " +
+        "Use this to poll an SCA session token returned by a previous tool call that triggered an SCA challenge. " +
+        "Returns one of: `waiting` (the user has not yet responded), `allow` (approved — retry the original request), " +
+        "or `deny` (rejected). Tokens expire after 15 minutes.",
+      inputSchema: {
+        token: z.string().describe("SCA session token from a prior SCA-required response"),
+      },
+    },
+    async ({ token }) =>
+      withClient(getClient, async (client) => {
+        const session = await getScaSession(client, token);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(session, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+
+  server.registerTool(
+    "sca_session_mock_decision",
+    {
+      description:
+        "Simulate a user SCA decision in the Qonto sandbox environment (testing only). " +
+        "Use after triggering an SCA-required operation in sandbox to bypass the mobile-app approval flow. " +
+        "Returns an error when the server is not configured for sandbox mode " +
+        "(no `oauth.staging-token` / `QONTOCTL_STAGING_TOKEN`).",
+      inputSchema: {
+        token: z.string().describe("SCA session token to resolve"),
+        decision: z.enum(["allow", "deny"]).describe("Simulated user decision"),
+      },
+    },
+    async ({ token, decision }) =>
+      withClient(getClient, async (client) => {
+        if (!client.isSandbox) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text:
+                  "Mocking SCA decisions is only available in the Qonto sandbox environment. " +
+                  "Configure `oauth.staging-token` in your config file or set the `QONTOCTL_STAGING_TOKEN` " +
+                  "environment variable to enable sandbox mode.",
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        await mockScaDecision(client, token, decision);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ token, decision, mocked: true }, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+}


### PR DESCRIPTION
Closes #432.

Surfaces the SCA session lifecycle to MCP callers so an LLM that receives an SCA-required response can poll for status (and, in sandbox, simulate the user decision) without leaving the MCP surface.

## Changes

- **`@qontoctl/core`** — add `HttpClient.isSandbox` getter (read-only, derived from existing `stagingToken` constructor option) so sandbox-only tools can gate at call time. No behavioral change. Adds 4 tests covering the getter + the corresponding `X-Qonto-Staging-Token` header behavior (small pre-existing test gap).
- **`@qontoctl/mcp`** — new `tools/sca-session.ts`:
  - `sca_session_show` wraps `getScaSession`, returns `{ token, status }` JSON (`waiting` / `allow` / `deny`).
  - `sca_session_mock_decision` wraps `mockScaDecision`. Returns a clear `isError: true` text result naming `oauth.staging-token` / `QONTOCTL_STAGING_TOKEN` when the server is not in sandbox mode — no API call is made.
- Wire `registerScaSessionTools` through `tools/index.ts` and `server.ts`.
- Bump `server.test.ts` tool count `122` → `124` with explicit containment assertions for both new tools.
- Extend `connectInMemory` test helper with optional `stagingToken` so sandbox-only behavior can be exercised in unit tests (backward compatible).

## Acceptance criteria

- [x] `mcp__qontoctl__sca_session_show` registered with input `{ token: string }`, returns SCA session status as text.
- [x] `mcp__qontoctl__sca_session_mock_decision` registered with input `{ token: string, decision: 'allow' | 'deny' }`. Returns a clear error in non-sandbox mode (without calling the API).
- [x] Both tools live in `packages/mcp/src/tools/sca-session.ts`, registered via `packages/mcp/src/server.ts`.
- [x] Unit tests: happy path, error path, sandbox gating (8 tests in `tools/sca-session.test.ts`).
- [x] Tool `description` strings explain when to use, with explicit reference to the SCA-required response trigger.

## Test plan

- [x] `pnpm build` — green (5/5 packages)
- [x] `pnpm lint` — green (8/8 packages)
- [x] `pnpm license-check` — green (96 production deps)
- [x] `pnpm test` — 1770 unit tests passing (core 833, mcp 295 incl. sca-session 8, cli 624, qontoctl 18)
- [ ] CI green (this PR)

## Notes

- E2E coverage for the SCA tool flow is **not in scope** here — tracked separately as #434 (currently blocked).
- The existing `formatScaRequiredResponse` in `packages/mcp/src/errors.ts` still emits the legacy "Poll GET /v2/sca/sessions/{token}" hint; updating it to recommend the new tools is **#433's scope**.
- Independent of the CLI sister tools in #431.