### PR TITLE
(fix) correct mockScaDecision URL and remove request body (#446)

### DIFF
--- a/packages/core/src/sca/sca-service.test.ts
+++ b/packages/core/src/sca/sca-service.test.ts
@@ -77,35 +77,54 @@ describe("SCA service", () => {
   });
 
   describe("mockScaDecision", () => {
-    it("sends POST to the correct mock endpoint with allow decision", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+    it("sends POST to the /allow path with no body for an allow decision", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
 
       await mockScaDecision(client, "tok-mock", "allow");
 
       const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/sca/sessions/mock/tok-mock/decision");
+      expect(url.pathname).toBe("/v2/mocked_sca_sessions/tok-mock/allow");
       expect(init.method).toBe("POST");
-      const body = JSON.parse(init.body as string) as Record<string, unknown>;
-      expect(body).toEqual({ decision: "allow" });
+      expect(init.body).toBeUndefined();
     });
 
-    it("sends deny decision", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+    it("sends POST to the /deny path with no body for a deny decision", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
 
       await mockScaDecision(client, "tok-mock", "deny");
 
-      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      const body = JSON.parse(init.body as string) as Record<string, unknown>;
-      expect(body).toEqual({ decision: "deny" });
+      const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/v2/mocked_sca_sessions/tok-mock/deny");
+      expect(init.method).toBe("POST");
+      expect(init.body).toBeUndefined();
     });
 
-    it("encodes the token in the URL", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+    it("does not set Content-Type when no body is sent", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
+
+      await mockScaDecision(client, "tok-mock", "allow");
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBeUndefined();
+    });
+
+    it("encodes the token in the URL but preserves the literal /allow suffix", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
 
       await mockScaDecision(client, "tok/special", "allow");
 
       const [url] = fetchSpy.mock.calls[0] as [URL];
-      expect(url.pathname).toBe("/v2/sca/sessions/mock/tok%2Fspecial/decision");
+      expect(url.pathname).toBe("/v2/mocked_sca_sessions/tok%2Fspecial/allow");
+    });
+
+    it("encodes the token in the URL but preserves the literal /deny suffix", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
+
+      await mockScaDecision(client, "tok/special", "deny");
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/mocked_sca_sessions/tok%2Fspecial/deny");
     });
   });
 

--- a/packages/core/src/sca/sca-service.ts
+++ b/packages/core/src/sca/sca-service.ts
@@ -24,11 +24,13 @@ export async function getScaSession(client: HttpClient, token: string): Promise<
 
 /**
  * Simulate a user SCA decision in sandbox mode.
+ *
+ * Posts to `POST /v2/mocked_sca_sessions/<token>/allow` or
+ * `/v2/mocked_sca_sessions/<token>/deny` (separate paths per decision)
+ * with no request body. Sandbox-only — production has no equivalent.
  */
 export async function mockScaDecision(client: HttpClient, token: string, decision: "allow" | "deny"): Promise<void> {
-  await client.requestVoid("POST", `/v2/sca/sessions/mock/${encodeURIComponent(token)}/decision`, {
-    body: { decision },
-  });
+  await client.requestVoid("POST", `/v2/mocked_sca_sessions/${encodeURIComponent(token)}/${decision}`);
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;

--- a/packages/mcp/src/tools/sca-session.test.ts
+++ b/packages/mcp/src/tools/sca-session.test.ts
@@ -99,7 +99,7 @@ describe("SCA session MCP tools", () => {
       });
 
       it("posts the decision and returns a confirmation payload", async () => {
-        fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+        fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
 
         const result = await mcpClient.callTool({
           name: "sca_session_mock_decision",
@@ -113,8 +113,8 @@ describe("SCA session MCP tools", () => {
         expect(parsed).toEqual({ token: "tok-mock", decision: "allow", mocked: true });
       });
 
-      it("calls POST /v2/sca/sessions/mock/<token>/decision with the decision body", async () => {
-        fetchSpy.mockReturnValue(jsonResponse({}, { status: 201 }));
+      it("calls POST /v2/mocked_sca_sessions/<token>/<decision> with no body", async () => {
+        fetchSpy.mockReturnValue(jsonResponse({}, { status: 200 }));
 
         await mcpClient.callTool({
           name: "sca_session_mock_decision",
@@ -122,10 +122,9 @@ describe("SCA session MCP tools", () => {
         });
 
         const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-        expect(url.pathname).toBe("/v2/sca/sessions/mock/tok-mock/decision");
+        expect(url.pathname).toBe("/v2/mocked_sca_sessions/tok-mock/deny");
         expect(init.method).toBe("POST");
-        const body = JSON.parse(init.body as string) as Record<string, unknown>;
-        expect(body).toEqual({ decision: "deny" });
+        expect(init.body).toBeUndefined();
       });
 
       it("formats Qonto API errors via the shared error wrapper", async () => {


### PR DESCRIPTION
## Summary

Fixes [#446](https://github.com/alexey-pelykh/qontoctl/issues/446). The Qonto sandbox uses two **separate paths** for the mock SCA decision endpoint with **no JSON body**:

- `POST /v2/mocked_sca_sessions/<token>/allow`
- `POST /v2/mocked_sca_sessions/<token>/deny`

The previous implementation called `POST /v2/sca/sessions/mock/<token>/decision` with body `{"decision":"allow"|"deny"}`, which 404s in production. The MCP tool `sca_session_mock_decision` (#432 / PR #440) and CLI `sca-session mock-decision` (#431 / PR #439) both wrap this function and were therefore non-functional in production.

## Why this URL/shape

Empirically verified against the live Qonto sandbox during the [#438 SCA token-binding spike](https://github.com/alexey-pelykh/qontoctl/issues/438):

- `docs/security/sca-token-binding.md:86-92` — recorded `POST /v2/mocked_sca_sessions/<tokenA>/allow → 200` from the experiment run on 2026-05-05
- `docs/security/sca-token-binding.md:128-132` — sandbox endpoint table: "Both endpoints take **no request body**. Returns 200 on success."
- `docs/security/sca-token-binding.md:186` — equivalent `curl` invocation

This issue is filed as Bug 4 in that document (`docs/security/sca-token-binding.md:147`).

## Changes

- `packages/core/src/sca/sca-service.ts` — change URL template to `/v2/mocked_sca_sessions/${encodeURIComponent(token)}/${decision}`; drop the body. Function signature unchanged: `(client, token, decision: "allow" | "deny") => Promise<void>`.
- `packages/core/src/sca/sca-service.test.ts` — replace 3 tests asserting the broken contract with 5 tests asserting the correct contract: `/allow` URL, `/deny` URL, no body, no `Content-Type` header, and token-encoding preserves the literal `/allow` and `/deny` suffix on both decisions.
- `packages/mcp/src/tools/sca-session.test.ts` — update the MCP-level wire test to assert the new URL and `init.body === undefined`. Status fixtures relaxed from 201 to 200 to reflect live behavior.

No callers (CLI, MCP, README) need source changes — function signature and user-facing descriptions are unchanged.

## Acceptance criteria

- [x] `mockScaDecision` calls `POST /v2/mocked_sca_sessions/<token>/allow` (for `decision: "allow"`) or `/deny` (for `decision: "deny"`).
- [x] No request body is sent.
- [x] Unit tests verify both URL paths and absence of body.
- [ ] An E2E sandbox test exercises the real flow end-to-end — **deferred to [#434](https://github.com/alexey-pelykh/qontoctl/issues/434)** per the issue's own AC note: this depends on Bug 5 follow-up exposing `scaMethod` to make a real SCA challenge possible to trigger in CI.
- [x] CLI/MCP tool descriptions continue to reflect the underlying behavior accurately (descriptions are semantic; no URL/body claims to drift against).

## Test plan

- [x] `pnpm build` — clean across all 5 packages
- [x] `pnpm test` — all unit suites green (core + cli + mcp)
- [x] `pnpm lint` — clean
- [x] `pnpm license-check` — clean
- [x] `pnpm test:e2e` — 48 failures observed, all confirmed pre-existing on `origin/main` (verified by re-running E2E with these 3 files reverted: same 48-failure count). Failures are concentrated in OAuth-scope-gated paths (webhooks, payment-link, intl beneficiary/eligibility/currencies, teams, cards list, recurring/bulk transfer create) — none touch SCA. The MCP server e2e (which references `sca_session_mock_decision` in `EXPECTED_TOOLS`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)