### PR TITLE
(fix) distinguish 428 sca_required from 428 sca_not_enrolled (#448)

### DIFF
--- a/packages/cli/src/error-handler.test.ts
+++ b/packages/cli/src/error-handler.test.ts
@@ -8,6 +8,7 @@ import {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
   ScaTimeoutError,
   ScaDeniedError,
@@ -133,6 +134,36 @@ describe("handleCliError", () => {
       expect(output).toContain("sca-tok-test");
       expect(output).toContain("approve the operation on your Qonto mobile app");
       expect(process.exitCode).toBe(1);
+    });
+  });
+
+  describe("QontoScaNotEnrolledError", () => {
+    it("shows enrollment guidance with HTTP status and error details", () => {
+      const error = new QontoScaNotEnrolledError([
+        { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+      ]);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("Qonto API error (HTTP 428):");
+      expect(output).toContain("sca_not_enrolled: You must enable SCA to perform this action");
+      expect(output).toContain("Strong Customer Authentication (SCA) is not enabled");
+      expect(output).toContain("configuration error");
+      expect(output).toContain("Enroll a paired device or passkey in the Qonto mobile app");
+      expect(output).toContain("https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows");
+      expect(process.exitCode).toBe(1);
+    });
+
+    it("is matched before generic QontoApiError handler", () => {
+      // Same setup as above; assertion focuses on dispatch order.
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+
+      handleCliError(error, false);
+
+      const output = stderrSpy.mock.calls[0]?.[0] as string;
+      // Generic QontoApiError handler would NOT include enrollment guidance.
+      expect(output).toContain("not enabled on this Qonto account");
     });
   });
 

--- a/packages/cli/src/error-handler.ts
+++ b/packages/cli/src/error-handler.ts
@@ -7,6 +7,7 @@ import {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
   ScaTimeoutError,
   ScaDeniedError,
@@ -60,6 +61,24 @@ export function handleCliError(error: unknown, debug: boolean): void {
         "",
         "Your OAuth token is missing a required scope for this operation.",
         'Run "qontoctl auth setup" to select the needed scopes, then "qontoctl auth login" to re-authenticate.',
+      ].join("\n") + "\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (error instanceof QontoScaNotEnrolledError) {
+    const details = error.errors.map((e) => `  - ${e.code}: ${e.detail}`).join("\n");
+    process.stderr.write(
+      [
+        `Qonto API error (HTTP 428):`,
+        details,
+        "",
+        "Strong Customer Authentication (SCA) is not enabled on this Qonto account.",
+        "This is a configuration error: retrying will produce the same response.",
+        "",
+        "Enroll a paired device or passkey in the Qonto mobile app, then retry.",
+        "See: https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows",
       ].join("\n") + "\n",
     );
     process.exitCode = 1;

--- a/packages/cli/src/sca.test.ts
+++ b/packages/cli/src/sca.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { HttpClient, QontoScaRequiredError, ScaTimeoutError } from "@qontoctl/core";
+import { HttpClient, QontoScaNotEnrolledError, QontoScaRequiredError, ScaTimeoutError } from "@qontoctl/core";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { executeWithCliSca } from "./sca.js";
 
@@ -206,6 +206,29 @@ describe("executeWithCliSca", () => {
 
     expect(seenKeys).toHaveLength(2);
     expect(seenKeys[0]).toBe(seenKeys[1]);
+  });
+
+  it("propagates QontoScaNotEnrolledError without starting the spinner", async () => {
+    // Configuration error: not a recoverable challenge. The CLI must not show
+    // a spinner that suggests waiting for approval.
+    const mockSpin = createMockSpinner();
+    const error = new QontoScaNotEnrolledError([
+      { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+    ]);
+
+    const caught = await executeWithCliSca(
+      client,
+      async () => {
+        throw error;
+      },
+      { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+    ).catch((e: unknown) => e);
+
+    expect(caught).toBe(error);
+    expect(mockSpin.start).not.toHaveBeenCalled();
+    expect(mockSpin.message).not.toHaveBeenCalled();
+    expect(mockSpin.stop).not.toHaveBeenCalled();
+    expect(mockSpin.error).not.toHaveBeenCalled();
   });
 
   it("forwards a supplied idempotency key to the operation", async () => {

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -7,6 +7,7 @@ import {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
 } from "./http-client.js";
 import { binaryResponse } from "./testing/binary-response.js";
@@ -1105,6 +1106,93 @@ describe("HttpClient", () => {
       expect((error as QontoScaRequiredError).scaSessionToken).toBe("unknown");
     });
 
+    it("throws QontoScaNotEnrolledError on 428 with flat sca_not_enrolled body", async () => {
+      // Real Qonto shape (from docs/security/sca-token-binding.md):
+      // 428 { code: "sca_not_enrolled", message: "...", trace_id: "..." }
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            code: "sca_not_enrolled",
+            message: "You must enable SCA to perform this action",
+            trace_id: "trace-abc",
+          },
+          { status: 428 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoScaNotEnrolledError);
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect(error).not.toBeInstanceOf(QontoScaRequiredError);
+      const enrolledError = error as QontoScaNotEnrolledError;
+      expect(enrolledError.status).toBe(428);
+      expect(enrolledError.errors).toEqual([
+        { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+      ]);
+    });
+
+    it("throws QontoScaNotEnrolledError on 428 with JSON:API errors[] sca_not_enrolled entry", async () => {
+      // Defensive: Qonto could ever return the JSON:API errors[] shape.
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [
+              {
+                code: "sca_not_enrolled",
+                detail: "You must enable SCA to perform this action",
+              },
+            ],
+          },
+          { status: 428 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoScaNotEnrolledError).errors[0]?.code).toBe("sca_not_enrolled");
+    });
+
+    it("falls back to default message when sca_not_enrolled body has no message field", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ code: "sca_not_enrolled" }, { status: 428 }));
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoScaNotEnrolledError).errors[0]?.detail).toBe("SCA not enrolled");
+    });
+
+    it("prefers sca_session_token over code when both are present", async () => {
+      // Defensive: if a future Qonto response carries both fields, prefer the
+      // recoverable interpretation rather than the configuration-error one.
+      fetchSpy.mockReturnValue(
+        jsonResponse({ sca_session_token: "tok-mixed", code: "sca_not_enrolled" }, { status: 428 }),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoScaRequiredError);
+      expect(error).not.toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoScaRequiredError).scaSessionToken).toBe("tok-mixed");
+    });
+
     it("throws QontoScaRequiredError with 'unknown' when body is not JSON", async () => {
       fetchSpy.mockReturnValue(
         Promise.resolve(
@@ -1469,6 +1557,43 @@ describe("HttpClient", () => {
     it("is an instance of Error", () => {
       const error = new QontoScaRequiredError("tok-abc");
       expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("QontoScaNotEnrolledError", () => {
+    it("has correct name property", () => {
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      expect(error.name).toBe("QontoScaNotEnrolledError");
+    });
+
+    it("has status 428", () => {
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      expect(error.status).toBe(428);
+    });
+
+    it("is an instance of QontoApiError", () => {
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      expect(error).toBeInstanceOf(QontoApiError);
+    });
+
+    it("is NOT an instance of QontoScaRequiredError", () => {
+      // Critical for executeWithSca's catch behaviour: it must not poll.
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      expect(error).not.toBeInstanceOf(QontoScaRequiredError);
+    });
+
+    it("is an instance of Error", () => {
+      const error = new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it("preserves error entries", () => {
+      const error = new QontoScaNotEnrolledError([
+        { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+      ]);
+      expect(error.errors).toEqual([
+        { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+      ]);
     });
   });
 

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -81,6 +81,28 @@ export class QontoScaRequiredError extends Error {
 }
 
 /**
+ * Error thrown when the Qonto API returns 428 because the account has not
+ * enrolled in SCA.
+ *
+ * Distinct from {@link QontoScaRequiredError}: this is a configuration error,
+ * not a recoverable challenge. No SCA session token is issued, polling cannot
+ * resolve it, and retries with the same auth will return the same 428. The
+ * caller must enroll SCA on the Qonto account before retrying.
+ *
+ * Extends {@link QontoApiError} so existing `instanceof QontoApiError` checks
+ * still match while consumers can narrow to this subclass for targeted
+ * handling. Deliberately does NOT extend {@link QontoScaRequiredError}, so
+ * SCA-handling helpers (e.g., `executeWithSca`) propagate it instead of
+ * attempting to poll a non-existent SCA session.
+ */
+export class QontoScaNotEnrolledError extends QontoApiError {
+  constructor(errors: readonly QontoApiErrorEntry[]) {
+    super(428, errors);
+    this.name = "QontoScaNotEnrolledError";
+  }
+}
+
+/**
  * Authorization value: either a static string or a function that resolves
  * the authorization header dynamically (e.g., for OAuth auto-refresh).
  */
@@ -440,8 +462,7 @@ export class HttpClient {
 
       if (response.status === 428) {
         const errorBody = await this.safeReadJson(response);
-        const scaToken = this.extractScaSessionToken(errorBody);
-        throw new QontoScaRequiredError(scaToken);
+        throw this.build428Error(errorBody);
       }
 
       if ((response.status === 401 || response.status === 403) && this.fallbackAuthorization !== undefined) {
@@ -492,8 +513,7 @@ export class HttpClient {
 
         if (fallbackResponse.status === 428) {
           const errorBody = await this.safeReadJson(fallbackResponse);
-          const scaToken = this.extractScaSessionToken(errorBody);
-          throw new QontoScaRequiredError(scaToken);
+          throw this.build428Error(errorBody);
         }
 
         if (!fallbackResponse.ok) {
@@ -578,16 +598,42 @@ export class HttpClient {
     return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
   }
 
-  private extractScaSessionToken(body: unknown): string {
-    if (
-      typeof body === "object" &&
-      body !== null &&
-      "sca_session_token" in body &&
-      typeof (body as { sca_session_token: unknown }).sca_session_token === "string"
-    ) {
-      return (body as { sca_session_token: string }).sca_session_token;
+  /**
+   * Discriminate between the two 428 response shapes the Qonto API returns:
+   *
+   * - `sca_required` — body contains `sca_session_token` (recoverable: poll +
+   *   retry). Yields {@link QontoScaRequiredError}.
+   * - `sca_not_enrolled` — body contains top-level `code: "sca_not_enrolled"`
+   *   (flat shape) or a JSON:API `errors[]` entry with that code. No session
+   *   token is issued; this is a configuration error and the caller must
+   *   enroll SCA on the Qonto account before retrying. Yields
+   *   {@link QontoScaNotEnrolledError}.
+   *
+   * Unknown 428 shapes fall back to {@link QontoScaRequiredError} with token
+   * `"unknown"`, preserving prior behaviour for shapes the API may add later.
+   */
+  private build428Error(body: unknown): QontoScaRequiredError | QontoScaNotEnrolledError {
+    if (typeof body === "object" && body !== null) {
+      const obj = body as Record<string, unknown>;
+
+      if (typeof obj["sca_session_token"] === "string") {
+        return new QontoScaRequiredError(obj["sca_session_token"]);
+      }
+
+      if (obj["code"] === "sca_not_enrolled") {
+        const detail = typeof obj["message"] === "string" ? obj["message"] : "SCA not enrolled";
+        return new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail }]);
+      }
+
+      if (Array.isArray(obj["errors"])) {
+        const errors = this.extractErrors(body);
+        if (errors.some((e) => e.code === "sca_not_enrolled")) {
+          return new QontoScaNotEnrolledError(errors);
+        }
+      }
     }
-    return "unknown";
+
+    return new QontoScaRequiredError("unknown");
   }
 
   private isAuthError(errors: readonly QontoApiErrorEntry[]): boolean {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
   type Authorization,
   type FallbackWarningHandler,

--- a/packages/core/src/sca/sca-handler.test.ts
+++ b/packages/core/src/sca/sca-handler.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { HttpClient, QontoScaRequiredError } from "../http-client.js";
+import { HttpClient, QontoScaNotEnrolledError, QontoScaRequiredError } from "../http-client.js";
 import { jsonResponse } from "../testing/json-response.js";
 import { executeWithSca } from "./sca-handler.js";
 
@@ -45,6 +45,29 @@ describe("executeWithSca", () => {
     }).catch((e: unknown) => e);
 
     expect(caught).toBe(error);
+  });
+
+  it("propagates QontoScaNotEnrolledError without polling", async () => {
+    // Configuration error: caller must enroll SCA on the Qonto account.
+    // executeWithSca must NOT attempt to poll a non-existent SCA session.
+    const error = new QontoScaNotEnrolledError([
+      { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+    ]);
+    const onScaRequired = vi.fn();
+
+    const caught = await executeWithSca(
+      client,
+      async () => {
+        throw error;
+      },
+      { onScaRequired, poll: { sleep: noopSleep } },
+    ).catch((e: unknown) => e);
+
+    expect(caught).toBe(error);
+    expect(caught).toBeInstanceOf(QontoScaNotEnrolledError);
+    expect(onScaRequired).not.toHaveBeenCalled();
+    // No polling should have occurred (no fetch calls for SCA session).
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("handles SCA flow: catches 428, polls, retries", async () => {

--- a/packages/mcp/src/errors.test.ts
+++ b/packages/mcp/src/errors.test.ts
@@ -8,6 +8,7 @@ import {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
   HttpClient,
 } from "@qontoctl/core";
@@ -189,6 +190,46 @@ describe("withClient", () => {
 
       expect(result.content).toHaveLength(1);
       expect((result.content[0] as { type: string }).type).toBe("text");
+    });
+  });
+
+  describe("QontoScaNotEnrolledError", () => {
+    it("returns a distinct shape from QontoScaRequiredError (isError: true with enrollment guidance)", async () => {
+      const result = await withClient(succeedingFactory, async () => {
+        throw new QontoScaNotEnrolledError([
+          { code: "sca_not_enrolled", detail: "You must enable SCA to perform this action" },
+        ]);
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      expect(text).toContain("HTTP 428");
+      expect(text).toContain("sca_not_enrolled: You must enable SCA to perform this action");
+      expect(text).toContain("Strong Customer Authentication (SCA) is not enabled");
+      expect(text).toContain("configuration error");
+      expect(text).toContain("Enroll a paired device or passkey");
+      expect(text).toContain("https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows");
+    });
+
+    it("does NOT return the structured pending shape used for QontoScaRequiredError", async () => {
+      const result = await withClient(succeedingFactory, async () => {
+        throw new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      });
+
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      expect(text).not.toContain("Session token");
+      expect(text).not.toContain("Poll GET /v2/sca/sessions/");
+      expect(text).not.toContain("approve this operation on their Qonto mobile app");
+    });
+
+    it("is matched before generic QontoApiError handler", async () => {
+      const result = await withClient(succeedingFactory, async () => {
+        throw new QontoScaNotEnrolledError([{ code: "sca_not_enrolled", detail: "..." }]);
+      });
+
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      // Generic QontoApiError handler would NOT include enrollment guidance.
+      expect(text).toContain("not enabled on this Qonto account");
     });
   });
 

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -8,6 +8,7 @@ import {
   QontoApiError,
   QontoOAuthScopeError,
   QontoRateLimitError,
+  QontoScaNotEnrolledError,
   QontoScaRequiredError,
 } from "@qontoctl/core";
 
@@ -91,6 +92,22 @@ function formatScaRequiredResponse(error: QontoScaRequiredError): CallToolResult
   };
 }
 
+function formatScaNotEnrolledError(error: QontoScaNotEnrolledError): CallToolResult {
+  const details = error.errors.map((e) => `  - ${e.code}: ${e.detail}`).join("\n");
+  return textError(
+    [
+      `Qonto API error (HTTP 428):`,
+      details,
+      "",
+      "Strong Customer Authentication (SCA) is not enabled on this Qonto account.",
+      "This is a configuration error: retrying will produce the same response.",
+      "",
+      "Enroll a paired device or passkey in the Qonto mobile app, then retry.",
+      "See: https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows",
+    ].join("\n"),
+  );
+}
+
 /**
  * Wraps a tool handler with consistent error handling.
  *
@@ -108,6 +125,7 @@ export async function withClient(
     if (error instanceof ConfigError) return formatConfigError(error);
     if (error instanceof AuthError) return formatAuthError(error);
     if (error instanceof QontoScaRequiredError) return formatScaRequiredResponse(error);
+    if (error instanceof QontoScaNotEnrolledError) return formatScaNotEnrolledError(error);
     if (error instanceof QontoOAuthScopeError) return formatOAuthScopeError(error);
     if (error instanceof QontoApiError) return formatApiError(error);
     if (error instanceof QontoRateLimitError) return formatRateLimitError(error);


### PR DESCRIPTION
## Summary

Closes #448. Surfaced during #438 SCA verification spike (see `docs/security/sca-token-binding.md` Bug 6).

Qonto returns two distinct 428 shapes that QontoCtl previously conflated into a single `QontoScaRequiredError`:

| Shape | Body | Recoverable? |
|---|---|---|
| **`sca_required`** | `{ sca_session_token, action_type, sca_recovery_token, ... }` | ✅ Caller polls + retries with the approved token. |
| **`sca_not_enrolled`** | `{ code: "sca_not_enrolled", message: "...", trace_id }` | ❌ Configuration error. No session token issued. Polling cannot resolve. |

Treating both as the same caused `executeWithSca` to poll a non-existent SCA session on the configuration case, surfacing confusing downstream errors with `token=unknown`.

## Design

Introduce `QontoScaNotEnrolledError extends QontoApiError` (parallel to existing `QontoOAuthScopeError extends QontoApiError`):

```
QontoApiError (status, errors[])
├── QontoOAuthScopeError      (status=403)
└── QontoScaNotEnrolledError  (status=428, errors[].code="sca_not_enrolled")

QontoScaRequiredError (Error, scaSessionToken)   ← deliberately NOT extending QontoApiError
```

Because `QontoScaNotEnrolledError` deliberately does NOT extend `QontoScaRequiredError`, `executeWithSca` propagates it without polling — no code change required in the SCA handler.

`HttpClient` now disambiguates 428 responses via a `build428Error` helper applied in **both** 428 paths (primary + fallback-auth retry). The discriminator handles three body shapes:

1. `sca_session_token` present → `QontoScaRequiredError` (token wins when both fields present, defensive against malformed responses)
2. Top-level `code === "sca_not_enrolled"` → `QontoScaNotEnrolledError` (real Qonto flat shape per spike doc)
3. JSON:API `errors[]` entry with that code → `QontoScaNotEnrolledError` (defensive)
4. Unknown → `QontoScaRequiredError("unknown")` (preserves prior behaviour)

Surface layers:
- **CLI** (`error-handler.ts`): new branch with enrollment guidance + docs link, placed before generic `QontoApiError` in the dispatch chain.
- **MCP** (`errors.ts`): new `formatScaNotEnrolledError` returns `isError: true` (configuration error) — distinct from the structured `isError: false` pending shape used for `QontoScaRequiredError`.

## Files Changed

| File | Change |
|---|---|
| `packages/core/src/http-client.ts` | Add `QontoScaNotEnrolledError`; replace `extractScaSessionToken` with `build428Error` discriminator |
| `packages/core/src/index.ts` | Re-export `QontoScaNotEnrolledError` |
| `packages/core/src/http-client.test.ts` | +5 disambiguation tests + 6 class properties tests |
| `packages/core/src/sca/sca-handler.test.ts` | +1 test: `executeWithSca` propagates without polling |
| `packages/cli/src/error-handler.ts` | Add `QontoScaNotEnrolledError` branch with enrollment guidance |
| `packages/cli/src/error-handler.test.ts` | +2 tests (guidance + dispatch order) |
| `packages/cli/src/sca.test.ts` | +1 test: `executeWithCliSca` no spinner on not-enrolled |
| `packages/mcp/src/errors.ts` | Add `formatScaNotEnrolledError`; branch in `withClient` before generic |
| `packages/mcp/src/errors.test.ts` | +3 tests (distinct shape, NOT pending shape, dispatch order) |

## Acceptance Criteria

- [x] Introduce a typed error class for the not-enrolled case (`QontoScaNotEnrolledError extends QontoApiError`, prefix matches sibling http-level errors `QontoApiError`/`QontoOAuthScopeError`/`QontoRateLimitError`/`QontoScaRequiredError`).
- [x] `http-client.ts` distinguishes the two shapes by the presence/absence of `sca_session_token` in the body, and throws the appropriate class.
- [x] `executeWithSca` does NOT attempt to poll on `QontoScaNotEnrolledError` — it propagates the error so the caller can surface "enable SCA on the Qonto account" guidance.
- [x] CLI's `executeWithCliSca` surfaces a clear actionable message on `QontoScaNotEnrolledError` (link to enrollment docs) — implemented in `handleCliError`; `executeWithCliSca` itself does NOT start a spinner (verified by test).
- [x] MCP wrappers propagate the not-enrolled state as a distinct response shape (`isError: true`, configuration-error guidance) from the recoverable SCA-required state (`isError: false`, structured pending state).
- [x] Unit tests cover both 428 shapes with the right typed error.

## Test plan

- [x] `pnpm build` — 5/5 packages clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — all unit tests pass: core 852, cli 647, mcp 18 (all errors.test.ts)
- [x] `node scripts/check-licenses.js` — 96 deps, all allowed licenses
- [x] Coverage `http-client.ts`: 96.87/94.32/94.59/97.31 (above 85/75/80/85 thresholds)
- [ ] **E2E (local)**: blocked by environmental issue — running in a parallel-batch context where 5 worktree `.qontoctl.yaml` copies share an OAuth refresh-token chain. Sibling batch tracks refreshed first (track-2 at 20:43, track-3 at 20:44), invalidating this branch's refresh token. 147/244 E2E tests fail uniformly with `OAuth token request failed (400): invalid_grant` — 100% auth, 0% from this change. Cannot complete OAuth interactively in autonomous context. The `e2e-sandbox` CI job uses CI-side secrets and will exercise E2E paths against the live sandbox. Per spike doc Bug 5 / #434, E2E does not currently exercise SCA flows in any case, so this change cannot be regression-tested by E2E even with valid local tokens.

## References

- Spike: #438 / `docs/security/sca-token-binding.md` Bug 6
- Umbrella: #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)