### PR TITLE
(fix) redact SCA session token in error messages and debug logs (#430)

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -888,6 +888,27 @@ describe("HttpClient", () => {
       expect(bodyLog).toContain('"currency":"EUR"');
     });
 
+    it("redacts sca_session_token body field in response body debug logs", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ outer: { sca_session_token: "leaky-token-XYZ", other: "ok" } }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.get("/v2/something");
+
+      const bodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Response body"),
+      );
+      expect(bodyLogCalls.length).toBeGreaterThan(0);
+      const bodyLog = bodyLogCalls[0]?.[0] as string;
+      expect(bodyLog).not.toContain("leaky-token-XYZ");
+      expect(bodyLog).toContain('"sca_session_token":"[REDACTED]"');
+      expect(bodyLog).toContain('"other":"ok"');
+    });
+
     it("redacts Authorization header in debug logs", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
       const logger = createMockLogger();
@@ -906,6 +927,50 @@ describe("HttpClient", () => {
       const headerLog = headerLogCalls[0]?.[0] as string;
       expect(headerLog).toContain("[REDACTED]");
       expect(headerLog).not.toContain("secret-key-123");
+    });
+
+    it("redacts X-Qonto-Staging-Token header in debug logs", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "sandbox-staging-token-secret-XYZ",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).not.toContain("sandbox-staging-token-secret-XYZ");
+      expect(headerLog).toContain('"X-Qonto-Staging-Token":"[REDACTED]"');
+    });
+
+    it("redacts X-Qonto-Sca-Session-Token header in debug logs on retry with token", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "ok" }, { status: 201 }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/transfers", { amount: 100 }, { scaSessionToken: "retry-token-secret-ABC" });
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      // The header log is emitted from buildHeaders before the SCA token is added in
+      // fetchWithRetry, so the SCA token isn't currently present in the captured log.
+      // The redaction map nonetheless covers the header name as defense-in-depth: any
+      // future log path that captures the assembled headers will redact it.
+      for (const call of headerLogCalls) {
+        const headerLog = call[0] as string;
+        expect(headerLog).not.toContain("retry-token-secret-ABC");
+      }
     });
 
     it("does not throw when logger is not provided", async () => {
@@ -951,6 +1016,30 @@ describe("HttpClient", () => {
 
       expect(error).toBeInstanceOf(QontoScaRequiredError);
       expect((error as QontoScaRequiredError).scaSessionToken).toBe("sca-tok-123");
+    });
+
+    it("does not leak SCA session token through any debug or verbose log on 428 (full request lifecycle)", async () => {
+      // Integration-style test: a debug-mode user running against a 428 must
+      // capture zero SCA token leakage across all logger channels.
+      const SECRET_TOKEN = "sca-leak-canary-abc-123-def-456";
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session_token: SECRET_TOKEN }, { status: 428 }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoScaRequiredError);
+      expect((error as QontoScaRequiredError).scaSessionToken).toBe(SECRET_TOKEN);
+      expect((error as QontoScaRequiredError).message).not.toContain(SECRET_TOKEN);
+
+      const allDebugCalls = logger.debug.mock.calls.map((c: string[]) => String(c[0]));
+      const allVerboseCalls = logger.verbose.mock.calls.map((c: string[]) => String(c[0]));
+      const allLogged = [...allDebugCalls, ...allVerboseCalls].join("\n");
+      expect(allLogged).not.toContain(SECRET_TOKEN);
     });
 
     it("throws QontoScaRequiredError with 'unknown' when no token in body", async () => {
@@ -1316,9 +1405,10 @@ describe("HttpClient", () => {
       expect(error.name).toBe("QontoScaRequiredError");
     });
 
-    it("includes session token in message", () => {
+    it("does not include session token in message", () => {
       const error = new QontoScaRequiredError("tok-456");
-      expect(error.message).toContain("tok-456");
+      expect(error.message).not.toContain("tok-456");
+      expect(error.message).toBe("SCA required");
     });
 
     it("exposes scaSessionToken property", () => {

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -69,11 +69,13 @@ export class QontoRateLimitError extends Error {
  * Error thrown when the Qonto API requires Strong Customer Authentication (428).
  *
  * The SCA session token can be used to poll the SCA session status and
- * retry the original request once approved.
+ * retry the original request once approved. The token is intentionally
+ * omitted from `.message` to avoid leaking it through generic error
+ * logging; callers needing the token can read `.scaSessionToken` directly.
  */
 export class QontoScaRequiredError extends Error {
   constructor(public readonly scaSessionToken: string) {
-    super(`SCA required (session token: ${scaSessionToken})`);
+    super(`SCA required`);
     this.name = "QontoScaRequiredError";
   }
 }
@@ -145,15 +147,30 @@ const SCA_SESSION_TOKEN_HEADER = "X-Qonto-Sca-Session-Token";
 const STAGING_TOKEN_HEADER = "X-Qonto-Staging-Token";
 
 /**
- * Field names redacted from debug log output to avoid leaking financial data.
+ * Field and header names redacted from debug log output.
+ *
+ * Covers two classes of secrets:
+ * - Financial data (IBAN, BIC, balances) that must not appear in logs.
+ * - Authentication and SCA tokens that grant API access if leaked.
+ *
+ * Header names are stored lowercase; matching is case-insensitive so the
+ * same set redacts both body fields (snake_case) and HTTP header names
+ * (which arrive in mixed case from `Headers` / our own builders).
  */
 const SENSITIVE_FIELDS: ReadonlySet<string> = new Set([
+  // Financial body fields
   "iban",
   "bic",
   "balance",
   "balance_cents",
   "authorized_balance",
   "authorized_balance_cents",
+  // SCA session token (body field and header form)
+  "sca_session_token",
+  "x-qonto-sca-session-token",
+  // Authentication and environment headers
+  "authorization",
+  "x-qonto-staging-token",
 ]);
 
 function redactSensitiveFields(value: unknown): unknown {
@@ -166,7 +183,7 @@ function redactSensitiveFields(value: unknown): unknown {
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      result[key] = SENSITIVE_FIELDS.has(key) ? "[REDACTED]" : redactSensitiveFields(val);
+      result[key] = SENSITIVE_FIELDS.has(key.toLowerCase()) ? "[REDACTED]" : redactSensitiveFields(val);
     }
     return result;
   }
@@ -393,7 +410,9 @@ export class HttpClient {
       const elapsed = performance.now() - startTime;
 
       this.logVerbose(`${response.status} ${response.statusText} (${elapsed.toFixed(0)}ms)`);
-      this.logDebug(`Response headers: ${JSON.stringify(Object.fromEntries(response.headers.entries()))}`);
+      this.logDebug(
+        `Response headers: ${JSON.stringify(redactSensitiveFields(Object.fromEntries(response.headers.entries())))}`,
+      );
 
       if (response.status === 429) {
         const retryAfter = this.parseRetryAfter(response);
@@ -456,7 +475,9 @@ export class HttpClient {
         const fallbackElapsed = performance.now() - fallbackStart;
 
         this.logVerbose(`${fallbackResponse.status} ${fallbackResponse.statusText} (${fallbackElapsed.toFixed(0)}ms)`);
-        this.logDebug(`Response headers: ${JSON.stringify(Object.fromEntries(fallbackResponse.headers.entries()))}`);
+        this.logDebug(
+          `Response headers: ${JSON.stringify(redactSensitiveFields(Object.fromEntries(fallbackResponse.headers.entries())))}`,
+        );
 
         if (fallbackResponse.status === 428) {
           const errorBody = await this.safeReadJson(fallbackResponse);
@@ -532,9 +553,7 @@ export class HttpClient {
       headers[STAGING_TOKEN_HEADER] = this.stagingToken;
     }
 
-    this.logDebug(
-      `Request headers: ${JSON.stringify({ ...headers, Authorization: "[REDACTED]", ...(this.stagingToken !== undefined ? { [STAGING_TOKEN_HEADER]: "[REDACTED]" } : {}) })}`,
-    );
+    this.logDebug(`Request headers: ${JSON.stringify(redactSensitiveFields(headers))}`);
 
     return headers;
   }

--- a/packages/core/src/sca/errors.ts
+++ b/packages/core/src/sca/errors.ts
@@ -3,23 +3,31 @@
 
 /**
  * Error thrown when SCA polling exceeds the maximum allowed time.
+ *
+ * The session token is intentionally omitted from `.message` to avoid
+ * leaking it through generic error logging. Callers needing the token
+ * for retry or diagnostics can read `.scaSessionToken` directly.
  */
 export class ScaTimeoutError extends Error {
   constructor(
-    public readonly token: string,
+    public readonly scaSessionToken: string,
     public readonly timeoutMs: number,
   ) {
-    super(`SCA session timed out after ${Math.round(timeoutMs / 1000)}s (token: ${token})`);
+    super(`SCA session timed out after ${Math.round(timeoutMs / 1000)}s`);
     this.name = "ScaTimeoutError";
   }
 }
 
 /**
  * Error thrown when the user denies the SCA request.
+ *
+ * The session token is intentionally omitted from `.message` to avoid
+ * leaking it through generic error logging. Callers needing the token
+ * for retry or diagnostics can read `.scaSessionToken` directly.
  */
 export class ScaDeniedError extends Error {
-  constructor(public readonly token: string) {
-    super(`SCA request denied by user (token: ${token})`);
+  constructor(public readonly scaSessionToken: string) {
+    super(`SCA request denied by user`);
     this.name = "ScaDeniedError";
   }
 }

--- a/packages/core/src/sca/sca-service.test.ts
+++ b/packages/core/src/sca/sca-service.test.ts
@@ -139,7 +139,8 @@ describe("SCA service", () => {
       const error = await pollScaSession(client, "tok-3", { sleep: noopSleep }).catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ScaDeniedError);
-      expect((error as ScaDeniedError).token).toBe("tok-3");
+      expect((error as ScaDeniedError).scaSessionToken).toBe("tok-3");
+      expect(error.message).not.toContain("tok-3");
     });
 
     it("throws ScaTimeoutError when timeout is exceeded", async () => {
@@ -151,8 +152,9 @@ describe("SCA service", () => {
       }).catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ScaTimeoutError);
-      expect((error as ScaTimeoutError).token).toBe("tok-4");
+      expect((error as ScaTimeoutError).scaSessionToken).toBe("tok-4");
       expect((error as ScaTimeoutError).timeoutMs).toBe(0);
+      expect(error.message).not.toContain("tok-4");
     });
 
     it("calls onPoll callback with attempt number and elapsed time", async () => {


### PR DESCRIPTION
## Summary

Closes #430. Surfaced during #428 council security review (security-architect Q4(b)). The Qonto SCA session token leaked through three error-class `.message` strings, and the debug-log redaction map didn't cover the token's body field or HTTP header forms.

- **Error messages**: removed `${scaSessionToken}` interpolation from `QontoScaRequiredError`, `ScaTimeoutError`, and `ScaDeniedError`. Token still accessible via `.scaSessionToken` field on each class.
- **Field rename**: `.token` → `.scaSessionToken` on `ScaTimeoutError`/`ScaDeniedError` for cross-class consistency.
- **Redaction map**: added `sca_session_token` (body), `x-qonto-sca-session-token` (header), `authorization`, `x-qonto-staging-token` to `SENSITIVE_FIELDS`. `redactSensitiveFields` now case-insensitive so the same map covers body fields (snake_case) and HTTP header names (mixed case).
- **Header logging**: replaced ad-hoc `Authorization` / `X-Qonto-Staging-Token` spread overrides in `buildHeaders` and unredacted `Response headers` logs with a single `redactSensitiveFields(...)` call.

## Acceptance criteria

- [x] Token absent from `.message` of all three SCA error classes; remains accessible via `.scaSessionToken` field.
- [x] `redactSensitiveFields` redacts `sca_session_token` body field.
- [x] Same map redacts `X-Qonto-Sca-Session-Token` header.
- [x] Unit tests for both error-message scrubbing and redaction map.
- [x] Integration test: mocked 428 with debug logger captures NO token across any `logger.debug` / `logger.verbose` call.

## Test plan

- [x] `pnpm --filter @qontoctl/core test` — 833 passing (5 new redaction/scrubbing tests).
- [x] `pnpm test` — full suite: core 833 + cli 624 + mcp + e2e build, all passing.
- [x] `pnpm lint` — clean.
- [x] `pnpm license-check` — 96 production deps, all allowed licenses.
- [x] `pnpm build` — 5 packages, clean compile.
- [ ] `pnpm test:e2e` — blocked locally by expired OAuth refresh token in worktree-provided `.qontoctl.yaml` (env / pre-existing); does not exercise SCA flow against real API. CI `e2e-sandbox` job is non-blocking per CLAUDE.md.

## Notes

- The CLI `error-handler.ts:88` and MCP `errors.ts:82` deliberately surface `.scaSessionToken` for retry UX. Out of scope for #430 (issue scope is `.message` and debug-log leakage, not user-facing display of the field).
- The `Request headers` debug log fires in `buildHeaders` BEFORE the SCA token is added in `fetchWithRetry`, so the SCA header redaction is defense-in-depth in the current flow. Documented in test comment.
- Caller note acknowledged: this PR also modifies `packages/core/src/http-client.ts` (lines around 76 and 150-158); rebase on top of #429 if/when that lands first.