### PR TITLE
(fix) preserve idempotency key across SCA retry in executeWithSca (#429)

### DIFF
--- a/packages/cli/src/commands/account.test.ts
+++ b/packages/cli/src/commands/account.test.ts
@@ -28,8 +28,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -110,16 +110,16 @@ export function registerAccountCommands(program: Command): void {
 
     const bankAccount = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         createBankAccount(
           client,
           { name: opts.name },
           {
-            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            idempotencyKey,
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data =
@@ -158,12 +158,12 @@ export function registerAccountCommands(program: Command): void {
 
     const bankAccount = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         updateBankAccount(client, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data =
@@ -205,12 +205,12 @@ export function registerAccountCommands(program: Command): void {
 
     await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         closeBankAccount(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/add.ts
+++ b/packages/cli/src/commands/beneficiary/add.ts
@@ -54,12 +54,12 @@ export function registerBeneficiaryAddCommand(parent: Command): void {
 
     const b = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createBeneficiary(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/beneficiary/trust.ts
+++ b/packages/cli/src/commands/beneficiary/trust.ts
@@ -19,12 +19,12 @@ export function registerBeneficiaryTrustCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         trustBeneficiaries(httpClient, ids, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/untrust.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.ts
@@ -19,12 +19,12 @@ export function registerBeneficiaryUntrustCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         untrustBeneficiaries(httpClient, ids, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/update.ts
+++ b/packages/cli/src/commands/beneficiary/update.ts
@@ -53,12 +53,12 @@ export function registerBeneficiaryUpdateCommand(parent: Command): void {
 
     const b = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         updateBeneficiary(httpClient, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/bulk-transfer/create.test.ts
+++ b/packages/cli/src/commands/bulk-transfer/create.test.ts
@@ -15,8 +15,12 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/bulk-transfer/create.ts
+++ b/packages/cli/src/commands/bulk-transfer/create.ts
@@ -43,16 +43,16 @@ export function registerBulkTransferCreateCommand(parent: Command): void {
 
     const bulkTransfer = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createBulkTransfer(
           httpClient,
           { transfers },
           {
-            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            idempotencyKey,
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? bulkTransfer : [toTableRow(bulkTransfer)];

--- a/packages/cli/src/commands/card/card.test.ts
+++ b/packages/cli/src/commands/card/card.test.ts
@@ -14,8 +14,12 @@ vi.mock("../../client.js", () => ({
 }));
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/card/create.ts
+++ b/packages/cli/src/commands/card/create.ts
@@ -147,12 +147,12 @@ export function registerCardCreateCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         createCard(client, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -177,12 +177,12 @@ export function registerCardBulkCreateCommand(parent: Command): void {
 
     const result = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         bulkCreateCards(client, cards, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data =

--- a/packages/cli/src/commands/card/discard.ts
+++ b/packages/cli/src/commands/card/discard.ts
@@ -30,12 +30,12 @@ export function registerCardDiscardCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         discardCard(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/lock.ts
+++ b/packages/cli/src/commands/card/lock.ts
@@ -24,12 +24,12 @@ export function registerCardLockCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         lockCard(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -46,12 +46,12 @@ export function registerCardUnlockCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         unlockCard(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/report.ts
+++ b/packages/cli/src/commands/card/report.ts
@@ -35,12 +35,12 @@ export function registerCardReportLostCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         reportCardLost(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -69,12 +69,12 @@ export function registerCardReportStolenCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         reportCardStolen(client, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/update-limits.ts
+++ b/packages/cli/src/commands/card/update-limits.ts
@@ -78,12 +78,12 @@ export function registerCardUpdateLimitsCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         updateCardLimits(client, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/update-nickname.ts
+++ b/packages/cli/src/commands/card/update-nickname.ts
@@ -24,12 +24,12 @@ export function registerCardUpdateNicknameCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         updateCardNickname(client, id, opts.nickname, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/update-options.ts
+++ b/packages/cli/src/commands/card/update-options.ts
@@ -44,12 +44,12 @@ export function registerCardUpdateOptionsCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         updateCardOptions(client, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/update-restrictions.ts
+++ b/packages/cli/src/commands/card/update-restrictions.ts
@@ -46,12 +46,12 @@ export function registerCardUpdateRestrictionsCommand(parent: Command): void {
 
     const card = await executeWithCliSca(
       client,
-      (scaSessionToken) =>
+      ({ scaSessionToken, idempotencyKey }) =>
         updateCardRestrictions(client, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/intl-beneficiary/add.test.ts
+++ b/packages/cli/src/commands/intl-beneficiary/add.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/intl-beneficiary/add.ts
+++ b/packages/cli/src/commands/intl-beneficiary/add.ts
@@ -60,12 +60,12 @@ export function registerIntlBeneficiaryAddCommand(parent: Command): void {
 
     const b = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createIntlBeneficiary(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-beneficiary/remove.test.ts
+++ b/packages/cli/src/commands/intl-beneficiary/remove.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/intl-beneficiary/remove.ts
+++ b/packages/cli/src/commands/intl-beneficiary/remove.ts
@@ -33,12 +33,12 @@ export function registerIntlBeneficiaryRemoveCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         removeIntlBeneficiary(httpClient, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/intl-beneficiary/update.test.ts
+++ b/packages/cli/src/commands/intl-beneficiary/update.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/intl-beneficiary/update.ts
+++ b/packages/cli/src/commands/intl-beneficiary/update.ts
@@ -51,12 +51,12 @@ export function registerIntlBeneficiaryUpdateCommand(parent: Command): void {
 
     const b = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         updateIntlBeneficiary(httpClient, id, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-transfer/create.test.ts
+++ b/packages/cli/src/commands/intl-transfer/create.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/intl-transfer/create.ts
+++ b/packages/cli/src/commands/intl-transfer/create.ts
@@ -57,12 +57,12 @@ export function registerIntlTransferCreateCommand(parent: Command): void {
 
     const transfer = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createIntlTransfer(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? transfer : [toTableRow(transfer)];

--- a/packages/cli/src/commands/recurring-transfer/cancel.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/cancel.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/recurring-transfer/cancel.ts
+++ b/packages/cli/src/commands/recurring-transfer/cancel.ts
@@ -33,12 +33,12 @@ export function registerRecurringTransferCancelCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         cancelRecurringTransfer(httpClient, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/recurring-transfer/create.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/create.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/recurring-transfer/create.ts
+++ b/packages/cli/src/commands/recurring-transfer/create.ts
@@ -69,12 +69,12 @@ export function registerRecurringTransferCreateCommand(parent: Command): void {
 
     const recurringTransfer = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createRecurringTransfer(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? recurringTransfer : [toTableRow(recurringTransfer)];

--- a/packages/cli/src/commands/request/approve.test.ts
+++ b/packages/cli/src/commands/request/approve.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/request/approve.ts
+++ b/packages/cli/src/commands/request/approve.ts
@@ -33,18 +33,18 @@ export function registerRequestApproveCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         approveRequest(
           httpClient,
           opts.type,
           id,
           opts.debitIban !== undefined ? { debit_iban: opts.debitIban } : undefined,
           {
-            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            idempotencyKey,
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/request/create-flash-card.test.ts
+++ b/packages/cli/src/commands/request/create-flash-card.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/request/create-flash-card.ts
+++ b/packages/cli/src/commands/request/create-flash-card.ts
@@ -46,12 +46,12 @@ export function registerRequestCreateFlashCardCommand(parent: Command): void {
 
     const request = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createFlashCardRequest(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/create-multi-transfer.test.ts
+++ b/packages/cli/src/commands/request/create-multi-transfer.test.ts
@@ -21,8 +21,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/request/create-multi-transfer.ts
+++ b/packages/cli/src/commands/request/create-multi-transfer.ts
@@ -61,12 +61,12 @@ export function registerRequestCreateMultiTransferCommand(parent: Command): void
 
     const request = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createMultiTransferRequest(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/create-virtual-card.test.ts
+++ b/packages/cli/src/commands/request/create-virtual-card.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/request/create-virtual-card.ts
+++ b/packages/cli/src/commands/request/create-virtual-card.ts
@@ -50,12 +50,12 @@ export function registerRequestCreateVirtualCardCommand(parent: Command): void {
 
     const request = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createVirtualCardRequest(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/decline.test.ts
+++ b/packages/cli/src/commands/request/decline.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/request/decline.ts
+++ b/packages/cli/src/commands/request/decline.ts
@@ -33,18 +33,18 @@ export function registerRequestDeclineCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         declineRequest(
           httpClient,
           opts.type,
           id,
           { declined_note: opts.reason },
           {
-            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            idempotencyKey,
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/transfer/bulk-verify-payee.test.ts
+++ b/packages/cli/src/commands/transfer/bulk-verify-payee.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/transfer/bulk-verify-payee.ts
+++ b/packages/cli/src/commands/transfer/bulk-verify-payee.ts
@@ -74,12 +74,12 @@ export function registerTransferBulkVerifyPayeeCommand(parent: Command): void {
 
     const results = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         bulkVerifyPayee(httpClient, entries, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data =

--- a/packages/cli/src/commands/transfer/cancel.test.ts
+++ b/packages/cli/src/commands/transfer/cancel.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/transfer/cancel.ts
+++ b/packages/cli/src/commands/transfer/cancel.ts
@@ -33,12 +33,12 @@ export function registerTransferCancelCommand(parent: Command): void {
 
     await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         cancelTransfer(httpClient, id, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/transfer/create.test.ts
+++ b/packages/cli/src/commands/transfer/create.test.ts
@@ -20,8 +20,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -135,12 +135,12 @@ export function registerTransferCreateCommand(parent: Command): void {
 
     const transfer = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         createTransfer(httpClient, params, {
-          ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+          idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? transfer : [toTableRow(transfer)];

--- a/packages/cli/src/commands/transfer/verify-payee.test.ts
+++ b/packages/cli/src/commands/transfer/verify-payee.test.ts
@@ -18,8 +18,12 @@ vi.mock("@qontoctl/core", async (importOriginal) => {
 });
 
 vi.mock("../../sca.js", () => ({
-  executeWithCliSca: vi.fn((_client: unknown, operation: (scaSessionToken?: string) => Promise<unknown>) =>
-    operation(undefined),
+  executeWithCliSca: vi.fn(
+    (
+      _client: unknown,
+      operation: (ctx: { scaSessionToken?: string; idempotencyKey: string }) => Promise<unknown>,
+      options?: { idempotencyKey?: string },
+    ) => operation({ idempotencyKey: options?.idempotencyKey ?? "test-idempotency-key" }),
   ),
 }));
 

--- a/packages/cli/src/commands/transfer/verify-payee.ts
+++ b/packages/cli/src/commands/transfer/verify-payee.ts
@@ -36,16 +36,16 @@ export function registerTransferVerifyPayeeCommand(parent: Command): void {
 
     const result = await executeWithCliSca(
       httpClient,
-      async (scaSessionToken) =>
+      async ({ scaSessionToken, idempotencyKey }) =>
         verifyPayee(
           httpClient,
           { iban: opts.iban, beneficiary_name: opts.name },
           {
-            ...(opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : {}),
+            idempotencyKey,
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true },
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? result : [toTableRow(result)];

--- a/packages/cli/src/sca.test.ts
+++ b/packages/cli/src/sca.test.ts
@@ -172,16 +172,61 @@ describe("executeWithCliSca", () => {
 
     const result = await executeWithCliSca(
       client,
-      async (scaToken) => {
+      async ({ scaSessionToken }) => {
         callCount++;
         if (callCount === 1) {
           throw new QontoScaRequiredError("tok-cli-5");
         }
-        return `result-with-${scaToken ?? "none"}`;
+        return `result-with-${scaSessionToken ?? "none"}`;
       },
       { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
     );
 
     expect(result).toBe("result-with-tok-cli-5");
+  });
+
+  it("forwards a stable idempotency key across both attempts", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
+    const mockSpin = createMockSpinner();
+    const seenKeys: string[] = [];
+    let called = false;
+
+    await executeWithCliSca(
+      client,
+      async ({ idempotencyKey }) => {
+        seenKeys.push(idempotencyKey);
+        if (!called) {
+          called = true;
+          throw new QontoScaRequiredError("tok-cli-idem");
+        }
+        return "ok";
+      },
+      { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+    );
+
+    expect(seenKeys).toHaveLength(2);
+    expect(seenKeys[0]).toBe(seenKeys[1]);
+  });
+
+  it("forwards a supplied idempotency key to the operation", async () => {
+    fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
+    const mockSpin = createMockSpinner();
+    const seenKeys: string[] = [];
+    let called = false;
+
+    await executeWithCliSca(
+      client,
+      async ({ idempotencyKey }) => {
+        seenKeys.push(idempotencyKey);
+        if (!called) {
+          called = true;
+          throw new QontoScaRequiredError("tok-cli-idem-supplied");
+        }
+        return "ok";
+      },
+      { poll: { sleep: noopSleep }, createSpinner: () => mockSpin, idempotencyKey: "cli-supplied-key" },
+    );
+
+    expect(seenKeys).toEqual(["cli-supplied-key", "cli-supplied-key"]);
   });
 });

--- a/packages/cli/src/sca.ts
+++ b/packages/cli/src/sca.ts
@@ -2,7 +2,13 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { spinner, type SpinnerResult } from "@clack/prompts";
-import { executeWithSca, ScaTimeoutError, type HttpClient, type PollScaSessionOptions } from "@qontoctl/core";
+import {
+  executeWithSca,
+  ScaTimeoutError,
+  type ExecuteWithScaContext,
+  type HttpClient,
+  type PollScaSessionOptions,
+} from "@qontoctl/core";
 
 export interface CliScaOptions {
   readonly verbose?: boolean | undefined;
@@ -10,6 +16,11 @@ export interface CliScaOptions {
   readonly poll?: PollScaSessionOptions | undefined;
   /** Spinner factory for testing. Defaults to clack's spinner(). */
   readonly createSpinner?: (() => SpinnerResult) | undefined;
+  /**
+   * Idempotency key forwarded to the operation. If not supplied, a UUID is
+   * generated once and reused across both attempts (initial 428 + SCA retry).
+   */
+  readonly idempotencyKey?: string | undefined;
 }
 
 /**
@@ -21,14 +32,20 @@ export interface CliScaOptions {
  * - On approval, stops the spinner with a success message
  * - On timeout, stops the spinner with an error message
  *
+ * The operation receives a context carrying a stable idempotency key (shared
+ * across the initial 428 attempt and the post-SCA retry) and an optional SCA
+ * session token (set on retry). Callers MUST forward `context.idempotencyKey`
+ * to the underlying API call so both wire requests carry the same
+ * `X-Qonto-Idempotency-Key` header.
+ *
  * @param client - HttpClient used for SCA session polling
- * @param operation - Function that performs the API operation. Called with an optional
- *   SCA session token for retry.
- * @param options - Verbose flag and polling options
+ * @param operation - Function that performs the API operation. Receives a context
+ *   with stable idempotency key and optional SCA session token (on retry).
+ * @param options - Verbose flag, polling options, and optional idempotency key
  */
 export async function executeWithCliSca<T>(
   client: HttpClient,
-  operation: (scaSessionToken?: string) => Promise<T>,
+  operation: (context: ExecuteWithScaContext) => Promise<T>,
   options?: CliScaOptions,
 ): Promise<T> {
   let s: SpinnerResult | undefined;
@@ -47,6 +64,7 @@ export async function executeWithCliSca<T>(
         s?.stop("SCA approved");
       },
       poll: options?.poll,
+      idempotencyKey: options?.idempotencyKey,
     });
   } catch (error: unknown) {
     if (s !== undefined) {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -66,7 +66,7 @@ const org = await getOrganization(client);
 
 - **`getScaSession(client, scaId)`** — retrieve an SCA session by ID
 - **`pollScaSession(client, scaId, options?)`** — poll an SCA session until completion
-- **`executeWithSca(fn, callbacks, options?)`** — execute an API call with SCA handling
+- **`executeWithSca(client, operation, options?)`** — execute an API call with SCA handling. The `operation` callback receives an `ExecuteWithScaContext` carrying a stable `idempotencyKey` (shared across the initial 428 attempt and the post-SCA retry) and an optional `scaSessionToken` (set on retry); callers MUST forward `context.idempotencyKey` to the underlying request so both wire attempts emit the same `X-Qonto-Idempotency-Key`. Supply `options.idempotencyKey` to pin the value (e.g. when the user passes `--idempotency-key`); otherwise a UUID is generated once and reused.
 - **`mockScaDecision(client, scaId, decision)`** — mock an SCA decision (sandbox only)
 - **`ScaDeniedError`** — error when SCA is denied by the user
 - **`ScaTimeoutError`** — error when SCA polling times out

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -529,5 +529,6 @@ export type {
   ScaSessionStatus,
   PollScaSessionOptions,
   ExecuteWithScaCallbacks,
+  ExecuteWithScaContext,
   ExecuteWithScaOptions,
 } from "./sca/index.js";

--- a/packages/core/src/sca/index.ts
+++ b/packages/core/src/sca/index.ts
@@ -5,4 +5,9 @@ export type { ScaMethod, ScaSession, ScaSessionStatus } from "./types.js";
 export { ScaDeniedError, ScaTimeoutError } from "./errors.js";
 export { ScaSessionSchema, ScaSessionStatusSchema } from "./schemas.js";
 export { getScaSession, mockScaDecision, pollScaSession, type PollScaSessionOptions } from "./sca-service.js";
-export { executeWithSca, type ExecuteWithScaCallbacks, type ExecuteWithScaOptions } from "./sca-handler.js";
+export {
+  executeWithSca,
+  type ExecuteWithScaCallbacks,
+  type ExecuteWithScaContext,
+  type ExecuteWithScaOptions,
+} from "./sca-handler.js";

--- a/packages/core/src/sca/sca-handler.test.ts
+++ b/packages/core/src/sca/sca-handler.test.ts
@@ -55,12 +55,12 @@ describe("executeWithSca", () => {
 
     const result = await executeWithSca(
       client,
-      async (scaToken) => {
+      async ({ scaSessionToken }) => {
         callCount++;
         if (callCount === 1) {
           throw new QontoScaRequiredError("tok-sca-1");
         }
-        return `retried-with-${scaToken ?? "none"}`;
+        return `retried-with-${scaSessionToken ?? "none"}`;
       },
       { poll: { sleep: noopSleep } },
     );
@@ -152,5 +152,124 @@ describe("executeWithSca", () => {
     );
 
     expect(callOrder).toEqual(["approved", "retry"]);
+  });
+
+  it("threads the same idempotency key to both attempts when none is supplied", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+    const seenKeys: string[] = [];
+    let called = false;
+
+    await executeWithSca(
+      client,
+      async ({ idempotencyKey }) => {
+        seenKeys.push(idempotencyKey);
+        if (!called) {
+          called = true;
+          throw new QontoScaRequiredError("tok-idem-auto");
+        }
+        return "ok";
+      },
+      { poll: { sleep: noopSleep } },
+    );
+
+    expect(seenKeys).toHaveLength(2);
+    expect(seenKeys[0]).toBe(seenKeys[1]);
+    expect(seenKeys[0]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  it("uses the supplied idempotency key on both attempts", async () => {
+    fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+    const seenKeys: string[] = [];
+    let called = false;
+
+    await executeWithSca(
+      client,
+      async ({ idempotencyKey }) => {
+        seenKeys.push(idempotencyKey);
+        if (!called) {
+          called = true;
+          throw new QontoScaRequiredError("tok-idem-supplied");
+        }
+        return "ok";
+      },
+      { idempotencyKey: "user-supplied-key", poll: { sleep: noopSleep } },
+    );
+
+    expect(seenKeys).toEqual(["user-supplied-key", "user-supplied-key"]);
+  });
+
+  it("emits matching X-Qonto-Idempotency-Key header on both wire requests across SCA retry", async () => {
+    // First call: 428 SCA Required from the API.
+    // Then: poll returns allow.
+    // Retry: 200 OK.
+    fetchSpy
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sca_session_token: "tok-wire-1" }), {
+            status: 428,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      )
+      .mockImplementationOnce(() => jsonResponse({ sca_session: { status: "allow" } }))
+      .mockImplementationOnce(() => jsonResponse({ id: "tx-1" }));
+
+    await executeWithSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        client.post(
+          "/v2/transfers",
+          { amount: 100 },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { poll: { sleep: noopSleep } },
+    );
+
+    // Three fetch calls: initial transfer (428), SCA poll, retry transfer.
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    const initialHeaders = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    const retryHeaders = fetchSpy.mock.calls[2]?.[1]?.headers as Record<string, string>;
+
+    expect(initialHeaders["X-Qonto-Idempotency-Key"]).toBeDefined();
+    expect(retryHeaders["X-Qonto-Idempotency-Key"]).toBe(initialHeaders["X-Qonto-Idempotency-Key"]);
+    expect(retryHeaders["X-Qonto-Sca-Session-Token"]).toBe("tok-wire-1");
+  });
+
+  it("emits supplied X-Qonto-Idempotency-Key header on both wire requests across SCA retry", async () => {
+    fetchSpy
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sca_session_token: "tok-wire-2" }), {
+            status: 428,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      )
+      .mockImplementationOnce(() => jsonResponse({ sca_session: { status: "allow" } }))
+      .mockImplementationOnce(() => jsonResponse({ id: "tx-2" }));
+
+    await executeWithSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        client.post(
+          "/v2/transfers",
+          { amount: 200 },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { idempotencyKey: "supplied-stable-key", poll: { sleep: noopSleep } },
+    );
+
+    const initialHeaders = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    const retryHeaders = fetchSpy.mock.calls[2]?.[1]?.headers as Record<string, string>;
+
+    expect(initialHeaders["X-Qonto-Idempotency-Key"]).toBe("supplied-stable-key");
+    expect(retryHeaders["X-Qonto-Idempotency-Key"]).toBe("supplied-stable-key");
   });
 });

--- a/packages/core/src/sca/sca-handler.ts
+++ b/packages/core/src/sca/sca-handler.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { randomUUID } from "node:crypto";
 import { QontoScaRequiredError } from "../http-client.js";
 import type { HttpClient } from "../http-client.js";
 import { pollScaSession, type PollScaSessionOptions } from "./sca-service.js";
@@ -17,6 +18,29 @@ export interface ExecuteWithScaCallbacks {
 export interface ExecuteWithScaOptions extends ExecuteWithScaCallbacks {
   /** Options for the SCA polling loop. */
   readonly poll?: PollScaSessionOptions | undefined;
+  /**
+   * Idempotency key threaded to both the initial attempt and the SCA retry.
+   * If not supplied, a UUID is generated once and reused across both attempts.
+   *
+   * Both HTTP attempts must carry the same `X-Qonto-Idempotency-Key` so the
+   * Qonto API recognizes them as the same logical operation and does not
+   * create duplicate pending pre-SCA records on retry.
+   */
+  readonly idempotencyKey?: string | undefined;
+}
+
+/**
+ * Context passed to the operation callback.
+ *
+ * The same `idempotencyKey` is used for both the initial 428 attempt and
+ * the post-SCA retry, ensuring the operation is idempotent across the
+ * SCA challenge.
+ */
+export interface ExecuteWithScaContext {
+  /** SCA session token, populated only on the retry after SCA approval. */
+  readonly scaSessionToken?: string | undefined;
+  /** Stable idempotency key shared across the initial attempt and the SCA retry. */
+  readonly idempotencyKey: string;
 }
 
 /**
@@ -27,18 +51,25 @@ export interface ExecuteWithScaOptions extends ExecuteWithScaCallbacks {
  * 2. Polls the SCA session until resolved
  * 3. Retries the original operation with the SCA token
  *
+ * Both attempts (initial 428 + post-SCA retry) receive the same idempotency
+ * key via the context argument. Callers MUST forward `context.idempotencyKey`
+ * to the underlying HTTP request so Qonto recognizes both attempts as the
+ * same logical operation and does not create duplicate records.
+ *
  * @param client - HttpClient used for SCA session polling
- * @param operation - Function that performs the API operation. Called with an optional
- *   SCA session token for retry.
- * @param options - Callbacks and polling options
+ * @param operation - Function that performs the API operation. Receives a context
+ *   carrying the stable idempotency key and (on retry) the SCA session token.
+ * @param options - Callbacks, polling options, and optional idempotency key
  */
 export async function executeWithSca<T>(
   client: HttpClient,
-  operation: (scaSessionToken?: string) => Promise<T>,
+  operation: (context: ExecuteWithScaContext) => Promise<T>,
   options?: ExecuteWithScaOptions,
 ): Promise<T> {
+  const idempotencyKey = options?.idempotencyKey ?? randomUUID();
+
   try {
-    return await operation();
+    return await operation({ idempotencyKey });
   } catch (error: unknown) {
     if (!(error instanceof QontoScaRequiredError)) {
       throw error;
@@ -54,6 +85,6 @@ export async function executeWithSca<T>(
 
     options?.onScaApproved?.();
 
-    return operation(scaSessionToken);
+    return operation({ scaSessionToken, idempotencyKey });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #429 (council finding from #428 review, security-architect Q4(a)).

`executeWithSca` invokes `operation()` twice across an SCA challenge (initial 428 + post-approval retry). When no `--idempotency-key` was supplied, `http-client.fetchWithRetry` minted a fresh `randomUUID()` per fetch, producing **two different idempotency keys for the same logical operation**. If Qonto's 428 response is mutating (creates a pending pre-SCA record), this enabled duplicate creations on retry.

The fix moves idempotency-key generation up to `executeWithSca`, which generates it once (or accepts a user-supplied value) and threads it to both invocations of the operation callback via a new context-object parameter. Callers forward `context.idempotencyKey` to the underlying request so both wire attempts emit the same `X-Qonto-Idempotency-Key` header.

## Changes

- **`@qontoctl/core` — `sca-handler.ts`**
  - Operation signature: `(scaSessionToken?: string) => Promise<T>` → `(context: { scaSessionToken?: string; idempotencyKey: string }) => Promise<T>`.
  - New `ExecuteWithScaOptions.idempotencyKey?: string | undefined` lets callers pin the value (e.g. when the user passes `--idempotency-key`).
  - New exported `ExecuteWithScaContext` type.
- **`@qontoctl/cli` — `sca.ts`**
  - `executeWithCliSca` mirrors the new signature and forwards `idempotencyKey` to the core wrapper.
  - All 30 CLI command call sites migrated to receive `{ scaSessionToken, idempotencyKey }` from the context and forward `idempotencyKey` to the API call.
  - 18 command test mocks updated to honor `options.idempotencyKey`, faithfully simulating real `executeWithSca` behavior.
- **Documentation** — `packages/core/README.md` updated.

## Acceptance Criteria

- [x] Both HTTP attempts (initial 428 + SCA-retry) carry the **same** `X-Qonto-Idempotency-Key` header.
- [x] Unit test asserts header equality across attempts via mocked HTTP transport.
- [x] Test passes for both supplied (`--idempotency-key`) and unsupplied paths.
- [x] Fix lives in core so the MCP wrapper (#433) inherits it.

## Tests

Two new wire-level tests in `core/src/sca/sca-handler.test.ts`:
- `emits matching X-Qonto-Idempotency-Key header on both wire requests across SCA retry` (auto-generated key)
- `emits supplied X-Qonto-Idempotency-Key header on both wire requests across SCA retry` (user-supplied key)

Plus context-shape assertions in both `core/src/sca/sca-handler.test.ts` and `cli/src/sca.test.ts`.

```
Test Files  81 passed (81)
     Tests  626 passed (626)
```

Lint, license-check, prettier, and full multi-package build all green.

## E2E

Local E2E run was blocked by an expired OAuth refresh token in `.qontoctl.yaml` (pre-existing environmental condition: `invalid_grant - The refresh token expired`). This affects every E2E test in the worktree, not just SCA-related ones, and is unrelated to this change — the diff does not touch the OAuth flow.

The new unit tests cover the wire-level invariant directly via mocked `fetch`. The `e2e-sandbox` CI job (non-blocking per repo policy) will exercise the path against the live sandbox if its secrets are configured.

## Test plan

- [ ] CI green (build, lint, license-check, tests across the 3-OS matrix).
- [ ] Verify both new wire-level header-equality tests run in `@qontoctl/core` test job.
- [ ] (Optional, post-token-refresh) Re-run `pnpm test:e2e` locally to confirm no regression in non-SCA paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)