### PR TITLE
(feat) add MCP executeWithMcpSca wrapper module (#433)

### DIFF
--- a/packages/mcp/src/sca.test.ts
+++ b/packages/mcp/src/sca.test.ts
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { HttpClient, QontoScaRequiredError, ScaDeniedError, ScaTimeoutError } from "@qontoctl/core";
+import { jsonResponse } from "@qontoctl/core/testing";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { executeWithMcpSca } from "./sca.js";
+
+class TestableHttpClient extends HttpClient {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override sleep(_ms: number): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const noopSleep = () => Promise.resolve();
+
+function formatStringSuccess(result: string): CallToolResult {
+  return {
+    content: [{ type: "text" as const, text: result }],
+    isError: false,
+  };
+}
+
+function getText(result: CallToolResult): string {
+  const first = result.content[0];
+  if (first === undefined || first.type !== "text") {
+    throw new Error("expected first content to be text");
+  }
+  return first.text;
+}
+
+describe("executeWithMcpSca", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: TestableHttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new TestableHttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("happy path", () => {
+    it("invokes formatSuccess with the operation result when no SCA is required", async () => {
+      const formatSuccess = vi.fn(formatStringSuccess);
+
+      const result = await executeWithMcpSca(client, async () => "ok", formatSuccess, {
+        poll: { sleep: noopSleep },
+      });
+
+      expect(formatSuccess).toHaveBeenCalledOnce();
+      expect(formatSuccess).toHaveBeenCalledWith("ok");
+      expect(result.isError).toBe(false);
+      expect(getText(result)).toBe("ok");
+    });
+  });
+
+  describe("with wait > 0 (default 30s polling path)", () => {
+    it("polls and retries with the SCA token on approval, returning formatSuccess", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async ({ scaSessionToken }) => {
+          callCount++;
+          if (callCount === 1) {
+            throw new QontoScaRequiredError("tok-mcp-success");
+          }
+          return `retried-with-${scaSessionToken ?? "none"}`;
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      expect(callCount).toBe(2);
+      expect(getText(result)).toBe("retried-with-tok-mcp-success");
+      expect(result.isError).toBe(false);
+    });
+
+    it("returns SCA-denied response when the user denies", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "deny" } }));
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          throw new QontoScaRequiredError("tok-mcp-deny");
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      expect(callCount).toBe(1);
+      const text = getText(result);
+      expect(text).toContain("SCA denied");
+      expect(text).toContain("rejected the approval");
+      expect(result.isError).toBe(false);
+    });
+  });
+
+  describe("with wait = 0 (pure two-step, no polling)", () => {
+    it("returns SCA-pending response immediately on 428 without polling", async () => {
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          throw new QontoScaRequiredError("tok-mcp-wait0");
+        },
+        formatStringSuccess,
+        { wait: 0 },
+      );
+
+      expect(callCount).toBe(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      const text = getText(result);
+      expect(text).toContain("tok-mcp-wait0");
+      expect(text).toContain("No inline poll was requested");
+      expect(result.isError).toBe(false);
+    });
+
+    it("invokes formatSuccess if the operation succeeds without SCA when wait=0", async () => {
+      const result = await executeWithMcpSca(client, async () => "ok-no-sca", formatStringSuccess, {
+        wait: 0,
+      });
+
+      expect(getText(result)).toBe("ok-no-sca");
+    });
+  });
+
+  describe("with wait = false (pure two-step, no polling)", () => {
+    it("returns SCA-pending response immediately on 428 without polling", async () => {
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          throw new QontoScaRequiredError("tok-mcp-waitfalse");
+        },
+        formatStringSuccess,
+        { wait: false },
+      );
+
+      expect(callCount).toBe(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      const text = getText(result);
+      expect(text).toContain("tok-mcp-waitfalse");
+      expect(text).toContain("No inline poll was requested");
+    });
+
+    it("invokes formatSuccess if the operation succeeds without SCA when wait=false", async () => {
+      const result = await executeWithMcpSca(client, async () => "ok-false", formatStringSuccess, {
+        wait: false,
+      });
+
+      expect(getText(result)).toBe("ok-false");
+    });
+  });
+
+  describe("with caller-supplied scaSessionToken", () => {
+    it("invokes the operation exactly once with the supplied token, no polling", async () => {
+      let callCount = 0;
+      let observedToken: string | undefined;
+
+      const result = await executeWithMcpSca(
+        client,
+        async ({ scaSessionToken }) => {
+          callCount++;
+          observedToken = scaSessionToken;
+          return `bound-with-${scaSessionToken ?? "none"}`;
+        },
+        formatStringSuccess,
+        { scaSessionToken: "tok-mcp-supplied" },
+      );
+
+      expect(callCount).toBe(1);
+      expect(observedToken).toBe("tok-mcp-supplied");
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(getText(result)).toBe("bound-with-tok-mcp-supplied");
+    });
+
+    it("returns a pending response if the supplied token retry yields a fresh challenge", async () => {
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          throw new QontoScaRequiredError("tok-mcp-fresh");
+        },
+        formatStringSuccess,
+        { scaSessionToken: "tok-mcp-supplied-stale" },
+      );
+
+      expect(callCount).toBe(1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      const text = getText(result);
+      expect(text).toContain("tok-mcp-fresh");
+      expect(text).not.toContain("tok-mcp-supplied-stale");
+    });
+
+    it("ignores wait when scaSessionToken is supplied", async () => {
+      let callCount = 0;
+
+      await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          return "ok";
+        },
+        formatStringSuccess,
+        { wait: 60, scaSessionToken: "tok-mcp-ignores-wait" },
+      );
+
+      expect(callCount).toBe(1);
+      // Polling never reached the HTTP transport.
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error propagation", () => {
+    it("rethrows non-SCA errors thrown by the operation in polling path", async () => {
+      const networkError = new Error("ECONNRESET");
+
+      await expect(
+        executeWithMcpSca(
+          client,
+          async () => {
+            throw networkError;
+          },
+          formatStringSuccess,
+          { wait: 10, poll: { sleep: noopSleep } },
+        ),
+      ).rejects.toBe(networkError);
+    });
+
+    it("rethrows non-SCA errors thrown by the operation in wait=0 path", async () => {
+      const apiError = new Error("validation failed");
+
+      await expect(
+        executeWithMcpSca(
+          client,
+          async () => {
+            throw apiError;
+          },
+          formatStringSuccess,
+          { wait: 0 },
+        ),
+      ).rejects.toBe(apiError);
+    });
+
+    it("rethrows non-SCA errors thrown by the operation in scaSessionToken path", async () => {
+      const apiError = new Error("validation failed");
+
+      await expect(
+        executeWithMcpSca(
+          client,
+          async () => {
+            throw apiError;
+          },
+          formatStringSuccess,
+          { scaSessionToken: "tok-mcp-supplied-throws" },
+        ),
+      ).rejects.toBe(apiError);
+    });
+  });
+
+  describe("ScaTimeoutError handling (synthetic from polling layer)", () => {
+    it("returns SCA-pending response when polling raises ScaTimeoutError", async () => {
+      // Simulate a ScaTimeoutError from the polling layer by injecting a sleep
+      // that throws synchronously the second time (mimicking a polling time
+      // budget exhausted before the session resolves). We bypass the polling
+      // layer's actual time math by stubbing Date.now() between attempts.
+      const realDateNow = Date.now;
+      let now = 1_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "waiting" } }));
+
+      const sleep = async () => {
+        // Advance virtual time past timeoutMs so the next iteration trips the
+        // elapsedMs >= timeoutMs check inside pollScaSession.
+        now += 10_000;
+      };
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-mcp-real-timeout");
+        },
+        formatStringSuccess,
+        { wait: 5, poll: { sleep, intervalMs: 1 } },
+      );
+
+      const text = getText(result);
+      expect(text).toContain("SCA required");
+      expect(text).toContain("tok-mcp-real-timeout");
+      expect(text).toContain("Polled for 5s without resolution");
+      expect(text).toContain("sca_session_show");
+      expect(result.isError).toBe(false);
+
+      Date.now = realDateNow;
+    });
+
+    it("returns SCA-pending response when the post-poll retry raises a fresh 428", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+      let callCount = 0;
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          callCount++;
+          if (callCount === 1) {
+            throw new QontoScaRequiredError("tok-mcp-first");
+          }
+          // Second attempt (after poll) re-issues a fresh challenge.
+          throw new QontoScaRequiredError("tok-mcp-fresh-after-poll");
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      expect(callCount).toBe(2);
+      const text = getText(result);
+      expect(text).toContain("tok-mcp-fresh-after-poll");
+      expect(text).not.toContain("tok-mcp-first");
+      expect(text).toContain("No inline poll was requested");
+      expect(result.isError).toBe(false);
+    });
+
+    it("returns SCA-denied response when polling raises ScaDeniedError directly", async () => {
+      // Force ScaDeniedError without going through the operation.
+      // We intercept executeWithSca by having the operation throw 428,
+      // then the poll fetch returns "deny".
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "deny" } }));
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-mcp-direct-deny");
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      // Sanity-check the error class names match what the wrapper expects.
+      expect(ScaDeniedError.name).toBe("ScaDeniedError");
+      expect(ScaTimeoutError.name).toBe("ScaTimeoutError");
+
+      const text = getText(result);
+      expect(text).toContain("SCA denied");
+      expect(result.isError).toBe(false);
+    });
+  });
+
+  describe("response text", () => {
+    it("references sca_session_show MCP tool, not the HTTP endpoint", async () => {
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-text-1");
+        },
+        formatStringSuccess,
+        { wait: 0 },
+      );
+
+      const text = getText(result);
+      expect(text).toContain("sca_session_show");
+      expect(text).not.toContain("/v2/sca/sessions/");
+      expect(text).not.toContain("Poll GET");
+    });
+
+    it("references sca_session_token continuation parameter", async () => {
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-text-2");
+        },
+        formatStringSuccess,
+        { wait: 0 },
+      );
+
+      expect(getText(result)).toContain("sca_session_token");
+    });
+
+    it("includes the session token in the pending response", async () => {
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-text-token-included");
+        },
+        formatStringSuccess,
+        { wait: 0 },
+      );
+
+      expect(getText(result)).toContain("tok-text-token-included");
+    });
+
+    it("indicates polling occurred when wait > 0 timed out", async () => {
+      const realDateNow = Date.now;
+      let now = 2_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "waiting" } }));
+
+      const sleep = async () => {
+        now += 100_000;
+      };
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-text-polled");
+        },
+        formatStringSuccess,
+        { wait: 7, poll: { sleep, intervalMs: 1 } },
+      );
+
+      expect(getText(result)).toContain("Polled for 7s");
+      Date.now = realDateNow;
+    });
+
+    it("indicates no polling occurred when wait=false", async () => {
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-text-nopoll");
+        },
+        formatStringSuccess,
+        { wait: false },
+      );
+
+      expect(getText(result)).toContain("No inline poll was requested");
+    });
+
+    it("denied response does not expose the session token", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "deny" } }));
+
+      const result = await executeWithMcpSca(
+        client,
+        async () => {
+          throw new QontoScaRequiredError("tok-deny-no-leak");
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      expect(getText(result)).not.toContain("tok-deny-no-leak");
+    });
+  });
+
+  describe("idempotency key", () => {
+    it("forwards a stable idempotency key across both attempts in the polling path", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+      const seenKeys: string[] = [];
+      let called = false;
+
+      await executeWithMcpSca(
+        client,
+        async ({ idempotencyKey }) => {
+          seenKeys.push(idempotencyKey);
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-idem-stable");
+          }
+          return "ok";
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep } },
+      );
+
+      expect(seenKeys).toHaveLength(2);
+      expect(seenKeys[0]).toBe(seenKeys[1]);
+    });
+
+    it("forwards a supplied idempotency key in the polling path", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+      const seenKeys: string[] = [];
+      let called = false;
+
+      await executeWithMcpSca(
+        client,
+        async ({ idempotencyKey }) => {
+          seenKeys.push(idempotencyKey);
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-idem-supplied");
+          }
+          return "ok";
+        },
+        formatStringSuccess,
+        { wait: 10, poll: { sleep: noopSleep }, idempotencyKey: "mcp-supplied-key" },
+      );
+
+      expect(seenKeys).toEqual(["mcp-supplied-key", "mcp-supplied-key"]);
+    });
+
+    it("forwards a supplied idempotency key in the wait=0 path", async () => {
+      const seenKeys: string[] = [];
+
+      await executeWithMcpSca(
+        client,
+        async ({ idempotencyKey }) => {
+          seenKeys.push(idempotencyKey);
+          return "ok";
+        },
+        formatStringSuccess,
+        { wait: 0, idempotencyKey: "mcp-wait0-key" },
+      );
+
+      expect(seenKeys).toEqual(["mcp-wait0-key"]);
+    });
+
+    it("forwards a supplied idempotency key in the scaSessionToken path", async () => {
+      const seenKeys: string[] = [];
+
+      await executeWithMcpSca(
+        client,
+        async ({ idempotencyKey }) => {
+          seenKeys.push(idempotencyKey);
+          return "ok";
+        },
+        formatStringSuccess,
+        { scaSessionToken: "tok-supplied-with-key", idempotencyKey: "mcp-token-key" },
+      );
+
+      expect(seenKeys).toEqual(["mcp-token-key"]);
+    });
+
+    it("generates an idempotency key when none supplied (wait=0 path)", async () => {
+      const seenKeys: string[] = [];
+
+      await executeWithMcpSca(
+        client,
+        async ({ idempotencyKey }) => {
+          seenKeys.push(idempotencyKey);
+          return "ok";
+        },
+        formatStringSuccess,
+        { wait: 0 },
+      );
+
+      expect(seenKeys).toHaveLength(1);
+      // UUID v4 shape
+      const key = seenKeys[0];
+      expect(key).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+  });
+
+  describe("defaults", () => {
+    it("defaults wait to 30 (uses polling path)", async () => {
+      // We verify the default by observing that a fresh QontoScaRequiredError
+      // engages the polling layer (fetchSpy is called for the SCA session
+      // poll). With wait=undefined the wrapper uses 30s.
+      fetchSpy.mockReturnValue(jsonResponse({ sca_session: { status: "allow" } }));
+      let called = false;
+
+      await executeWithMcpSca(
+        client,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-default-wait");
+          }
+          return "ok";
+        },
+        formatStringSuccess,
+        // No wait specified — should default to 30 (polling engaged).
+        { poll: { sleep: noopSleep } },
+      );
+
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/mcp/src/sca.ts
+++ b/packages/mcp/src/sca.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { randomUUID } from "node:crypto";
+import {
+  executeWithSca,
+  QontoScaRequiredError,
+  ScaDeniedError,
+  ScaTimeoutError,
+  type ExecuteWithScaContext,
+  type HttpClient,
+  type PollScaSessionOptions,
+} from "@qontoctl/core";
+
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+const DEFAULT_WAIT_SECONDS = 30;
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+const SCA_TOKEN_VALIDITY_MINUTES = 15;
+
+export interface McpScaOptions {
+  /**
+   * Maximum seconds to poll for SCA approval before falling back to a
+   * pending response. `false` or `0` disables polling entirely (pure
+   * two-step flow). Defaults to 30. Tool-boundary callers should
+   * Zod-enforce a max of 120 seconds.
+   */
+  readonly wait?: number | false | undefined;
+  /**
+   * Pre-existing SCA session token from a prior call that triggered SCA.
+   * When supplied, the wrapper invokes the operation exactly once with
+   * the token attached, performs no polling, and returns the result.
+   * Use this to bind a previously approved SCA challenge to a retry.
+   */
+  readonly scaSessionToken?: string | undefined;
+  /**
+   * Idempotency key forwarded to the operation. If unset, a UUID is
+   * generated once and shared across both wire attempts (initial 428 +
+   * post-SCA retry) when polling is engaged.
+   */
+  readonly idempotencyKey?: string | undefined;
+  /**
+   * Polling overrides. `intervalMs` defaults to 3000; `timeoutMs` is
+   * derived from `wait` and cannot be set here. `sleep` is the test seam
+   * for mocked timers.
+   */
+  readonly poll?: Pick<PollScaSessionOptions, "intervalMs" | "sleep" | "onPoll"> | undefined;
+}
+
+/**
+ * Execute an operation with SCA handling and MCP-appropriate response shaping.
+ *
+ * Three execution modes are selected by `options`:
+ *
+ * 1. **Pre-polled retry** (`options.scaSessionToken` is set): the operation
+ *    is invoked exactly once with the supplied SCA token. No polling.
+ * 2. **Pure two-step** (`options.wait` is `0` or `false`): the operation
+ *    is invoked once. On 428 the wrapper returns a structured pending
+ *    response immediately so the caller can poll out-of-band via
+ *    `sca_session_show` and retry with the captured token.
+ * 3. **Bounded poll** (`options.wait > 0`, the default): the wrapper
+ *    delegates to `executeWithSca`, polling for up to `wait` seconds at
+ *    a 3-second interval. On approval the operation is retried with the
+ *    SCA token and the success result is formatted via `formatSuccess`.
+ *    On poll timeout a structured pending response is returned so the
+ *    caller can continue out-of-band. On user denial a structured denied
+ *    response is returned (not an error — denial is a final user choice,
+ *    not a programming fault).
+ *
+ * Non-SCA errors thrown by the operation propagate to the caller, where
+ * `withClient` (in `errors.ts`) formats them as MCP error responses.
+ *
+ * @param client HttpClient used for SCA session polling.
+ * @param operation Function performing the API call. Receives a context
+ *   carrying the stable idempotency key and (on retry) the SCA session
+ *   token. Callers MUST forward `context.idempotencyKey` to the underlying
+ *   request so both wire attempts share an `X-Qonto-Idempotency-Key`.
+ * @param formatSuccess Maps the operation's success value to a
+ *   `CallToolResult`. Only invoked on a successful, non-SCA-pending result.
+ * @param options Wait, scaSessionToken, idempotencyKey, and poll overrides.
+ */
+export async function executeWithMcpSca<T>(
+  client: HttpClient,
+  operation: (context: ExecuteWithScaContext) => Promise<T>,
+  formatSuccess: (result: T) => CallToolResult,
+  options?: McpScaOptions,
+): Promise<CallToolResult> {
+  const wait = options?.wait ?? DEFAULT_WAIT_SECONDS;
+
+  if (options?.scaSessionToken !== undefined) {
+    return invokeOnceAndFormat(operation, formatSuccess, {
+      scaSessionToken: options.scaSessionToken,
+      idempotencyKey: options.idempotencyKey ?? randomUUID(),
+    });
+  }
+
+  if (wait === false || wait === 0) {
+    return invokeOnceAndFormat(operation, formatSuccess, {
+      idempotencyKey: options?.idempotencyKey ?? randomUUID(),
+    });
+  }
+
+  try {
+    const result = await executeWithSca(client, operation, {
+      poll: {
+        intervalMs: options?.poll?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+        timeoutMs: wait * 1000,
+        ...(options?.poll?.sleep !== undefined ? { sleep: options.poll.sleep } : {}),
+        ...(options?.poll?.onPoll !== undefined ? { onPoll: options.poll.onPoll } : {}),
+      },
+      ...(options?.idempotencyKey !== undefined ? { idempotencyKey: options.idempotencyKey } : {}),
+    });
+    return formatSuccess(result);
+  } catch (error: unknown) {
+    if (error instanceof ScaTimeoutError) {
+      return formatScaPendingResponse(error.scaSessionToken, wait);
+    }
+    if (error instanceof ScaDeniedError) {
+      return formatScaDeniedResponse();
+    }
+    if (error instanceof QontoScaRequiredError) {
+      return formatScaPendingResponse(error.scaSessionToken, false);
+    }
+    throw error;
+  }
+}
+
+async function invokeOnceAndFormat<T>(
+  operation: (context: ExecuteWithScaContext) => Promise<T>,
+  formatSuccess: (result: T) => CallToolResult,
+  context: ExecuteWithScaContext,
+): Promise<CallToolResult> {
+  try {
+    const result = await operation(context);
+    return formatSuccess(result);
+  } catch (error: unknown) {
+    if (error instanceof QontoScaRequiredError) {
+      return formatScaPendingResponse(error.scaSessionToken, false);
+    }
+    throw error;
+  }
+}
+
+function formatScaPendingResponse(token: string, wait: number | false): CallToolResult {
+  const polledLine =
+    wait === false || wait === 0
+      ? "No inline poll was requested; the SCA session is pending the user's decision."
+      : `Polled for ${String(wait)}s without resolution; the SCA session is still pending the user's decision.`;
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          "SCA required. The user must approve this operation on their Qonto mobile app.",
+          "",
+          polledLine,
+          "",
+          `Session token: ${token}`,
+          `Token validity: ${String(SCA_TOKEN_VALIDITY_MINUTES)} minutes from issuance.`,
+          "",
+          "To continue:",
+          `  1. Poll the session status with the \`sca_session_show\` tool, passing token: "${token}".`,
+          "  2. Once the status is `allow`, retry this tool with the same parameters PLUS",
+          `     \`sca_session_token: "${token}"\` to bind the approval to this operation.`,
+          "  3. Or call this tool again with a higher `wait` value (max 120 seconds) to poll inline.",
+          "",
+          "Note: PSD2 dynamic linking binds the session token to the original request",
+          "parameters (amount, payee). Reusing the token for a different operation will be",
+          "rejected by Qonto.",
+        ].join("\n"),
+      },
+    ],
+    isError: false,
+  };
+}
+
+function formatScaDeniedResponse(): CallToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: [
+          "SCA denied. The user rejected the approval on their Qonto mobile app.",
+          "",
+          "The operation was not performed. To proceed, retry the tool to issue a fresh",
+          "SCA challenge for the user to approve.",
+        ].join("\n"),
+      },
+    ],
+    isError: false,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `packages/mcp/src/sca.ts` exporting `executeWithMcpSca<T>(client, operation, formatSuccess, options)` — the MCP counterpart to `executeWithCliSca`. Wraps an SCA-aware operation and produces a `CallToolResult` with three execution modes:

- **Pre-polled retry** (`options.scaSessionToken` supplied): operation invoked exactly once with the token, no polling.
- **Pure two-step** (`options.wait` is `0` or `false`): operation invoked once; on 428 returns a structured pending response so callers can poll out-of-band via the `sca_session_show` MCP tool.
- **Bounded poll** (`options.wait > 0`, default 30): delegates to `executeWithSca` with `intervalMs: 3000` and `timeoutMs: wait * 1000`. On poll timeout returns a pending response; on user denial returns a non-error denied response.

Replaces the dead-end `formatScaRequiredResponse` path with two purpose-built formatters referencing the `sca_session_show` MCP tool and `sca_session_token` continuation parameter — not the HTTP endpoint. The pending response notes PSD2 dynamic linking (token bound to amount + payee) per the #438 spike outcome.

This module is a standalone building block for #428 (umbrella). Wiring into the eight MCP write tools is WI-G's responsibility (separate follow-up PR).

## Acceptance criteria coverage

- ✅ New `packages/mcp/src/sca.ts` exports `executeWithMcpSca<T>(client, operation, formatSuccess, options)` (file:line `sca.ts:78`).
- ✅ `options.wait`: `number | false`, default 30, max 120 Zod-enforced at tool boundary (`sca.ts:28`).
- ✅ `options.scaSessionToken`: `string | undefined`, retries directly when supplied (`sca.ts:34`, `sca.ts:86`).
- ✅ Bounded poll path uses `PollScaSessionOptions { intervalMs: 3000, timeoutMs: wait*1000 }`; on timeout returns `formatScaPendingResponse(token, wait)` (`sca.ts:99-117`).
- ✅ `ScaDeniedError` returns clean non-error response (`sca.ts:118-120`, `sca.ts:174-181`).
- ✅ Response text references MCP tools and continuation knob, not HTTP endpoints (verified by adversarial test asserting `not.toContain("/v2/sca/sessions/")`).
- ✅ Unit tests cover all 8 AC paths plus extras: 28/28 pass.

## Test plan

- [x] Unit tests pass (28 new tests in `packages/mcp/src/sca.test.ts`)
- [x] Coverage on new module: 100% statements / functions / lines, 93.75% branches
- [x] Full repo unit tests pass (322 MCP + all CLI / core / umbrella)
- [x] Lint, typecheck, prettier clean
- [x] License-check clean
- [ ] CI green (3-OS matrix)

## Local E2E status

E2E suite was run via the batch lock (`bash .tmp/do-all-20260506-0bca/e2e-lock.sh pnpm test:e2e`). 147 of 244 tests fail with `OAuth token request failed (400): invalid_grant` — the refresh token in the local `.qontoctl.yaml` is expired/revoked. **This is a pre-existing environmental issue unrelated to this change**: the wrapper has no consumers in production code yet (WI-G follow-up wires it in) and no E2E surface yet (#449/#450 adds SCA-flow E2E later). The remaining 85 E2E tests pass + 12 skip.

Per repo CLAUDE.md, the `e2e-sandbox` CI job is documented as not blocking the merge gate; the standard CI job (unit tests + lint + license-check) is the gate.

## Scope linkage

- Closes #433 (WI-F per `.tmp/scopes/sca-continuation.md`)
- Builds on #438 (PSD2 dynamic-linking verification — Outcome A confirmed)
- Inherits #429 (idempotency-key fix in core's `executeWithSca`)
- References #432 (the new MCP `sca_session_show` / `sca_session_mock_decision` tools)
- Building block for #428 (umbrella)

🤖 Generated with [Claude Code](https://claude.com/claude-code)