### PR TITLE
(feat) expose scaMethod / X-Qonto-2fa-Preference through createClient and CLI/MCP (#447)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ ESLint enforces this via `eslint-plugin-header`.
 
 **Staging token:** The `oauth.staging-token` config field (or `QONTOCTL_STAGING_TOKEN` env var) injects an `X-Qonto-Staging-Token` header into all API requests, routing them to the Qonto sandbox environment. The staging token lives inside the `oauth` section because the sandbox is OAuth-only. When a staging token is present, sandbox URLs are used automatically. The staging token is also sent with OAuth token exchange, refresh, and revocation requests.
 
+**SCA method:** The `sca.method` config field (or `QONTOCTL_SCA_METHOD` env var, or hidden `--sca-method <value>` CLI flag) sets the `X-Qonto-2fa-Preference` header on write requests. Production accepts `paired-device`, `passkey`, `sms-otp`; sandbox additionally accepts `mock`. When a staging token is present and no method is otherwise set, QontoCtl auto-defaults to `"mock"` so sandbox writes work without a paired-device enrollment. **Production never auto-defaults.** The MCP server resolves the method from env/config only — it is intentionally NOT exposed as a tool input, so an LLM client cannot pick the SCA method on a write. See `docs/sandbox-testing.md`.
+
 **E2E sandbox in CI:** When `QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`, and `QONTOCTL_REFRESH_TOKEN` secrets are configured in the repository, the `e2e-sandbox` CI job runs E2E tests against the sandbox environment after the main CI job passes. This job is not part of the CI gate and does not block merging.
 
 **Running:**

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -147,7 +147,7 @@ export QONTOCTL_CLIENT_ID="sandbox-client-id"
 export QONTOCTL_CLIENT_SECRET="sandbox-client-secret"
 ```
 
-When `oauth.staging-token` is configured (or the `QONTOCTL_STAGING_TOKEN` env var is set), sandbox URLs are used automatically.
+When `oauth.staging-token` is configured (or the `QONTOCTL_STAGING_TOKEN` env var is set), sandbox URLs are used automatically. SCA writes against sandbox additionally need an `X-Qonto-2fa-Preference: mock` header — QontoCtl auto-applies this when a staging token is set. See [`sandbox-testing.md`](./sandbox-testing.md) for SCA-method overrides and the `qontoctl sca-session mock-decision` workflow.
 
 The sandbox uses separate OAuth endpoints:
 

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -1,0 +1,102 @@
+# Sandbox Testing Guide
+
+Notes for exercising QontoCtl against the [Qonto sandbox](https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows). Production users do not need to read this — the sandbox-only behavior described here is gated behind a staging token and never auto-engages on production traffic.
+
+## Why this guide exists
+
+Sandbox accounts cannot enroll a real paired device. Without an enrollment, every "write" request to Qonto (create transfer, update card, …) returns `428 sca_not_enrolled` regardless of credentials. The Qonto sandbox provides a `mock` SCA flow for this, but it is opt-in via the `X-Qonto-2fa-Preference` HTTP header. QontoCtl exposes that header through:
+
+- The `sca.method` config field
+- The `QONTOCTL_SCA_METHOD` env var (and profile-scoped `QONTOCTL_{PROFILE}_SCA_METHOD`)
+- The hidden `--sca-method <value>` CLI flag (advanced; for testing)
+
+When a [staging token](./oauth-setup.md#sandbox-setup) is configured and `sca.method` is **unset**, QontoCtl auto-defaults to `mock` so sandbox writes work out-of-the-box. **Production paths never auto-default**: omit the staging token and the header is omitted, letting Qonto apply its own rules.
+
+## Allowed values
+
+| Value           | Where        | Notes                                                                                        |
+| --------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| `paired-device` | Production   | Default when the header is omitted; requires the user to have enrolled a paired device.      |
+| `passkey`       | Production   | Passkey-based SCA.                                                                           |
+| `sms-otp`       | Production   | SMS one-time-password fallback.                                                              |
+| `mock`          | Sandbox only | Triggers a mock SCA challenge that can be approved via `qontoctl sca-session mock-decision`. |
+
+Setting `mock` against the production endpoint is a configuration error — Qonto will reject the request. Setting any of `paired-device` / `passkey` / `sms-otp` against a sandbox account that hasn't enrolled returns `428 sca_not_enrolled`.
+
+## Configuration
+
+### Profile YAML
+
+```yaml
+oauth:
+    client-id: "sandbox-client-id"
+    client-secret: "sandbox-client-secret"
+    staging-token: "your-staging-token"
+sca:
+    method: mock # explicit; auto-defaults to "mock" when omitted in sandbox
+```
+
+### Environment variables
+
+```sh
+export QONTOCTL_STAGING_TOKEN="your-staging-token"
+export QONTOCTL_CLIENT_ID="sandbox-client-id"
+export QONTOCTL_CLIENT_SECRET="sandbox-client-secret"
+
+# Optional — only needed if you want to override the sandbox auto-default
+export QONTOCTL_SCA_METHOD="mock"
+```
+
+With a named profile, every variable picks up the profile prefix:
+
+```sh
+export QONTOCTL_SANDBOX_STAGING_TOKEN="..."
+export QONTOCTL_SANDBOX_SCA_METHOD="mock"
+```
+
+### CLI flag (testing only)
+
+```sh
+qontoctl --sca-method paired-device transfer create ...
+```
+
+The flag is **hidden from `--help`** because end users should not need it: production defaults are correct, sandbox auto-defaults to `mock`. It exists so engineers can override the resolved value when reproducing sandbox edge cases.
+
+## Precedence
+
+Highest wins:
+
+1. `--sca-method <value>` CLI flag
+2. `QONTOCTL_SCA_METHOD` env var (and profile-scoped variant)
+3. `sca.method` field in the profile YAML
+4. Sandbox auto-default `"mock"` (only when a staging token is configured)
+5. Otherwise: header is omitted (Qonto applies its own default — `paired-device` in production)
+
+## MCP server behavior
+
+The MCP server resolves the SCA method from **environment / config only** — there is no MCP tool input parameter for it. This is deliberate: letting an LLM client choose the SCA method on a write is a threat-model risk in production. Operators control the SCA method by setting env vars or config; the LLM cannot.
+
+Sandbox MCP testing therefore looks like:
+
+```sh
+QONTOCTL_STAGING_TOKEN="..." \
+  QONTOCTL_CLIENT_ID="..." \
+  QONTOCTL_CLIENT_SECRET="..." \
+  qontoctl mcp serve  # auto-defaults sca.method to "mock"
+```
+
+## Approving sandbox SCA challenges
+
+Once a write returns `428 sca_required` with a session token, approve via:
+
+```sh
+qontoctl sca-session mock-decision <token> allow
+```
+
+The corresponding MCP tool is `sca_session_mock_decision`. Both are sandbox-only and refuse to run when no staging token is configured.
+
+## See also
+
+- [`oauth-setup.md`](./oauth-setup.md) — OAuth app registration, including sandbox setup
+- [`security/sca-token-binding.md`](./security/sca-token-binding.md) — empirical verification of SCA token request-binding (PSD2 Art. 5)
+- [Qonto SCA flow reference](https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows)

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -286,4 +286,144 @@ describe("createClient", () => {
       "Warning: OAuth authentication failed, falling back to API key for GET /v2/organizations\n",
     );
   });
+
+  describe("scaMethod plumbing", () => {
+    it("does not pass scaMethod by default (production, no override)", async () => {
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBeUndefined();
+    });
+
+    it("forwards --sca-method flag value to HttpClient", async () => {
+      const options: GlobalOptions = { output: "table", scaMethod: "passkey" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("passkey");
+    });
+
+    it("forwards config.sca.method when no flag override", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          apiKey: { organizationSlug: "org", secretKey: "secret" },
+          sca: { method: "sms-otp" },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("sms-otp");
+    });
+
+    it("--sca-method flag wins over config.sca.method", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          apiKey: { organizationSlug: "org", secretKey: "secret" },
+          sca: { method: "passkey" },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table", scaMethod: "paired-device" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("paired-device");
+    });
+
+    it('auto-defaults to "mock" when sandbox (stagingToken set) and no override or config', async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "at",
+            stagingToken: "tok_sandbox",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+        },
+        endpoint: "https://thirdparty-sandbox.staging.qonto.co",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("mock");
+    });
+
+    it("config.sca.method wins over sandbox auto-default", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "at",
+            stagingToken: "tok_sandbox",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+          sca: { method: "passkey" },
+        },
+        endpoint: "https://thirdparty-sandbox.staging.qonto.co",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("passkey");
+    });
+
+    it("--sca-method flag wins over sandbox auto-default", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "at",
+            stagingToken: "tok_sandbox",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+        },
+        endpoint: "https://thirdparty-sandbox.staging.qonto.co",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table", scaMethod: "paired-device" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBe("paired-device");
+    });
+
+    it("does NOT auto-default in production (no stagingToken)", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "at",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.scaMethod).toBeUndefined();
+    });
+  });
 });

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -6,6 +6,7 @@ import {
   type HttpClientLogger,
   HttpClient,
   resolveConfig,
+  resolveScaMethod,
   buildApiKeyAuthorization,
   createOAuthAuthorization,
   OAUTH_TOKEN_URL,
@@ -67,6 +68,8 @@ export async function createClient(options: GlobalOptions): Promise<HttpClient> 
     };
   }
 
+  const scaMethod = resolveScaMethod(config, options.scaMethod);
+
   return new HttpClient({
     baseUrl: endpoint,
     authorization,
@@ -76,5 +79,6 @@ export async function createClient(options: GlobalOptions): Promise<HttpClient> 
     },
     logger,
     stagingToken: config.oauth?.stagingToken,
+    ...(scaMethod !== undefined ? { scaMethod } : {}),
   });
 }

--- a/packages/cli/src/inherited-options.test.ts
+++ b/packages/cli/src/inherited-options.test.ts
@@ -6,7 +6,7 @@ import { Command, Option } from "commander";
 import { addInheritableOptions, resolveGlobalOptions } from "./inherited-options.js";
 
 describe("addInheritableOptions", () => {
-  it("adds --profile, --verbose, and --debug to a command", () => {
+  it("adds --profile, --verbose, --debug, and --sca-method to a command", () => {
     const cmd = new Command("test");
     addInheritableOptions(cmd);
 
@@ -14,6 +14,7 @@ describe("addInheritableOptions", () => {
     expect(optionNames).toContain("--profile");
     expect(optionNames).toContain("--verbose");
     expect(optionNames).toContain("--debug");
+    expect(optionNames).toContain("--sca-method");
   });
 
   it("adds -p as shorthand for --profile", () => {
@@ -22,6 +23,14 @@ describe("addInheritableOptions", () => {
 
     const profileOption = cmd.options.find((o) => o.long === "--profile");
     expect(profileOption?.short).toBe("-p");
+  });
+
+  it("hides --sca-method from help", () => {
+    const cmd = new Command("test");
+    addInheritableOptions(cmd);
+
+    const scaOption = cmd.options.find((o) => o.long === "--sca-method");
+    expect(scaOption?.hidden).toBe(true);
   });
 });
 

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -12,7 +12,8 @@ export function addInheritableOptions(cmd: Command): Command {
   return cmd
     .addOption(new Option("-p, --profile <name>", "configuration profile to use"))
     .addOption(new Option("--verbose", "enable verbose output"))
-    .addOption(new Option("--debug", "enable debug output (implies --verbose)"));
+    .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
+    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp());
 }
 
 /**

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -19,6 +19,12 @@ export interface GlobalOptions {
   readonly output: OutputFormat;
   readonly verbose?: true | undefined;
   readonly debug?: true | undefined;
+  /**
+   * SCA method preference (`X-Qonto-2fa-Preference` header). Hidden flag for
+   * advanced/testing use; in production, leave unset and let Qonto apply its
+   * default. See `docs/sandbox-testing.md`.
+   */
+  readonly scaMethod?: string | undefined;
 }
 
 /**

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -306,6 +306,17 @@ describe("createProgram", () => {
       const program = parseGlobalOptions(["-o", "yaml"]);
       expect(program.opts()["output"]).toBe("yaml");
     });
+
+    it("parses --sca-method option", () => {
+      const program = parseGlobalOptions(["--sca-method", "passkey"]);
+      expect(program.opts()["scaMethod"]).toBe("passkey");
+    });
+
+    it("does not include --sca-method in help output (hidden)", () => {
+      const program = createProgram();
+      const helpText = program.helpInformation();
+      expect(helpText).not.toContain("--sca-method");
+    });
   });
 
   describe("pagination options", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -41,7 +41,8 @@ export function createProgram(): Command {
     .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
     .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
     .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
-    .addOption(new Option("--no-paginate", "disable auto-pagination"));
+    .addOption(new Option("--no-paginate", "disable auto-pagination"))
+    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp());
 
   registerCompletionCommand(program);
   registerBeneficiaryCommands(program);

--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -279,4 +279,53 @@ describe("applyEnvOverlay", () => {
     const result = applyEnvOverlay(config, { env: {} });
     expect(result.oauth?.stagingToken).toBe("file_token");
   });
+
+  it("overlays QONTOCTL_SCA_METHOD env var into sca section", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      env: { QONTOCTL_SCA_METHOD: "passkey" },
+    });
+    expect(result.sca?.method).toBe("passkey");
+  });
+
+  it("creates sca section when SCA_METHOD env var is set but no sca in config", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      env: { QONTOCTL_SCA_METHOD: "mock" },
+    });
+    expect(result.sca).toBeDefined();
+    expect(result.sca?.method).toBe("mock");
+  });
+
+  it("SCA_METHOD env var overrides file sca.method", () => {
+    const config = { sca: { method: "passkey" } };
+    const result = applyEnvOverlay(config, {
+      env: { QONTOCTL_SCA_METHOD: "sms-otp" },
+    });
+    expect(result.sca?.method).toBe("sms-otp");
+  });
+
+  it("overlays profile-scoped SCA_METHOD env var", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      profile: "staging",
+      env: { QONTOCTL_STAGING_SCA_METHOD: "mock" },
+    });
+    expect(result.sca?.method).toBe("mock");
+  });
+
+  it("returns config unchanged when no SCA_METHOD env var is set", () => {
+    const config = { sca: { method: "passkey" } };
+    const result = applyEnvOverlay(config, { env: {} });
+    expect(result.sca?.method).toBe("passkey");
+  });
+
+  it("ignores bare SCA_METHOD when profile is specified", () => {
+    const config = {};
+    const result = applyEnvOverlay(config, {
+      profile: "staging",
+      env: { QONTOCTL_SCA_METHOD: "mock" },
+    });
+    expect(result.sca).toBeUndefined();
+  });
 });

--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -12,18 +12,21 @@ const CLIENT_SECRET_SUFFIX = "CLIENT_SECRET";
 const ACCESS_TOKEN_SUFFIX = "ACCESS_TOKEN";
 const REFRESH_TOKEN_SUFFIX = "REFRESH_TOKEN";
 const STAGING_TOKEN_SUFFIX = "STAGING_TOKEN";
+const SCA_METHOD_SUFFIX = "SCA_METHOD";
 
 /**
  * Overlays environment variables onto a config.
  *
  * - Without profile: reads `QONTOCTL_ORGANIZATION_SLUG`, `QONTOCTL_SECRET_KEY`,
  *   `QONTOCTL_ENDPOINT`, `QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`,
- *   `QONTOCTL_ACCESS_TOKEN`, `QONTOCTL_REFRESH_TOKEN`, and `QONTOCTL_STAGING_TOKEN`
+ *   `QONTOCTL_ACCESS_TOKEN`, `QONTOCTL_REFRESH_TOKEN`, `QONTOCTL_STAGING_TOKEN`,
+ *   and `QONTOCTL_SCA_METHOD`
  * - With profile: reads `QONTOCTL_{PROFILE}_ORGANIZATION_SLUG`,
  *   `QONTOCTL_{PROFILE}_SECRET_KEY`, `QONTOCTL_{PROFILE}_ENDPOINT`,
  *   `QONTOCTL_{PROFILE}_CLIENT_ID`, `QONTOCTL_{PROFILE}_CLIENT_SECRET`,
- *   `QONTOCTL_{PROFILE}_ACCESS_TOKEN`, `QONTOCTL_{PROFILE}_REFRESH_TOKEN`, and
- *   `QONTOCTL_{PROFILE}_STAGING_TOKEN` (profile name uppercased, hyphens→underscores)
+ *   `QONTOCTL_{PROFILE}_ACCESS_TOKEN`, `QONTOCTL_{PROFILE}_REFRESH_TOKEN`,
+ *   `QONTOCTL_{PROFILE}_STAGING_TOKEN`, and `QONTOCTL_{PROFILE}_SCA_METHOD`
+ *   (profile name uppercased, hyphens→underscores)
  *
  * Env vars take precedence over file values.
  */
@@ -45,6 +48,7 @@ export function applyEnvOverlay(
   const accessToken = env[`${prefix}_${ACCESS_TOKEN_SUFFIX}`];
   const refreshToken = env[`${prefix}_${REFRESH_TOKEN_SUFFIX}`];
   const stagingToken = env[`${prefix}_${STAGING_TOKEN_SUFFIX}`];
+  const scaMethod = env[`${prefix}_${SCA_METHOD_SUFFIX}`];
 
   let result = config;
 
@@ -99,6 +103,10 @@ export function applyEnvOverlay(
         stagingToken,
       },
     };
+  }
+
+  if (scaMethod !== undefined) {
+    result = { ...result, sca: { ...result.sca, method: scaMethod } };
   }
 
   return result;

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,8 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-export type { ApiKeyCredentials, OAuthCredentials, QontoctlConfig, ConfigResult, ResolveOptions } from "./types.js";
-export { resolveConfig, ConfigError } from "./resolve.js";
+export type {
+  ApiKeyCredentials,
+  OAuthCredentials,
+  QontoctlConfig,
+  ConfigResult,
+  ResolveOptions,
+  ScaConfig,
+} from "./types.js";
+export { resolveConfig, resolveScaMethod, ConfigError } from "./resolve.js";
 export { loadConfigFile } from "./loader.js";
 export type { LoadResult } from "./loader.js";
 export { isValidProfileName, validateConfig } from "./validate.js";

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -6,7 +6,7 @@ import { mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { resolveConfig, ConfigError } from "./resolve.js";
+import { resolveConfig, resolveScaMethod, ConfigError } from "./resolve.js";
 
 describe("resolveConfig", () => {
   let testDir: string;
@@ -288,5 +288,94 @@ describe("resolveConfig", () => {
       },
     });
     expect(result.endpoint).toBe("https://env.example.com");
+  });
+
+  it("loads sca.method from config file", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization-slug: org\n  secret-key: secret\nsca:\n  method: passkey\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: {},
+    });
+    expect(result.config.sca?.method).toBe("passkey");
+  });
+
+  it("QONTOCTL_SCA_METHOD env var overlays sca.method", async () => {
+    await writeFile(
+      join(testDir, ".qontoctl.yaml"),
+      "api-key:\n  organization-slug: org\n  secret-key: secret\nsca:\n  method: passkey\n",
+    );
+
+    const result = await resolveConfig({
+      cwd: testDir,
+      home: testHome,
+      env: { QONTOCTL_SCA_METHOD: "sms-otp" },
+    });
+    expect(result.config.sca?.method).toBe("sms-otp");
+  });
+});
+
+describe("resolveScaMethod", () => {
+  it("returns override when provided", () => {
+    expect(resolveScaMethod({}, "paired-device")).toBe("paired-device");
+  });
+
+  it("override wins over config and sandbox default", () => {
+    expect(
+      resolveScaMethod(
+        {
+          sca: { method: "passkey" },
+          oauth: { clientId: "c", clientSecret: "s", stagingToken: "tok" },
+        },
+        "paired-device",
+      ),
+    ).toBe("paired-device");
+  });
+
+  it("returns config.sca.method when no override", () => {
+    expect(resolveScaMethod({ sca: { method: "sms-otp" } })).toBe("sms-otp");
+  });
+
+  it("config wins over sandbox default", () => {
+    expect(
+      resolveScaMethod({
+        sca: { method: "passkey" },
+        oauth: { clientId: "c", clientSecret: "s", stagingToken: "tok" },
+      }),
+    ).toBe("passkey");
+  });
+
+  it('returns "mock" when in sandbox and no override or config', () => {
+    expect(
+      resolveScaMethod({
+        oauth: { clientId: "c", clientSecret: "s", stagingToken: "tok" },
+      }),
+    ).toBe("mock");
+  });
+
+  it("does NOT auto-default in production (no staging token)", () => {
+    expect(resolveScaMethod({})).toBeUndefined();
+    expect(
+      resolveScaMethod({
+        oauth: { clientId: "c", clientSecret: "s" },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveScaMethod({
+        apiKey: { organizationSlug: "org", secretKey: "sec" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does NOT auto-default when override is undefined but config has empty sca", () => {
+    expect(resolveScaMethod({ sca: {} })).toBeUndefined();
+  });
+
+  it("undefined override is treated as no override (falls through to config/default)", () => {
+    expect(resolveScaMethod({ sca: { method: "passkey" } }, undefined)).toBe("passkey");
   });
 });

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import type { ConfigResult, ResolveOptions } from "./types.js";
+import type { ConfigResult, QontoctlConfig, ResolveOptions } from "./types.js";
 import { loadConfigFile } from "./loader.js";
 import { validateConfig } from "./validate.js";
 import { applyEnvOverlay } from "./env.js";
 import { API_BASE_URL, SANDBOX_BASE_URL } from "../constants.js";
+
+/**
+ * Sandbox-only SCA method that triggers a mock SCA challenge instead of
+ * requiring a paired-device enrollment. Defaulted automatically when a
+ * staging token is configured and no method is otherwise set, so
+ * sandbox-targeted code paths get an exercisable SCA flow out of the box.
+ */
+const SANDBOX_DEFAULT_SCA_METHOD = "mock";
 
 export class ConfigError extends Error {
   constructor(message: string) {
@@ -97,6 +105,37 @@ function resolveEndpoint(config: { endpoint?: string; oauth?: { stagingToken?: s
     return SANDBOX_BASE_URL;
   }
   return API_BASE_URL;
+}
+
+/**
+ * Resolves the effective SCA method (`X-Qonto-2fa-Preference` header value).
+ *
+ * Precedence (highest first):
+ *   1. `override` — caller-provided value (e.g., the `--sca-method` CLI flag).
+ *   2. `config.sca.method` — file or env-overlaid value.
+ *   3. Sandbox auto-default `"mock"` — applied only when a staging token is
+ *      present (i.e. `config.oauth.stagingToken` is set), so sandbox writes
+ *      can complete without a paired-device enrollment. **Production paths
+ *      never auto-default**: if no staging token is configured and no
+ *      override/config method is provided, the result is `undefined` and the
+ *      header is omitted (Qonto then applies its own default).
+ *
+ * The shape (`paired-device`, `passkey`, `sms-otp`, `mock`) is passed through
+ * verbatim — Qonto's API governs which values are valid for the active
+ * environment. Mis-use returns `428 sca_not_enrolled`/configuration errors;
+ * it does not corrupt state.
+ */
+export function resolveScaMethod(config: QontoctlConfig, override?: string): string | undefined {
+  if (override !== undefined) {
+    return override;
+  }
+  if (config.sca?.method !== undefined) {
+    return config.sca.method;
+  }
+  if (config.oauth?.stagingToken !== undefined) {
+    return SANDBOX_DEFAULT_SCA_METHOD;
+  }
+  return undefined;
 }
 
 function describeSearchLocations(profile: string | undefined, loadedPath: string | undefined): string {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -26,12 +26,26 @@ export interface OAuthCredentials {
 }
 
 /**
+ * SCA-related configuration.
+ */
+export interface ScaConfig {
+  /**
+   * SCA method preference, sent as the `X-Qonto-2fa-Preference` header on
+   * write requests. Production allows `paired-device`, `passkey`, `sms-otp`;
+   * sandbox additionally allows `mock`. Free-form `string` to accommodate
+   * future Qonto values without a core release.
+   */
+  method?: string;
+}
+
+/**
  * Parsed configuration from a `.qontoctl.yaml` file.
  */
 export interface QontoctlConfig {
   apiKey?: ApiKeyCredentials;
   oauth?: OAuthCredentials;
   endpoint?: string;
+  sca?: ScaConfig;
 }
 
 /**

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -275,6 +275,57 @@ describe("validateConfig", () => {
     const result = validateConfig({ "staging-token": "tok_abc123" });
     expect(result.warnings).toContain('Unknown configuration key: "staging-token"');
   });
+
+  it("parses valid sca.method", () => {
+    const result = validateConfig({ sca: { method: "passkey" } });
+    expect(result.config.sca).toEqual({ method: "passkey" });
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("accepts hyphenated header values like paired-device", () => {
+    const result = validateConfig({ sca: { method: "paired-device" } });
+    expect(result.config.sca).toEqual({ method: "paired-device" });
+    expect(result.errors).toEqual([]);
+  });
+
+  it("allows null sca section", () => {
+    const result = validateConfig({ sca: null });
+    expect(result.config.sca).toBeUndefined();
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns empty config for empty sca mapping", () => {
+    const result = validateConfig({ sca: {} });
+    expect(result.config.sca).toBeUndefined();
+    expect(result.errors).toEqual([]);
+  });
+
+  it("errors when sca section is not a mapping", () => {
+    const result = validateConfig({ sca: "passkey" });
+    expect(result.errors).toContain('"sca" must be a mapping');
+  });
+
+  it("errors when sca section is an array", () => {
+    const result = validateConfig({ sca: [] });
+    expect(result.errors).toContain('"sca" must be a mapping');
+  });
+
+  it("errors when sca.method is not a string", () => {
+    const result = validateConfig({ sca: { method: 123 } });
+    expect(result.errors).toContain('"sca.method" must be a string');
+  });
+
+  it("warns on unknown keys inside sca", () => {
+    const result = validateConfig({ sca: { method: "passkey", future: "value" } });
+    expect(result.warnings).toContain('Unknown key in "sca": "future"');
+    expect(result.config.sca).toEqual({ method: "passkey" });
+  });
+
+  it("does not warn on sca as known top-level key", () => {
+    const result = validateConfig({ sca: { method: "mock" } });
+    expect(result.warnings).toEqual([]);
+  });
 });
 
 describe("isValidProfileName", () => {

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -13,7 +13,7 @@ export function isValidProfileName(name: string): boolean {
   return !/[/\\]/.test(name) && !name.includes("..");
 }
 
-const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key", "oauth", "endpoint"]);
+const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key", "oauth", "endpoint", "sca"]);
 const KNOWN_API_KEY_KEYS = new Set(["organization-slug", "secret-key"]);
 const KNOWN_OAUTH_KEYS = new Set([
   "client-id",
@@ -25,6 +25,7 @@ const KNOWN_OAUTH_KEYS = new Set([
   "scopes",
   "staging-token",
 ]);
+const KNOWN_SCA_KEYS = new Set(["method"]);
 
 export interface ValidationResult {
   config: QontoctlConfig;
@@ -176,6 +177,34 @@ export function validateConfig(raw: unknown): ValidationResult {
         } catch {
           errors.push('"endpoint" must be a valid URL');
         }
+      }
+    }
+  }
+
+  if ("sca" in doc) {
+    const scaSection = doc["sca"];
+
+    if (scaSection === null || scaSection === undefined) {
+      // sca section present but empty — not an error
+    } else if (typeof scaSection !== "object" || Array.isArray(scaSection)) {
+      errors.push('"sca" must be a mapping');
+    } else {
+      const sca = scaSection as Record<string, unknown>;
+
+      for (const key of Object.keys(sca)) {
+        if (!KNOWN_SCA_KEYS.has(key)) {
+          warnings.push(`Unknown key in "sca": "${key}"`);
+        }
+      }
+
+      const method = sca["method"];
+
+      if (method !== undefined && typeof method !== "string") {
+        errors.push('"sca.method" must be a string');
+      }
+
+      if (typeof method === "string") {
+        config.sca = { method };
       }
     }
   }

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -111,7 +111,14 @@ export interface HttpClientOptions {
   /** Maximum number of retries on 429 responses. Defaults to 5. */
   readonly maxRetries?: number | undefined;
 
-  /** SCA method preference for write requests. Sent as `X-Qonto-2fa-Preference` header. */
+  /**
+   * SCA method preference for write requests. Sent verbatim as the
+   * `X-Qonto-2fa-Preference` header (omitted when undefined). Production
+   * accepts `paired-device`, `passkey`, `sms-otp`; sandbox additionally
+   * accepts `mock`. The default-resolution policy (sandbox auto-default,
+   * env, config) lives in `resolveScaMethod`; this field is a raw transport
+   * option.
+   */
   readonly scaMethod?: string | undefined;
 
   /** Staging token sent as `X-Qonto-Staging-Token` to route requests to the sandbox environment. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
 
 export {
   resolveConfig,
+  resolveScaMethod,
   ConfigError,
   isValidProfileName,
   loadConfigFile,
@@ -35,6 +36,7 @@ export type {
   QontoctlConfig,
   ConfigResult,
   ResolveOptions,
+  ScaConfig,
   LoadResult,
   ValidationResult,
   TokenUpdate,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,6 +7,7 @@ import {
   buildApiKeyAuthorization,
   createOAuthAuthorization,
   resolveConfig,
+  resolveScaMethod,
   OAUTH_TOKEN_URL,
   OAUTH_TOKEN_SANDBOX_URL,
   type Authorization,
@@ -36,6 +37,10 @@ await runStdioServer({
       throw new Error("No credentials found in configuration");
     }
 
+    // SCA method is resolved from env/config only — never as a tool input —
+    // so an LLM client cannot pick the SCA method, only an operator can.
+    const scaMethod = resolveScaMethod(config);
+
     return new HttpClient({
       baseUrl: endpoint,
       authorization,
@@ -44,6 +49,7 @@ await runStdioServer({
         process.stderr.write(`Warning: OAuth authentication failed, falling back to API key for ${method} ${path}\n`);
       },
       stagingToken: config.oauth?.stagingToken,
+      ...(scaMethod !== undefined ? { scaMethod } : {}),
     });
   },
 });


### PR DESCRIPTION
## Summary

- Plumbs `scaMethod` (the `X-Qonto-2fa-Preference` header) through `createClient` and the MCP `getClient` lambda. The header was already supported by `HttpClient`; this PR exposes it via config / env / CLI.
- New `resolveScaMethod(config, override?)` helper in core: precedence is **CLI flag → env → config → sandbox auto-default `"mock"` → undefined**. Production NEVER auto-defaults.
- Hidden `--sca-method <value>` CLI flag (program-level + inheritable on subcommands), `QONTOCTL_SCA_METHOD` env var (with profile-scoped `QONTOCTL_{PROFILE}_SCA_METHOD`), and `sca.method` config field. AC asked for "at least one of"; this PR ships all three for parity with `staging-token`.
- MCP server resolves from env/config only — **no tool input parameter** — so an LLM client cannot pick the SCA method on a write (per the AC threat-model note).
- New `docs/sandbox-testing.md` covers allowed values, precedence, the MCP threat model, and the `qontoctl sca-session mock-decision` workflow. `docs/oauth-setup.md` and `CLAUDE.md` cross-link.

## Why

Bug 5 from the #438 SCA verification spike: `HttpClient` accepts `scaMethod` (header `X-Qonto-2fa-Preference`), but no CLI or MCP path forwarded it. Sandbox writes therefore returned `428 sca_not_enrolled` regardless of test setup, blocking #434 (E2E SCA coverage). Production behavior is unchanged — the header is omitted unless explicitly set.

## Acceptance criteria

| AC | Evidence |
|----|----------|
| `createClient` accepts `scaMethod` and forwards to `HttpClient` | `packages/cli/src/client.ts` calls `resolveScaMethod(config, options.scaMethod)`; 7 new tests in `client.test.ts` § "scaMethod plumbing" |
| CLI surface (a/b/c — at least one) | All three: `--sca-method <value>` (hidden), `QONTOCTL_SCA_METHOD` env (and profile variant), `sca.method` config field |
| MCP env-driven only (LLM cannot pick) | `packages/mcp/src/index.ts` calls `resolveScaMethod(config)` with no override channel; comment documents the threat model |
| Sandbox auto-default `"mock"` when `scaMethod` unset | Resolution returns `"mock"` when `config.oauth?.stagingToken !== undefined` and override+config are empty; covered by tests in both `resolve.test.ts` and `client.test.ts` |
| Production NEVER auto-defaults | Resolution returns `undefined` when no staging token; covered by `resolve.test.ts` ("does NOT auto-default in production") |
| Unit tests cover header set/absent/sandbox/production | 30+ new tests across 6 test files (`resolve.test.ts`, `env.test.ts`, `validate.test.ts`, `client.test.ts`, `program.test.ts`, `inherited-options.test.ts`); existing `http-client.test.ts` already covered the header passthrough |
| Documentation | `docs/sandbox-testing.md` (new), `docs/oauth-setup.md` (cross-link), `CLAUDE.md` (paragraph) |

## Test plan

- [x] `pnpm build` — 5 packages, all green
- [x] `pnpm lint` — 8 tasks, clean (one `no-duplicate-type-constituents` fixed during polish)
- [x] `pnpm format:check` — clean
- [x] `pnpm license-check` — 96 production deps, all allowed
- [x] `pnpm test` — core: 866 tests, cli: 655 tests, mcp: 295 tests, all pass
- [ ] `pnpm test:e2e` — **blocked locally by environmental auth issue** (the OAuth refresh token in this worktree's `.qontoctl.yaml` returns `invalid_grant` — a coordination artifact across the parallel batch tracks; failures are 147/244 across read AND write paths, all with plain-text `Authentication failed`. This PR does NOT touch the GET path.) The repo's `e2e-sandbox` CI job will run E2E against the sandbox using fresh secrets.
- [ ] CI gate (`CI` job)
- [ ] CI advisory (`e2e-sandbox` job, when secrets available)

## Notes for reviewer

- `scaMethod` is intentionally typed as free-form `string | undefined` (not constrained to the existing `ScaMethod` type) because the type uses underscores (`paired_device`) for API response shape, while the header expects hyphens (`paired-device`); free-form keeps both formats and any future Qonto values working without a core release.
- Sandbox auto-default is gated on `oauth.stagingToken !== undefined` — same trigger as `HttpClient.isSandbox`. API-key auth uses production endpoint regardless of staging token (see `CLAUDE.md`), so the auto-default is effectively a no-op for api-key+staging-token mixes.
- Refs: #428 (umbrella), #438 (spike Bug 5), #434 (downstream — sandbox SCA E2E coverage now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)