### PR TITLE
(fix) use PATCH for trust/untrust beneficiaries (#444)

### DIFF
--- a/packages/cli/src/commands/beneficiary/trust.test.ts
+++ b/packages/cli/src/commands/beneficiary/trust.test.ts
@@ -76,7 +76,7 @@ describe("beneficiary trust command", () => {
     expect(parsed.ids).toEqual(["ben-1", "ben-2"]);
   });
 
-  it("sends POST with ids to the correct endpoint", async () => {
+  it("sends PATCH with ids to the correct endpoint", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
@@ -87,7 +87,7 @@ describe("beneficiary trust command", () => {
 
     const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/trust");
-    expect(opts.method).toBe("POST");
+    expect(opts.method).toBe("PATCH");
     const body = JSON.parse(opts.body as string) as { ids: string[] };
     expect(body.ids).toEqual(["ben-1"]);
   });

--- a/packages/cli/src/commands/beneficiary/trust.ts
+++ b/packages/cli/src/commands/beneficiary/trust.ts
@@ -10,7 +10,9 @@ import type { GlobalOptions, WriteOptions } from "../../options.js";
 import { executeWithCliSca } from "../../sca.js";
 
 export function registerBeneficiaryTrustCommand(parent: Command): void {
-  const trust = parent.command("trust <id...>").description("Trust one or more beneficiaries");
+  const trust = parent
+    .command("trust <id...>")
+    .description("Trust one or more beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope)");
   addInheritableOptions(trust);
   addWriteOptions(trust);
   trust.action(async (ids: string[], _opts: unknown, cmd: Command) => {

--- a/packages/cli/src/commands/beneficiary/untrust.test.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.test.ts
@@ -76,7 +76,7 @@ describe("beneficiary untrust command", () => {
     expect(parsed.ids).toEqual(["ben-1", "ben-2"]);
   });
 
-  it("sends POST with ids to the correct endpoint", async () => {
+  it("sends PATCH with ids to the correct endpoint", async () => {
     fetchSpy.mockImplementation(() => jsonResponse({}));
 
     const { createProgram } = await import("../../program.js");
@@ -87,7 +87,7 @@ describe("beneficiary untrust command", () => {
 
     const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/untrust");
-    expect(opts.method).toBe("POST");
+    expect(opts.method).toBe("PATCH");
     const body = JSON.parse(opts.body as string) as { ids: string[] };
     expect(body.ids).toEqual(["ben-1"]);
   });

--- a/packages/cli/src/commands/beneficiary/untrust.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.ts
@@ -10,7 +10,9 @@ import type { GlobalOptions, WriteOptions } from "../../options.js";
 import { executeWithCliSca } from "../../sca.js";
 
 export function registerBeneficiaryUntrustCommand(parent: Command): void {
-  const untrust = parent.command("untrust <id...>").description("Untrust one or more beneficiaries");
+  const untrust = parent
+    .command("untrust <id...>")
+    .description("Untrust one or more beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope)");
   addInheritableOptions(untrust);
   addWriteOptions(untrust);
   untrust.action(async (ids: string[], _opts: unknown, cmd: Command) => {

--- a/packages/core/src/beneficiaries/service.test.ts
+++ b/packages/core/src/beneficiaries/service.test.ts
@@ -301,12 +301,12 @@ describe("trustBeneficiaries", () => {
     vi.restoreAllMocks();
   });
 
-  it("sends POST to /trust with ids", async () => {
+  it("sends PATCH to /trust with ids", async () => {
     fetchSpy.mockReturnValue(jsonResponse({}));
     await trustBeneficiaries(client, ["ben-1", "ben-2"]);
     const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/trust");
-    expect(opts.method).toBe("POST");
+    expect(opts.method).toBe("PATCH");
     const body = JSON.parse(opts.body as string) as Record<string, unknown>;
     expect(body).toEqual({ ids: ["ben-1", "ben-2"] });
   });
@@ -329,12 +329,12 @@ describe("untrustBeneficiaries", () => {
     vi.restoreAllMocks();
   });
 
-  it("sends POST to /untrust with ids", async () => {
+  it("sends PATCH to /untrust with ids", async () => {
     fetchSpy.mockReturnValue(jsonResponse({}));
     await untrustBeneficiaries(client, ["ben-1"]);
     const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/sepa/beneficiaries/untrust");
-    expect(opts.method).toBe("POST");
+    expect(opts.method).toBe("PATCH");
     const body = JSON.parse(opts.body as string) as Record<string, unknown>;
     expect(body).toEqual({ ids: ["ben-1"] });
   });

--- a/packages/core/src/beneficiaries/service.ts
+++ b/packages/core/src/beneficiaries/service.ts
@@ -94,22 +94,30 @@ export async function updateBeneficiary(
 
 /**
  * Trust one or more SEPA beneficiaries.
+ *
+ * Note: this endpoint requires the `beneficiary.trust` OAuth scope, which is
+ * Embed-partner-only on Qonto. Standard third-party OAuth apps and API-key
+ * tenants do not have it and will receive 403 from the API.
  */
 export async function trustBeneficiaries(
   client: HttpClient,
   ids: string[],
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<void> {
-  await client.post("/v2/sepa/beneficiaries/trust", { ids }, options);
+  await client.patch("/v2/sepa/beneficiaries/trust", { ids }, options);
 }
 
 /**
  * Untrust one or more SEPA beneficiaries.
+ *
+ * Note: this endpoint requires the `beneficiary.trust` OAuth scope, which is
+ * Embed-partner-only on Qonto. Standard third-party OAuth apps and API-key
+ * tenants do not have it and will receive 403 from the API.
  */
 export async function untrustBeneficiaries(
   client: HttpClient,
   ids: string[],
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<void> {
-  await client.post("/v2/sepa/beneficiaries/untrust", { ids }, options);
+  await client.patch("/v2/sepa/beneficiaries/untrust", { ids }, options);
 }

--- a/packages/mcp/src/tools/beneficiary.test.ts
+++ b/packages/mcp/src/tools/beneficiary.test.ts
@@ -301,7 +301,7 @@ describe("beneficiary MCP tools", () => {
       expect(parsed.ids).toEqual(["ben-1", "ben-2"]);
     });
 
-    it("sends POST with ids to the correct endpoint", async () => {
+    it("sends PATCH with ids to the correct endpoint", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
 
       await mcpClient.callTool({
@@ -311,7 +311,7 @@ describe("beneficiary MCP tools", () => {
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/sepa/beneficiaries/trust");
-      expect(opts.method).toBe("POST");
+      expect(opts.method).toBe("PATCH");
       const body = JSON.parse(opts.body as string) as { ids: string[] };
       expect(body.ids).toEqual(["ben-1"]);
     });
@@ -334,7 +334,7 @@ describe("beneficiary MCP tools", () => {
       expect(parsed.ids).toEqual(["ben-1", "ben-2"]);
     });
 
-    it("sends POST with ids to the correct endpoint", async () => {
+    it("sends PATCH with ids to the correct endpoint", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
 
       await mcpClient.callTool({
@@ -344,7 +344,7 @@ describe("beneficiary MCP tools", () => {
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/sepa/beneficiaries/untrust");
-      expect(opts.method).toBe("POST");
+      expect(opts.method).toBe("PATCH");
       const body = JSON.parse(opts.body as string) as { ids: string[] };
       expect(body.ids).toEqual(["ben-1"]);
     });

--- a/packages/mcp/src/tools/beneficiary.ts
+++ b/packages/mcp/src/tools/beneficiary.ts
@@ -151,7 +151,8 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
   server.registerTool(
     "beneficiary_trust",
     {
-      description: "Trust one or more SEPA beneficiaries",
+      description:
+        "Trust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403)",
       inputSchema: {
         ids: z.array(z.string()).min(1).describe("Beneficiary IDs to trust"),
       },
@@ -174,7 +175,8 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
   server.registerTool(
     "beneficiary_untrust",
     {
-      description: "Untrust one or more SEPA beneficiaries",
+      description:
+        "Untrust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403)",
       inputSchema: {
         ids: z.array(z.string()).min(1).describe("Beneficiary IDs to untrust"),
       },


### PR DESCRIPTION
## Summary

Fix `trustBeneficiaries` / `untrustBeneficiaries` to use **PATCH** (the actual Qonto API verb) instead of POST. The previous POST calls have always 404'd. Surfaced during the SCA verification spike (#438 / `docs/security/sca-token-binding.md` Bug 1 & 2).

Closes #444.

## Changes

- `packages/core/src/beneficiaries/service.ts` — switch `trustBeneficiaries` and `untrustBeneficiaries` to `client.patch(...)`
- Test assertions in `core` (`service.test.ts`), `cli` (`trust.test.ts`, `untrust.test.ts`), and `mcp` (`beneficiary.test.ts`) now assert `PATCH`
- JSDoc on the two service functions documents the **Embed-partner-only `beneficiary.trust` OAuth scope** requirement
- CLI command help text and MCP tool descriptions now warn that the endpoint requires the Embed-partner scope and that standard third-party apps will receive 403

## Decision (AC #5)

**Keep the CLI / MCP commands; document the restriction**. Removal would be irreversible and inconsistent with the rest of the codebase, which exposes the full Qonto API surface regardless of whether a given tenant has the partner scope. The 403 from the API combined with the new help text gives users a clear, self-explanatory error before and during the call.

## Test plan

- [x] `pnpm build` — 5/5 packages
- [x] `pnpm test` — all suites (incl. updated trust/untrust assertions in core, CLI, MCP)
- [x] `pnpm lint` — 8/8 packages
- [x] `pnpm license-check` — 96 deps OK
- [x] `pnpm test:e2e` — `packages/e2e/src/commands/beneficiary.e2e.test.ts` passes 3/3 (the relevant SEPA-beneficiaries suite). Other E2E failures observed locally are pre-existing local-environment OAuth scope gaps unrelated to this change (cards / webhooks / payment-links / intl / teams / MCP beneficiary list+show); main's CI `E2E (Sandbox)` is green at run 25453581163.

## Acceptance Criteria

- [x] `trustBeneficiaries` uses `client.patch(...)` — `service.ts:107`
- [x] `untrustBeneficiaries` uses `client.patch(...)` — `service.ts:122`
- [x] Unit tests assert the HTTP method — 6 `expect(opts.method).toBe("PATCH")` assertions across 3 packages
- [x] CLI commands `qontoctl beneficiary trust` and `qontoctl beneficiary untrust` continue to work or fail with a clear "Embed-partner-only" message — registrations intact, descriptions updated
- [x] Decision recorded — keep commands + document restriction; surfaced in JSDoc, CLI help, and MCP tool descriptions