### PR TITLE
(fix) build428Error throws typed error on unknown 428 shape (#445)

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -1093,7 +1093,12 @@ describe("HttpClient", () => {
       expect(allLogged).not.toContain(SECRET_TOKEN);
     });
 
-    it("throws QontoScaRequiredError with 'unknown' when no token in body", async () => {
+    it("throws generic QontoApiError when 428 body has neither sca_session_token nor sca_not_enrolled", async () => {
+      // Defensive: a 428 shape we have not seen before (no token, no
+      // sca_not_enrolled code) must NOT fabricate a fake session token.
+      // Surface a typed QontoApiError so callers do not retry with
+      // X-Qonto-Sca-Session-Token: "unknown" (which Qonto rejects with a
+      // confusing follow-up error).
       fetchSpy.mockReturnValue(jsonResponse({}, { status: 428 }));
       const client = new TestableHttpClient({
         baseUrl: "https://thirdparty.qonto.com",
@@ -1102,8 +1107,39 @@ describe("HttpClient", () => {
 
       const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
 
-      expect(error).toBeInstanceOf(QontoScaRequiredError);
-      expect((error as QontoScaRequiredError).scaSessionToken).toBe("unknown");
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect(error).not.toBeInstanceOf(QontoScaRequiredError);
+      expect(error).not.toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoApiError).status).toBe(428);
+      expect((error as QontoApiError).errors).toEqual([{ code: "unknown", detail: "Unknown error" }]);
+    });
+
+    it("preserves JSON:API errors[] code/detail on unknown 428 shape", async () => {
+      // When the 428 body carries a JSON:API errors[] envelope without a
+      // recognized SCA code, the original code/detail must be propagated to
+      // the caller (not collapsed into a sentinel "unknown" token).
+      fetchSpy.mockReturnValue(
+        jsonResponse(
+          {
+            errors: [{ code: "future_sca_variant", detail: "A new 428 shape we don't yet recognize" }],
+          },
+          { status: 428 },
+        ),
+      );
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+      });
+
+      const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect(error).not.toBeInstanceOf(QontoScaRequiredError);
+      expect(error).not.toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoApiError).status).toBe(428);
+      expect((error as QontoApiError).errors).toEqual([
+        { code: "future_sca_variant", detail: "A new 428 shape we don't yet recognize" },
+      ]);
     });
 
     it("throws QontoScaNotEnrolledError on 428 with flat sca_not_enrolled body", async () => {
@@ -1193,7 +1229,10 @@ describe("HttpClient", () => {
       expect((error as QontoScaRequiredError).scaSessionToken).toBe("tok-mixed");
     });
 
-    it("throws QontoScaRequiredError with 'unknown' when body is not JSON", async () => {
+    it("throws generic QontoApiError when 428 body is not JSON", async () => {
+      // Non-JSON 428 (e.g., plaintext from an upstream proxy) must surface as
+      // a typed QontoApiError, not a fabricated QontoScaRequiredError("unknown")
+      // that callers would re-send to Qonto on retry.
       fetchSpy.mockReturnValue(
         Promise.resolve(
           new Response("Precondition Required", {
@@ -1209,8 +1248,11 @@ describe("HttpClient", () => {
 
       const error = await client.post("/v2/transfers", { amount: 100 }).catch((e: unknown) => e);
 
-      expect(error).toBeInstanceOf(QontoScaRequiredError);
-      expect((error as QontoScaRequiredError).scaSessionToken).toBe("unknown");
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect(error).not.toBeInstanceOf(QontoScaRequiredError);
+      expect(error).not.toBeInstanceOf(QontoScaNotEnrolledError);
+      expect((error as QontoApiError).status).toBe(428);
+      expect((error as QontoApiError).errors).toEqual([{ code: "unknown", detail: "Unknown error" }]);
     });
 
     it("sends X-Qonto-2fa-Preference header on write requests when scaMethod is set", async () => {

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -616,10 +616,13 @@ export class HttpClient {
    *   enroll SCA on the Qonto account before retrying. Yields
    *   {@link QontoScaNotEnrolledError}.
    *
-   * Unknown 428 shapes fall back to {@link QontoScaRequiredError} with token
-   * `"unknown"`, preserving prior behaviour for shapes the API may add later.
+   * Unknown 428 shapes fall back to a generic {@link QontoApiError} carrying
+   * the JSON:API `errors[]` code/detail when present, otherwise a sentinel
+   * `[{ code: "unknown", detail: "Unknown error" }]` entry. This avoids
+   * fabricating a `"unknown"` SCA session token that callers would send back
+   * to Qonto on retry, which Qonto rejects with a confusing follow-up error.
    */
-  private build428Error(body: unknown): QontoScaRequiredError | QontoScaNotEnrolledError {
+  private build428Error(body: unknown): QontoScaRequiredError | QontoScaNotEnrolledError | QontoApiError {
     if (typeof body === "object" && body !== null) {
       const obj = body as Record<string, unknown>;
 
@@ -640,7 +643,7 @@ export class HttpClient {
       }
     }
 
-    return new QontoScaRequiredError("unknown");
+    return new QontoApiError(428, this.extractErrors(body));
   }
 
   private isAuthError(errors: readonly QontoApiErrorEntry[]): boolean {


### PR DESCRIPTION
## Summary

Closes #445.

`build428Error` (renamed from `extractScaSessionToken` in #448) previously fell back to `new QontoScaRequiredError("unknown")` for any 428 shape that lacked both `sca_session_token` and a `sca_not_enrolled` indicator. Downstream callers would then send `X-Qonto-Sca-Session-Token: unknown` on retry, which Qonto rejects with a confusing follow-up error masking the root cause.

With the bug previously fixed in #448 (distinguishing `sca_required` from `sca_not_enrolled`), the fallback path should not fire in normal operation — but defensive hardening still requires surfacing the original 428 error code/detail rather than fabricating a session token.

## Changes

- `packages/core/src/http-client.ts` — `build428Error` fallback now returns `new QontoApiError(428, this.extractErrors(body))`. The existing `extractErrors` helper already handles JSON:API `errors[]` envelopes and falls back to a `[{ code: "unknown", detail: "Unknown error" }]` sentinel for unparseable bodies. The return-type union widens to include `QontoApiError`. JSDoc rewritten to describe the new contract precisely and to explain why the fabricated sentinel token was harmful.
- `packages/core/src/http-client.test.ts` —
  - Renamed and tightened the two existing tests that asserted the old `"unknown"` behavior (empty 428 body, non-JSON 428 body) to assert the new typed-error behavior: `instanceof QontoApiError`, NOT `QontoScaRequiredError`, NOT `QontoScaNotEnrolledError`, `status === 428`, exact `errors[]` shape.
  - New test "preserves JSON:API errors[] code/detail on unknown 428 shape" verifying that an unrecognized JSON:API error code propagates verbatim instead of collapsing into the sentinel.

## Acceptance Criteria

- [x] **AC1** — `build428Error` throws a typed error (`QontoApiError` with original error code/detail) when `sca_session_token` is missing rather than fabricating `"unknown"`.
- [x] **AC2** — `sca_not_enrolled` 428 responses surface as `QontoScaNotEnrolledError` (introduced in #448, unchanged here, no regression).
- [x] **AC3** — Unit tests cover all 428 shapes: real challenge → `QontoScaRequiredError`(real token); flat `sca_not_enrolled` → `QontoScaNotEnrolledError`; JSON:API `errors[]` `sca_not_enrolled` → `QontoScaNotEnrolledError`; unknown shape (empty body, JSON:API errors[] with unrecognized code, non-JSON body) → `QontoApiError(428)`. NO test asserts `QontoScaRequiredError("unknown")` anywhere.

## Test plan

- [x] `pnpm --filter @qontoctl/core test` → 880 passed
- [x] `pnpm test` → all packages green (core 880 + cli 658 + others)
- [x] `pnpm build` → 5/5 successful
- [x] `pnpm lint` → 8/8 successful
- [x] Targeted: `vitest run http-client.test -t "428"` → all 8 SCA-related 428 tests pass; new test names verified non-vacuous (would fail against pre-fix code).

## References

- Issue: #445
- Spike doc: `docs/security/sca-token-binding.md` (Bug 3)
- Companion fix: #448 (Bug 6, distinguishes `sca_required` vs `sca_not_enrolled`)
- Umbrella: #428 (SCA continuation)