### PR TITLE
(fix) correct SCA 428 mock shape in transfer.test.ts

### DIFF
--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -455,10 +455,14 @@ describe("transfer MCP tools", () => {
             postCount++;
             observedIdempotencyKeys.push(headers?.["X-Qonto-Idempotency-Key"] ?? null);
             if (postCount === 1) {
-              // First attempt: 428 SCA required.
+              // First attempt: 428 SCA required. Real Qonto API returns top-level fields,
+              // not an `errors[]` array — see docs/security/sca-token-binding.md.
               return new Response(
                 JSON.stringify({
-                  errors: [{ code: "sca_required", detail: "SCA required", sca_session_token: SCA_TOKEN }],
+                  action_type: "transfer.single.create",
+                  code: "sca_required",
+                  message: "SCA required",
+                  sca_session_token: SCA_TOKEN,
                 }),
                 {
                   status: 428,


### PR DESCRIPTION
## Context

Main is broken — `transfer MCP tools > transfer_create > SCA continuation > preserves a stable idempotency key across the initial 428 + post-poll retry` fails on all 3 OS targets.

## Root Cause

The test (added by #428, PR #470) mocked a 428 SCA challenge with `{errors: [{code: "sca_required", sca_session_token: ...}]}`, but real Qonto API returns these fields at the **top level** of the body (per `docs/security/sca-token-binding.md`).

Pre-#445, `build428Error` had a `return new QontoScaRequiredError("unknown")` fallback for unrecognized 428 shapes — the test's `errors[]` shape didn't match either branch but the fallback still produced the right exception type, so retry happened (with a bogus "unknown" token, but the test didn't assert on token value). #428's PR CI passed against base 631300e (which had #448 but the "unknown" fallback intact).

Then #445 (PR #469, de58953) correctly removed that fallback in favor of throwing a typed error. After #445 + #428 both landed on main (rebase order: 631300e → de58953 → b55aba0), the test's mock 428 now produces a generic `QontoApiError(428, ...)` instead of `QontoScaRequiredError`, so `executeWithMcpSca` doesn't recognize it as recoverable and skips the retry.

## Fix

Update the mock to use the documented Qonto response shape (top-level `code`, `message`, `sca_session_token`). One-line change in the test; production code is correct. Other tests in the same file (e.g. `accepts wait=false`) already use the correct shape, so this was an isolated drift.

## Verification

`pnpm test --filter @qontoctl/mcp` passes locally (25 transfer tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>