### PR TITLE
(feat) wire SCA continuation into MCP write tools (#428)

### DIFF
--- a/packages/core/src/internal-transfers/service.ts
+++ b/packages/core/src/internal-transfers/service.ts
@@ -13,7 +13,7 @@ import type { CreateInternalTransferParams, InternalTransfer } from "./types.js"
 export async function createInternalTransfer(
   client: HttpClient,
   params: CreateInternalTransferParams,
-  options?: { readonly idempotencyKey?: string },
+  options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<InternalTransfer> {
   const endpointPath = "/v2/internal_transfers";
   const response = await client.post(endpointPath, { internal_transfer: params }, options);

--- a/packages/mcp/src/errors.test.ts
+++ b/packages/mcp/src/errors.test.ts
@@ -168,18 +168,27 @@ describe("withClient", () => {
       expect(text).toContain("SCA required");
       expect(text).toContain("approve this operation on their Qonto mobile app");
       expect(text).toContain("sca-tok-abc");
-      expect(text).toContain("/v2/sca/sessions/sca-tok-abc");
     });
 
-    it("includes polling instructions and status descriptions", async () => {
+    it("references the MCP continuation surface (sca_session_show + sca_session_token), not the HTTP endpoint", async () => {
       const result = await withClient(succeedingFactory, async () => {
         throw new QontoScaRequiredError("sca-tok-def");
       });
 
       const text = (result.content[0] as { type: "text"; text: string }).text;
-      expect(text).toContain("waiting");
-      expect(text).toContain("allow");
-      expect(text).toContain("deny");
+      expect(text).toContain("sca_session_show");
+      expect(text).toContain("sca_session_token");
+      expect(text).not.toContain("/v2/sca/sessions/");
+      expect(text).not.toContain("Poll GET");
+    });
+
+    it("indicates that no inline poll occurred (this is a fallback dead-end path; wrapped tools poll inline)", async () => {
+      const result = await withClient(succeedingFactory, async () => {
+        throw new QontoScaRequiredError("sca-tok-fallback");
+      });
+
+      const text = (result.content[0] as { type: "text"; text: string }).text;
+      expect(text).toContain("No inline poll was requested");
       expect(text).toContain("15 minutes");
     });
 
@@ -218,7 +227,7 @@ describe("withClient", () => {
 
       const text = (result.content[0] as { type: "text"; text: string }).text;
       expect(text).not.toContain("Session token");
-      expect(text).not.toContain("Poll GET /v2/sca/sessions/");
+      expect(text).not.toContain("sca_session_show");
       expect(text).not.toContain("approve this operation on their Qonto mobile app");
     });
 

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -13,6 +13,7 @@ import {
 } from "@qontoctl/core";
 
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { formatScaPendingResponse } from "./sca.js";
 
 function textError(message: string): CallToolResult {
   return {
@@ -72,26 +73,6 @@ function formatRateLimitError(error: QontoRateLimitError): CallToolResult {
   return textError(`Rate limit exceeded.${retryHint} Please wait before retrying.`);
 }
 
-function formatScaRequiredResponse(error: QontoScaRequiredError): CallToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text: [
-          "SCA required. The user needs to approve this operation on their Qonto mobile app.",
-          "",
-          `Session token: ${error.scaSessionToken}`,
-          `Poll GET /v2/sca/sessions/${error.scaSessionToken} for status.`,
-          "",
-          "Possible statuses: waiting (still pending), allow (approved), deny (rejected).",
-          "Token validity: 15 minutes.",
-        ].join("\n"),
-      },
-    ],
-    isError: false,
-  };
-}
-
 function formatScaNotEnrolledError(error: QontoScaNotEnrolledError): CallToolResult {
   const details = error.errors.map((e) => `  - ${e.code}: ${e.detail}`).join("\n");
   return textError(
@@ -124,7 +105,7 @@ export async function withClient(
   } catch (error: unknown) {
     if (error instanceof ConfigError) return formatConfigError(error);
     if (error instanceof AuthError) return formatAuthError(error);
-    if (error instanceof QontoScaRequiredError) return formatScaRequiredResponse(error);
+    if (error instanceof QontoScaRequiredError) return formatScaPendingResponse(error.scaSessionToken, false);
     if (error instanceof QontoScaNotEnrolledError) return formatScaNotEnrolledError(error);
     if (error instanceof QontoOAuthScopeError) return formatOAuthScopeError(error);
     if (error instanceof QontoApiError) return formatApiError(error);

--- a/packages/mcp/src/sca.ts
+++ b/packages/mcp/src/sca.ts
@@ -68,9 +68,10 @@ export function scaOptionsFromArgs(args: {
  * absent so it does not satisfy `exactOptionalPropertyTypes` checks. Used by
  * every wired tool to forward the wrapper's context to its underlying core call.
  */
-export function coreOptionsFromContext(
-  context: ExecuteWithScaContext,
-): { readonly idempotencyKey: string; readonly scaSessionToken?: string } {
+export function coreOptionsFromContext(context: ExecuteWithScaContext): {
+  readonly idempotencyKey: string;
+  readonly scaSessionToken?: string;
+} {
   return {
     idempotencyKey: context.idempotencyKey,
     ...(context.scaSessionToken !== undefined ? { scaSessionToken: context.scaSessionToken } : {}),

--- a/packages/mcp/src/sca.ts
+++ b/packages/mcp/src/sca.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 import {
   executeWithSca,
   QontoScaRequiredError,
@@ -17,6 +18,64 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 const DEFAULT_WAIT_SECONDS = 30;
 const DEFAULT_POLL_INTERVAL_MS = 3000;
 const SCA_TOKEN_VALIDITY_MINUTES = 15;
+const MAX_WAIT_SECONDS = 120;
+
+/**
+ * Zod schema fragment shared by every MCP write tool that participates
+ * in SCA continuation. Spread into a tool's `inputSchema` alongside the
+ * tool-specific fields.
+ *
+ * - `sca_session_token`: caller supplies a previously issued SCA session
+ *   token to bind a prior approval to this retry. When set, no polling
+ *   happens and the operation is invoked exactly once.
+ * - `wait`: maximum seconds to poll inline for SCA approval (0-120).
+ *   `false` (or omitted with `0`) disables polling so the tool returns
+ *   a structured pending response immediately on a 428. Default 30.
+ */
+export const scaContinuationSchema = {
+  sca_session_token: z
+    .string()
+    .optional()
+    .describe(
+      "SCA session token from a prior call to bind a previously approved SCA challenge to this retry. When set, no polling occurs and the operation runs exactly once with the token attached.",
+    ),
+  wait: z
+    .union([z.number().int().min(0).max(MAX_WAIT_SECONDS), z.literal(false)])
+    .optional()
+    .describe(
+      `Maximum seconds (0-${String(MAX_WAIT_SECONDS)}) to poll inline for SCA approval before returning a structured pending response. Use false or 0 for a pure two-step flow (return immediately on SCA required). Default 30.`,
+    ),
+};
+
+/**
+ * Translate the Zod-validated tool args into `McpScaOptions` for
+ * `executeWithMcpSca`. Drops `undefined` keys per the project's
+ * `exactOptionalPropertyTypes` discipline.
+ */
+export function scaOptionsFromArgs(args: {
+  readonly sca_session_token?: string | undefined;
+  readonly wait?: number | false | undefined;
+}): McpScaOptions {
+  return {
+    ...(args.sca_session_token !== undefined ? { scaSessionToken: args.sca_session_token } : {}),
+    ...(args.wait !== undefined ? { wait: args.wait } : {}),
+  };
+}
+
+/**
+ * Convert an `ExecuteWithScaContext` into the `{ idempotencyKey, scaSessionToken? }`
+ * shape accepted by core service write functions, dropping the SCA token when
+ * absent so it does not satisfy `exactOptionalPropertyTypes` checks. Used by
+ * every wired tool to forward the wrapper's context to its underlying core call.
+ */
+export function coreOptionsFromContext(
+  context: ExecuteWithScaContext,
+): { readonly idempotencyKey: string; readonly scaSessionToken?: string } {
+  return {
+    idempotencyKey: context.idempotencyKey,
+    ...(context.scaSessionToken !== undefined ? { scaSessionToken: context.scaSessionToken } : {}),
+  };
+}
 
 export interface McpScaOptions {
   /**
@@ -141,7 +200,19 @@ async function invokeOnceAndFormat<T>(
   }
 }
 
-function formatScaPendingResponse(token: string, wait: number | false): CallToolResult {
+/**
+ * Build the structured "SCA pending" MCP response.
+ *
+ * The response carries the SCA session token, the polling situation
+ * (whether an inline poll occurred and for how long), and instructions
+ * for the user/LLM to continue out-of-band via the `sca_session_show`
+ * tool and the per-tool `sca_session_token` continuation parameter.
+ *
+ * Exported so non-wrapper code paths (`withClient` fallback in
+ * `errors.ts`) can return the same continuation-aware text shape
+ * without importing the dead-end formatter.
+ */
+export function formatScaPendingResponse(token: string, wait: number | false): CallToolResult {
   const polledLine =
     wait === false || wait === 0
       ? "No inline poll was requested; the SCA session is pending the user's decision."

--- a/packages/mcp/src/tools/beneficiary.ts
+++ b/packages/mcp/src/tools/beneficiary.ts
@@ -13,6 +13,7 @@ import {
   untrustBeneficiaries,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerBeneficiaryTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -80,13 +81,15 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
   server.registerTool(
     "beneficiary_add",
     {
-      description: "Create a new SEPA beneficiary",
+      description:
+        "Create a new SEPA beneficiary. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         name: z.string().describe("Beneficiary name"),
         iban: z.string().describe("IBAN"),
         bic: z.string().optional().describe("BIC/SWIFT code"),
         email: z.string().optional().describe("Email address"),
         activity_tag: z.string().optional().describe("Activity tag"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
@@ -99,23 +102,23 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
           ...(args.activity_tag !== undefined ? { activity_tag: args.activity_tag } : {}),
         };
 
-        const beneficiary = await createBeneficiary(client, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(beneficiary, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            createBeneficiary(client, params, coreOptionsFromContext(context)),
+          (beneficiary) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "beneficiary_update",
     {
-      description: "Update an existing SEPA beneficiary",
+      description:
+        "Update an existing SEPA beneficiary. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Beneficiary ID (UUID)"),
         name: z.string().optional().describe("Beneficiary name"),
@@ -123,28 +126,28 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
         bic: z.string().optional().describe("BIC/SWIFT code"),
         email: z.string().optional().describe("Email address"),
         activity_tag: z.string().optional().describe("Activity tag"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, ...fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
         const params: UpdateBeneficiaryParams = {
-          ...(fields.name !== undefined ? { name: fields.name } : {}),
-          ...(fields.iban !== undefined ? { iban: fields.iban } : {}),
-          ...(fields.bic !== undefined ? { bic: fields.bic } : {}),
-          ...(fields.email !== undefined ? { email: fields.email } : {}),
-          ...(fields.activity_tag !== undefined ? { activity_tag: fields.activity_tag } : {}),
+          ...(args.name !== undefined ? { name: args.name } : {}),
+          ...(args.iban !== undefined ? { iban: args.iban } : {}),
+          ...(args.bic !== undefined ? { bic: args.bic } : {}),
+          ...(args.email !== undefined ? { email: args.email } : {}),
+          ...(args.activity_tag !== undefined ? { activity_tag: args.activity_tag } : {}),
         };
 
-        const beneficiary = await updateBeneficiary(client, id, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(beneficiary, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            updateBeneficiary(client, args.id, params, coreOptionsFromContext(context)),
+          (beneficiary) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
@@ -152,47 +155,47 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
     "beneficiary_trust",
     {
       description:
-        "Trust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403)",
+        "Trust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         ids: z.array(z.string()).min(1).describe("Beneficiary IDs to trust"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ ids }) =>
-      withClient(getClient, async (client) => {
-        await trustBeneficiaries(client, ids);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ trusted: true, ids }, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            trustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ trusted: true, ids: args.ids }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "beneficiary_untrust",
     {
       description:
-        "Untrust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403)",
+        "Untrust one or more SEPA beneficiaries (requires Embed-partner-only `beneficiary.trust` OAuth scope; standard third-party apps will receive 403). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         ids: z.array(z.string()).min(1).describe("Beneficiary IDs to untrust"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ ids }) =>
-      withClient(getClient, async (client) => {
-        await untrustBeneficiaries(client, ids);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ untrusted: true, ids }, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            untrustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ untrusted: true, ids: args.ids }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 }

--- a/packages/mcp/src/tools/beneficiary.ts
+++ b/packages/mcp/src/tools/beneficiary.ts
@@ -104,8 +104,7 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            createBeneficiary(client, params, coreOptionsFromContext(context)),
+          (context) => createBeneficiary(client, params, coreOptionsFromContext(context)),
           (beneficiary) => ({
             content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
           }),
@@ -141,8 +140,7 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            updateBeneficiary(client, args.id, params, coreOptionsFromContext(context)),
+          (context) => updateBeneficiary(client, args.id, params, coreOptionsFromContext(context)),
           (beneficiary) => ({
             content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
           }),
@@ -165,8 +163,7 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            trustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
+          (context) => trustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
           () => ({
             content: [{ type: "text" as const, text: JSON.stringify({ trusted: true, ids: args.ids }, null, 2) }],
           }),
@@ -189,8 +186,7 @@ export function registerBeneficiaryTools(server: McpServer, getClient: () => Pro
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            untrustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
+          (context) => untrustBeneficiaries(client, args.ids, coreOptionsFromContext(context)),
           () => ({
             content: [{ type: "text" as const, text: JSON.stringify({ untrusted: true, ids: args.ids }, null, 2) }],
           }),

--- a/packages/mcp/src/tools/bulk-transfer.ts
+++ b/packages/mcp/src/tools/bulk-transfer.ts
@@ -32,12 +32,7 @@ export function registerBulkTransferTools(server: McpServer, getClient: () => Pr
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            createBulkTransfer(
-              client,
-              { transfers: args.transfers },
-              coreOptionsFromContext(context),
-            ),
+          (context) => createBulkTransfer(client, { transfers: args.transfers }, coreOptionsFromContext(context)),
           (bulkTransfer) => ({
             content: [{ type: "text" as const, text: JSON.stringify(bulkTransfer, null, 2) }],
           }),

--- a/packages/mcp/src/tools/bulk-transfer.ts
+++ b/packages/mcp/src/tools/bulk-transfer.ts
@@ -5,12 +5,14 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type HttpClient, createBulkTransfer, getBulkTransfer, listBulkTransfers } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerBulkTransferTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
     "bulk_transfer_create",
     {
-      description: "Create a bulk transfer",
+      description:
+        "Create a bulk transfer. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         transfers: z
           .array(
@@ -23,15 +25,25 @@ export function registerBulkTransferTools(server: McpServer, getClient: () => Pr
           )
           .min(1)
           .describe("Array of transfers to create"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
-      withClient(getClient, async (client) => {
-        const bulkTransfer = await createBulkTransfer(client, { transfers: args.transfers });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(bulkTransfer, null, 2) }],
-        };
-      }),
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createBulkTransfer(
+              client,
+              { transfers: args.transfers },
+              coreOptionsFromContext(context),
+            ),
+          (bulkTransfer) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(bulkTransfer, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(

--- a/packages/mcp/src/tools/card.ts
+++ b/packages/mcp/src/tools/card.ts
@@ -189,8 +189,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            createCard(client, params, coreOptionsFromContext(context)),
+          (context) => createCard(client, params, coreOptionsFromContext(context)),
           (card) => ({
             content: [
               {
@@ -252,8 +251,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            bulkCreateCards(client, params, coreOptionsFromContext(context)),
+          (context) => bulkCreateCards(client, params, coreOptionsFromContext(context)),
           (result) => ({
             content: [
               {
@@ -281,8 +279,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            lockCard(client, args.id, coreOptionsFromContext(context)),
+          (context) => lockCard(client, args.id, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -305,8 +302,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            unlockCard(client, args.id, coreOptionsFromContext(context)),
+          (context) => unlockCard(client, args.id, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -329,8 +325,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            reportCardLost(client, args.id, coreOptionsFromContext(context)),
+          (context) => reportCardLost(client, args.id, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -353,8 +348,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            reportCardStolen(client, args.id, coreOptionsFromContext(context)),
+          (context) => reportCardStolen(client, args.id, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -377,8 +371,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            discardCard(client, args.id, coreOptionsFromContext(context)),
+          (context) => discardCard(client, args.id, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -428,8 +421,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            updateCardLimits(client, args.id, params, coreOptionsFromContext(context)),
+          (context) => updateCardLimits(client, args.id, params, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -453,8 +445,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
       withClient(getClient, async (client) =>
         executeWithMcpSca(
           client,
-          (context) =>
-            updateCardNickname(client, args.id, args.nickname, coreOptionsFromContext(context)),
+          (context) => updateCardNickname(client, args.id, args.nickname, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -488,8 +479,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            updateCardOptions(client, args.id, params, coreOptionsFromContext(context)),
+          (context) => updateCardOptions(client, args.id, params, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),
@@ -539,8 +529,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            updateCardRestrictions(client, args.id, params, coreOptionsFromContext(context)),
+          (context) => updateCardRestrictions(client, args.id, params, coreOptionsFromContext(context)),
           (card) => ({
             content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
           }),

--- a/packages/mcp/src/tools/card.ts
+++ b/packages/mcp/src/tools/card.ts
@@ -28,6 +28,7 @@ import {
   listCardAppearances,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerCardTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -119,7 +120,8 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
   server.registerTool(
     "card_create",
     {
-      description: "Create a new card",
+      description:
+        "Create a new card. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         holder_id: z.string().describe("Cardholder membership ID"),
         initiator_id: z.string().describe("Order initiator membership ID"),
@@ -147,6 +149,7 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
         categories: z.array(z.string()).optional().describe("Allowed merchant categories"),
         card_design: z.string().optional().describe("Card design identifier"),
         type_of_print: z.enum(["print", "embossed"]).optional().describe("Print type (Plus cards only)"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
@@ -184,23 +187,28 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
           ...(args.type_of_print !== undefined ? { type_of_print: args.type_of_print } : {}),
         };
 
-        const card = await createCard(client, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            createCard(client, params, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(card, null, 2),
+              },
+            ],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "card_bulk_create",
     {
-      description: "Bulk create cards (up to 50)",
+      description:
+        "Bulk create cards (up to 50). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         cards: z
           .array(
@@ -222,11 +230,12 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
           .min(1)
           .max(50)
           .describe("Array of card definitions"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ cards }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
-        const params: CreateCardParams[] = cards.map((c) => ({
+        const params: CreateCardParams[] = args.cards.map((c) => ({
           holder_id: c.holder_id,
           initiator_id: c.initiator_id,
           organization_id: c.organization_id,
@@ -241,138 +250,148 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
           ...(c.pre_expires_at !== undefined ? { pre_expires_at: c.pre_expires_at } : {}),
         }));
 
-        const result = await bulkCreateCards(client, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            bulkCreateCards(client, params, coreOptionsFromContext(context)),
+          (result) => ({
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "card_lock",
     {
-      description: "Lock a card",
+      description:
+        "Lock a card. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        const card = await lockCard(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            lockCard(client, args.id, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_unlock",
     {
-      description: "Unlock a card",
+      description:
+        "Unlock a card. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        const card = await unlockCard(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            unlockCard(client, args.id, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_report_lost",
     {
-      description: "Report a physical card as lost (irreversible)",
+      description:
+        "Report a physical card as lost (irreversible). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        const card = await reportCardLost(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            reportCardLost(client, args.id, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_report_stolen",
     {
-      description: "Report a physical card as stolen (irreversible)",
+      description:
+        "Report a physical card as stolen (irreversible). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        const card = await reportCardStolen(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            reportCardStolen(client, args.id, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_discard",
     {
-      description: "Discard a card (irreversible)",
+      description:
+        "Discard a card (irreversible). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        const card = await discardCard(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            discardCard(client, args.id, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_update_limits",
     {
-      description: "Update a card's spending limits",
+      description:
+        "Update a card's spending limits. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
         atm_monthly_limit: z.number().int().optional().describe("Monthly ATM withdrawal limit (EUR)"),
@@ -384,109 +403,106 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
         payment_transaction_limit_option: z.boolean().optional().describe("Enable per-transaction limit"),
         payment_transaction_limit: z.number().int().optional().describe("Per-transaction limit (EUR)"),
         payment_lifespan_limit: z.number().int().optional().describe("Total spending cap (flash cards, EUR)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, ...fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
         const params: UpdateCardLimitsParams = {
-          ...(fields.atm_monthly_limit !== undefined ? { atm_monthly_limit: fields.atm_monthly_limit } : {}),
-          ...(fields.atm_daily_limit_option !== undefined
-            ? { atm_daily_limit_option: fields.atm_daily_limit_option }
+          ...(args.atm_monthly_limit !== undefined ? { atm_monthly_limit: args.atm_monthly_limit } : {}),
+          ...(args.atm_daily_limit_option !== undefined ? { atm_daily_limit_option: args.atm_daily_limit_option } : {}),
+          ...(args.atm_daily_limit !== undefined ? { atm_daily_limit: args.atm_daily_limit } : {}),
+          ...(args.payment_monthly_limit !== undefined ? { payment_monthly_limit: args.payment_monthly_limit } : {}),
+          ...(args.payment_daily_limit_option !== undefined
+            ? { payment_daily_limit_option: args.payment_daily_limit_option }
             : {}),
-          ...(fields.atm_daily_limit !== undefined ? { atm_daily_limit: fields.atm_daily_limit } : {}),
-          ...(fields.payment_monthly_limit !== undefined
-            ? { payment_monthly_limit: fields.payment_monthly_limit }
+          ...(args.payment_daily_limit !== undefined ? { payment_daily_limit: args.payment_daily_limit } : {}),
+          ...(args.payment_transaction_limit_option !== undefined
+            ? { payment_transaction_limit_option: args.payment_transaction_limit_option }
             : {}),
-          ...(fields.payment_daily_limit_option !== undefined
-            ? { payment_daily_limit_option: fields.payment_daily_limit_option }
+          ...(args.payment_transaction_limit !== undefined
+            ? { payment_transaction_limit: args.payment_transaction_limit }
             : {}),
-          ...(fields.payment_daily_limit !== undefined ? { payment_daily_limit: fields.payment_daily_limit } : {}),
-          ...(fields.payment_transaction_limit_option !== undefined
-            ? { payment_transaction_limit_option: fields.payment_transaction_limit_option }
-            : {}),
-          ...(fields.payment_transaction_limit !== undefined
-            ? { payment_transaction_limit: fields.payment_transaction_limit }
-            : {}),
-          ...(fields.payment_lifespan_limit !== undefined
-            ? { payment_lifespan_limit: fields.payment_lifespan_limit }
-            : {}),
+          ...(args.payment_lifespan_limit !== undefined ? { payment_lifespan_limit: args.payment_lifespan_limit } : {}),
         };
 
-        const card = await updateCardLimits(client, id, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            updateCardLimits(client, args.id, params, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "card_update_nickname",
     {
-      description: "Update a card's nickname",
+      description:
+        "Update a card's nickname. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
         nickname: z.string().min(1).max(40).describe("New nickname (1-40 characters)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, nickname }) =>
-      withClient(getClient, async (client) => {
-        const card = await updateCardNickname(client, id, nickname);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            updateCardNickname(client, args.id, args.nickname, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "card_update_options",
     {
-      description: "Update a card's options (ATM, NFC, online, foreign)",
+      description:
+        "Update a card's options (ATM, NFC, online, foreign). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
         atm_option: z.boolean().describe("Enable ATM withdrawals"),
         nfc_option: z.boolean().describe("Enable contactless payments"),
         online_option: z.boolean().describe("Enable online payments"),
         foreign_option: z.boolean().describe("Enable international payments"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, ...fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
         const params: UpdateCardOptionsParams = {
-          atm_option: fields.atm_option,
-          nfc_option: fields.nfc_option,
-          online_option: fields.online_option,
-          foreign_option: fields.foreign_option,
+          atm_option: args.atm_option,
+          nfc_option: args.nfc_option,
+          online_option: args.online_option,
+          foreign_option: args.foreign_option,
         };
 
-        const card = await updateCardOptions(client, id, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            updateCardOptions(client, args.id, params, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "card_update_restrictions",
     {
-      description: "Update a card's restrictions (active days, merchant categories)",
+      description:
+        "Update a card's restrictions (active days, merchant categories). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Card ID (UUID)"),
         active_days: z
@@ -511,25 +527,25 @@ export function registerCardTools(server: McpServer, getClient: () => Promise<Ht
           )
           .optional()
           .describe("Allowed merchant categories (empty array disables)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, ...fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
         const params: UpdateCardRestrictionsParams = {
-          ...(fields.active_days !== undefined ? { active_days: fields.active_days } : {}),
-          ...(fields.categories !== undefined ? { categories: fields.categories } : {}),
+          ...(args.active_days !== undefined ? { active_days: args.active_days } : {}),
+          ...(args.categories !== undefined ? { categories: args.categories } : {}),
         };
 
-        const card = await updateCardRestrictions(client, id, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(card, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            updateCardRestrictions(client, args.id, params, coreOptionsFromContext(context)),
+          (card) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(card, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 

--- a/packages/mcp/src/tools/internal-transfer.ts
+++ b/packages/mcp/src/tools/internal-transfer.ts
@@ -5,38 +5,49 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { type HttpClient, createInternalTransfer } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerInternalTransferTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
     "internal_transfer_create",
     {
-      description: "Create an internal transfer between two bank accounts within the same organization",
+      description:
+        "Create an internal transfer between two bank accounts within the same organization. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         debit_iban: z.string().describe("IBAN of the account to debit"),
         credit_iban: z.string().describe("IBAN of the account to credit"),
         reference: z.string().max(99).describe("Transfer reference (max 99 characters)"),
         amount: z.number().positive().describe("Amount to transfer"),
         currency: z.string().default("EUR").describe("Currency code (must be EUR)"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
-      withClient(getClient, async (client) => {
-        const internalTransfer = await createInternalTransfer(client, {
-          debit_iban: args.debit_iban,
-          credit_iban: args.credit_iban,
-          reference: args.reference,
-          amount: String(args.amount),
-          currency: args.currency,
-        });
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(internalTransfer, null, 2),
-            },
-          ],
-        };
-      }),
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createInternalTransfer(
+              client,
+              {
+                debit_iban: args.debit_iban,
+                credit_iban: args.credit_iban,
+                reference: args.reference,
+                amount: String(args.amount),
+                currency: args.currency,
+              },
+              coreOptionsFromContext(context),
+            ),
+          (internalTransfer) => ({
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(internalTransfer, null, 2),
+              },
+            ],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 }

--- a/packages/mcp/src/tools/intl-transfer.ts
+++ b/packages/mcp/src/tools/intl-transfer.ts
@@ -6,6 +6,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CreateIntlTransferParams, HttpClient } from "@qontoctl/core";
 import { getIntlTransferRequirements, createIntlTransfer } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerIntlTransferTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -34,11 +35,13 @@ export function registerIntlTransferTools(server: McpServer, getClient: () => Pr
   server.registerTool(
     "intl_transfer_create",
     {
-      description: "Create an international transfer",
+      description:
+        "Create an international transfer. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         beneficiary_id: z.string().describe("International beneficiary ID (UUID)"),
         quote_id: z.string().describe("Quote ID (UUID)"),
         fields: z.record(z.string(), z.unknown()).optional().describe("Additional transfer fields as key-value pairs"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
@@ -49,16 +52,20 @@ export function registerIntlTransferTools(server: McpServer, getClient: () => Pr
           ...(args.fields !== undefined ? args.fields : {}),
         };
 
-        const transfer = await createIntlTransfer(client, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(transfer, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            createIntlTransfer(client, params, coreOptionsFromContext(context)),
+          (transfer) => ({
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(transfer, null, 2),
+              },
+            ],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 }

--- a/packages/mcp/src/tools/intl-transfer.ts
+++ b/packages/mcp/src/tools/intl-transfer.ts
@@ -54,8 +54,7 @@ export function registerIntlTransferTools(server: McpServer, getClient: () => Pr
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            createIntlTransfer(client, params, coreOptionsFromContext(context)),
+          (context) => createIntlTransfer(client, params, coreOptionsFromContext(context)),
           (transfer) => ({
             content: [
               {

--- a/packages/mcp/src/tools/recurring-transfer.ts
+++ b/packages/mcp/src/tools/recurring-transfer.ts
@@ -11,12 +11,14 @@ import {
   listRecurringTransfers,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerRecurringTransferTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
     "recurring_transfer_create",
     {
-      description: "Create a recurring transfer",
+      description:
+        "Create a recurring transfer. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         beneficiary_id: z.string().describe("Beneficiary UUID"),
         bank_account_id: z.string().describe("Bank account UUID to debit"),
@@ -26,24 +28,34 @@ export function registerRecurringTransferTools(server: McpServer, getClient: () 
         note: z.string().optional().describe("Optional note"),
         first_execution_date: z.string().describe("First execution date (YYYY-MM-DD)"),
         frequency: z.enum(["weekly", "monthly", "quarterly", "half_yearly", "yearly"]).describe("Transfer frequency"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
-      withClient(getClient, async (client) => {
-        const recurringTransfer = await createRecurringTransfer(client, {
-          beneficiary_id: args.beneficiary_id,
-          bank_account_id: args.bank_account_id,
-          amount: args.amount,
-          currency: args.currency,
-          reference: args.reference,
-          first_execution_date: args.first_execution_date,
-          frequency: args.frequency,
-          ...(args.note !== undefined ? { note: args.note } : {}),
-        });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(recurringTransfer, null, 2) }],
-        };
-      }),
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createRecurringTransfer(
+              client,
+              {
+                beneficiary_id: args.beneficiary_id,
+                bank_account_id: args.bank_account_id,
+                amount: args.amount,
+                currency: args.currency,
+                reference: args.reference,
+                first_execution_date: args.first_execution_date,
+                frequency: args.frequency,
+                ...(args.note !== undefined ? { note: args.note } : {}),
+              },
+              coreOptionsFromContext(context),
+            ),
+          (recurringTransfer) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(recurringTransfer, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(

--- a/packages/mcp/src/tools/request.ts
+++ b/packages/mcp/src/tools/request.ts
@@ -14,6 +14,7 @@ import {
   createMultiTransferRequest,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 const requestTypeEnum = z.enum(["flash_card", "virtual_card", "transfer", "multi_transfer"]);
 
@@ -51,45 +52,72 @@ export function registerRequestTools(server: McpServer, getClient: () => Promise
   server.registerTool(
     "request_approve",
     {
-      description: "Approve a pending request (SCA may be required)",
+      description:
+        "Approve a pending request. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         request_type: requestTypeEnum.describe("Type of request to approve"),
         id: z.string().describe("Request UUID"),
         debit_iban: z.string().optional().describe("IBAN of account to debit or link to the card"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ request_type, id, debit_iban }) =>
-      withClient(getClient, async (client) => {
-        await approveRequest(client, request_type, id, debit_iban !== undefined ? { debit_iban } : undefined);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ approved: true, id }, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            approveRequest(
+              client,
+              args.request_type,
+              args.id,
+              args.debit_iban !== undefined ? { debit_iban: args.debit_iban } : undefined,
+              coreOptionsFromContext(context),
+            ),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ approved: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "request_decline",
     {
-      description: "Decline a pending request",
+      description:
+        "Decline a pending request. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         request_type: requestTypeEnum.describe("Type of request to decline"),
         id: z.string().describe("Request UUID"),
         declined_note: z.string().describe("Reason for declining"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ request_type, id, declined_note }) =>
-      withClient(getClient, async (client) => {
-        await declineRequest(client, request_type, id, { declined_note });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ declined: true, id }, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            declineRequest(
+              client,
+              args.request_type,
+              args.id,
+              { declined_note: args.declined_note },
+              coreOptionsFromContext(context),
+            ),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ declined: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "request_create_flash_card",
     {
-      description: "Create a flash card request",
+      description:
+        "Create a flash card request. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         note: z.string().optional().describe("Description to help the approver"),
         payment_lifespan_limit: z.string().optional().describe("Spending limit (e.g. 250.00)"),
@@ -97,50 +125,76 @@ export function registerRequestTools(server: McpServer, getClient: () => Promise
           .string()
           .optional()
           .describe("Card expiration datetime (ISO 8601, must be future, max 1 year)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ note, payment_lifespan_limit, pre_expires_at }) =>
-      withClient(getClient, async (client) => {
-        const request = await createFlashCardRequest(client, {
-          ...(note !== undefined ? { note } : {}),
-          ...(payment_lifespan_limit !== undefined ? { payment_lifespan_limit } : {}),
-          ...(pre_expires_at !== undefined ? { pre_expires_at } : {}),
-        });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createFlashCardRequest(
+              client,
+              {
+                ...(args.note !== undefined ? { note: args.note } : {}),
+                ...(args.payment_lifespan_limit !== undefined
+                  ? { payment_lifespan_limit: args.payment_lifespan_limit }
+                  : {}),
+                ...(args.pre_expires_at !== undefined ? { pre_expires_at: args.pre_expires_at } : {}),
+              },
+              coreOptionsFromContext(context),
+            ),
+          (request) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "request_create_virtual_card",
     {
-      description: "Create a virtual card request",
+      description:
+        "Create a virtual card request. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         note: z.string().optional().describe("Description to help the approver (max 125 chars)"),
         payment_monthly_limit: z.string().optional().describe("Monthly spending limit (e.g. 5.00)"),
         card_level: z.enum(["virtual", "virtual_partner"]).optional().describe("Card level").default("virtual"),
         card_design: z.string().optional().describe("Card design identifier"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ note, payment_monthly_limit, card_level, card_design }) =>
-      withClient(getClient, async (client) => {
-        const request = await createVirtualCardRequest(client, {
-          ...(note !== undefined ? { note } : {}),
-          ...(payment_monthly_limit !== undefined ? { payment_monthly_limit } : {}),
-          card_level,
-          ...(card_design !== undefined ? { card_design } : {}),
-        });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createVirtualCardRequest(
+              client,
+              {
+                ...(args.note !== undefined ? { note: args.note } : {}),
+                ...(args.payment_monthly_limit !== undefined
+                  ? { payment_monthly_limit: args.payment_monthly_limit }
+                  : {}),
+                card_level: args.card_level,
+                ...(args.card_design !== undefined ? { card_design: args.card_design } : {}),
+              },
+              coreOptionsFromContext(context),
+            ),
+          (request) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "request_create_multi_transfer",
     {
-      description: "Create a multi-transfer request (1-400 transfers)",
+      description:
+        "Create a multi-transfer request (1-400 transfers). SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         note: z.string().describe("Description for the request (max 140 chars)"),
         transfers: z
@@ -160,19 +214,29 @@ export function registerRequestTools(server: McpServer, getClient: () => Promise
           .describe("Array of transfer items"),
         scheduled_date: z.string().optional().describe("Execution date (YYYY-MM-DD)"),
         debit_iban: z.string().optional().describe("Source account IBAN"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ note, transfers, scheduled_date, debit_iban }) =>
-      withClient(getClient, async (client) => {
-        const request = await createMultiTransferRequest(client, {
-          note,
-          transfers,
-          ...(scheduled_date !== undefined ? { scheduled_date } : {}),
-          ...(debit_iban !== undefined ? { debit_iban } : {}),
-        });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) =>
+            createMultiTransferRequest(
+              client,
+              {
+                note: args.note,
+                transfers: args.transfers,
+                ...(args.scheduled_date !== undefined ? { scheduled_date: args.scheduled_date } : {}),
+                ...(args.debit_iban !== undefined ? { debit_iban: args.debit_iban } : {}),
+              },
+              coreOptionsFromContext(context),
+            ),
+          (request) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(request, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 }

--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -382,6 +382,137 @@ describe("transfer MCP tools", () => {
         "VoP verification result: MATCH_RESULT_NOT_POSSIBLE",
       );
     });
+
+    describe("SCA continuation", () => {
+      const SCA_TOKEN = "sca-tok-mcp-transfer-create";
+
+      it("returns structured pending response on 428 with wait=0 (pure two-step)", async () => {
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: { ...createArgs, vop_proof_token: "explicit", wait: 0 },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain("SCA required");
+        expect(text).toContain(SCA_TOKEN);
+        expect(text).toContain("sca_session_show");
+        expect(text).toContain("sca_session_token");
+        // The dead-end formatter is NOT used.
+        expect(text).not.toContain("Poll GET");
+        expect(text).not.toContain("/v2/sca/sessions/");
+      });
+
+      it("retries the operation with the supplied sca_session_token (no polling)", async () => {
+        let postCount = 0;
+        const observedScaTokens: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {
+            const headers = init.headers as Record<string, string> | undefined;
+            observedScaTokens.push(headers?.["X-Qonto-Sca-Session-Token"] ?? null);
+            postCount++;
+            return jsonResponse({ transfer: makeTransfer({ id: "txfr-after-retry" }) });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: {
+            ...createArgs,
+            vop_proof_token: "explicit",
+            sca_session_token: SCA_TOKEN,
+          },
+        });
+
+        expect(postCount).toBe(1);
+        expect(observedScaTokens[0]).toBe(SCA_TOKEN);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { id: string };
+        expect(parsed.id).toBe("txfr-after-retry");
+      });
+
+      it("preserves a stable idempotency key across the initial 428 + post-poll retry", async () => {
+        let postCount = 0;
+        const observedIdempotencyKeys: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          const headers = init.headers as Record<string, string> | undefined;
+
+          if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {
+            postCount++;
+            observedIdempotencyKeys.push(headers?.["X-Qonto-Idempotency-Key"] ?? null);
+            if (postCount === 1) {
+              // First attempt: 428 SCA required.
+              return new Response(
+                JSON.stringify({
+                  errors: [{ code: "sca_required", detail: "SCA required", sca_session_token: SCA_TOKEN }],
+                }),
+                {
+                  status: 428,
+                  headers: { "content-type": "application/json", "X-Qonto-Sca-Session-Token": SCA_TOKEN },
+                },
+              );
+            }
+            return jsonResponse({ transfer: makeTransfer({ id: "txfr-poll-retry" }) });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            return jsonResponse({ sca_session: { status: "allow" } });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: {
+            ...createArgs,
+            vop_proof_token: "explicit",
+            wait: 5,
+          },
+        });
+
+        expect(postCount).toBe(2);
+        expect(observedIdempotencyKeys[0]).toBeTruthy();
+        expect(observedIdempotencyKeys[0]).toBe(observedIdempotencyKeys[1]);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { id: string };
+        expect(parsed.id).toBe("txfr-poll-retry");
+      });
+
+      it("accepts wait=false in the input schema (pure two-step)", async () => {
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: { ...createArgs, vop_proof_token: "explicit", wait: false },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain(SCA_TOKEN);
+      });
+    });
   });
 
   describe("transfer_verify_payee", () => {

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -174,8 +174,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
 
         return executeWithMcpSca(
           client,
-          (context) =>
-            createTransfer(client, params, coreOptionsFromContext(context)),
+          (context) => createTransfer(client, params, coreOptionsFromContext(context)),
           (transfer) => {
             const content: { type: "text"; text: string }[] = [
               { type: "text" as const, text: JSON.stringify(transfer, null, 2) },

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -15,6 +15,7 @@ import {
   bulkVerifyPayee,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerTransferTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -83,7 +84,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
     "transfer_create",
     {
       description:
-        "Create a SEPA transfer. Provide either beneficiary_id (existing beneficiary) or beneficiary (inline beneficiary object with name and iban), but not both.",
+        "Create a SEPA transfer. Provide either beneficiary_id (existing beneficiary) or beneficiary (inline beneficiary object with name and iban), but not both. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         beneficiary_id: z
           .string()
@@ -113,6 +114,7 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
           .string()
           .optional()
           .describe("VoP proof token from verify-payee (auto-resolved when omitted)"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
@@ -170,19 +172,24 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
           ...(args.attachment_ids !== undefined ? { attachment_ids: args.attachment_ids } : {}),
         };
 
-        const transfer = await createTransfer(client, params);
-
-        const content: { type: "text"; text: string }[] = [
-          { type: "text" as const, text: JSON.stringify(transfer, null, 2) },
-        ];
-        if (vopResult !== undefined && vopResult.match_result !== "MATCH_RESULT_MATCH") {
-          content.push({
-            type: "text" as const,
-            text: `VoP verification result: ${vopResult.match_result}`,
-          });
-        }
-
-        return { content };
+        return executeWithMcpSca(
+          client,
+          (context) =>
+            createTransfer(client, params, coreOptionsFromContext(context)),
+          (transfer) => {
+            const content: { type: "text"; text: string }[] = [
+              { type: "text" as const, text: JSON.stringify(transfer, null, 2) },
+            ];
+            if (vopResult !== undefined && vopResult.match_result !== "MATCH_RESULT_MATCH") {
+              content.push({
+                type: "text" as const,
+                text: `VoP verification result: ${vopResult.match_result}`,
+              });
+            }
+            return { content };
+          },
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 


### PR DESCRIPTION
## Summary

Closes #428 by wiring `executeWithMcpSca` (merged in #466) into every MCP write tool. SCA-required (HTTP 428) responses now become continuation points instead of dead ends — callers can poll out-of-band via `sca_session_show` and rebind the approval to a retry via the new `sca_session_token` parameter, or block inline with the new `wait` parameter (default 30s, max 120s).

## Changes

- **Wrapper integration** — 8 modules / 25 write tools now invoke `executeWithMcpSca`:
  - `transfer_create`
  - `intl_transfer_create`
  - `internal_transfer_create`
  - `bulk_transfer_create`
  - `recurring_transfer_create`
  - `card_create`, `card_bulk_create`, `card_lock`, `card_unlock`, `card_report_lost`, `card_report_stolen`, `card_discard`, `card_update_limits`, `card_update_nickname`, `card_update_options`, `card_update_restrictions`
  - `beneficiary_add`, `beneficiary_update`, `beneficiary_trust`, `beneficiary_untrust`
  - `request_approve`, `request_decline`, `request_create_flash_card`, `request_create_virtual_card`, `request_create_multi_transfer`
- **Schema** — new `scaContinuationSchema` Zod fragment adds `sca_session_token` (string, optional) + `wait` (number 0-120 or `false`, optional) to each tool's `inputSchema`.
- **Helpers** — new `coreOptionsFromContext(context)` in `packages/mcp/src/sca.ts` forwards the wrapper's context (`idempotencyKey` + optional `scaSessionToken`) to the underlying core service calls. Centralizes the spread that would otherwise repeat 25× across tools.
- **Response shape** — old `formatScaRequiredResponse` removed; `withClient` fallback now uses the exported `formatScaPendingResponse`. The structured pending response references `sca_session_show` + `sca_session_token` (not the raw HTTP endpoint).
- **Tool descriptions** — each wired tool's top-level `description` advertises SCA upfront so an LLM client can pre-warn the user.
- **Core plumbing** — adds `scaSessionToken` option to `createInternalTransfer` in core for uniform plumbing across all wired write operations.
- **Tests** — 4 new unit tests on `transfer_create` cover wait=0, supplied token, polling-path idempotency stability, and wait=false. `errors.test.ts` updated for the new SCA response shape. All 327 MCP + 658 CLI unit tests pass.

## Out of scope

- E2E coverage for SCA continuation flows (deferred to WI-H / #434 per scope's verification plan).
- Documentation updates (deferred to WI-J / #436).

## Test plan

- [x] `pnpm build` — all 5 packages clean
- [x] `pnpm test` — 327 MCP + 658 CLI passing
- [x] `pnpm lint` — clean
- [x] `pnpm license-check` — clean
- [ ] `pnpm test:e2e` — currently blocked by expired OAuth credentials in `.qontoctl.yaml` (access-token expired 2026-05-05; refresh-token rejected `invalid_grant`). Pre-existing environment issue affecting the entire parallel batch (confirmed by stashing changes and re-running on `origin/main` baseline). Will be unblocked when operator refreshes the OAuth token; the E2E sandbox CI job will re-validate post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)