### PR TITLE
(feat) skip vop_proof_token auto-resolve on SCA retry (#437)

### DIFF
--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -98,6 +98,15 @@ export function registerTransferCreateCommand(parent: Command): void {
     let vopProofToken: string;
     let beneficiaryField: { beneficiary_id: string } | { beneficiary: InlineBeneficiary };
 
+    // WI-K (#437): the CLI does NOT exhibit the MCP retry-path edge case for
+    // `vop_proof_token` × `sca_session_token`. The CLI uses a single inline
+    // SCA polling flow (`executeWithCliSca`): the auto-resolved
+    // `vopProofToken` is captured in this closure variable BEFORE the SCA
+    // challenge and reused verbatim on the post-SCA retry, so PSD2 dynamic
+    // linking holds and `verifyPayee` is never re-run mid-flow. The MCP
+    // analogue (`packages/mcp/src/tools/transfer.ts`) handles a caller-driven
+    // two-step retry where the auto-resolution must be skipped to preserve
+    // the binding — see the WI-K block there.
     if (opts.beneficiaryName !== undefined && opts.beneficiaryIban !== undefined) {
       if (opts.beneficiary !== undefined) {
         throw new Error(

--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -516,6 +516,77 @@ describe("transfer MCP tools", () => {
         const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
         expect(text).toContain(SCA_TOKEN);
       });
+
+      // WI-K (#437): when retrying with caller-supplied sca_session_token,
+      // vop_proof_token auto-resolution is intentionally skipped so PSD2
+      // dynamic linking (RTS Art. 5) is preserved on the bound retry.
+      it("skips vop_proof_token auto-resolution when sca_session_token is supplied (WI-K)", async () => {
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers" && init.method === "POST") {
+            return jsonResponse({ transfer: makeTransfer({ id: "txfr-skip-autoresolve" }) });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: {
+            ...createArgs,
+            vop_proof_token: "explicit-from-original",
+            sca_session_token: SCA_TOKEN,
+          },
+        });
+
+        // Success: not an error response.
+        expect(result.isError).not.toBe(true);
+
+        // Auto-resolution must NOT have run: no /beneficiaries/ or /verify_payee call.
+        const calls = fetchSpy.mock.calls as [URL, RequestInit][];
+        const benCall = calls.find((c) => c[0].pathname.includes("/beneficiaries/"));
+        const vopCall = calls.find((c) => c[0].pathname.includes("/verify_payee"));
+        expect(benCall).toBeUndefined();
+        expect(vopCall).toBeUndefined();
+
+        // The transfer call carries the explicit caller-supplied vop_proof_token.
+        const transferCall = calls.find((c) => c[0].pathname === "/v2/sepa/transfers") as
+          | [URL, RequestInit]
+          | undefined;
+        expect(transferCall).toBeDefined();
+        const body = JSON.parse((transferCall as [URL, RequestInit])[1].body as string) as {
+          vop_proof_token: string;
+        };
+        expect(body.vop_proof_token).toBe("explicit-from-original");
+
+        // The retry carries the SCA session token header (binding the prior approval).
+        const headers = (transferCall as [URL, RequestInit])[1].headers as Record<string, string> | undefined;
+        expect(headers?.["X-Qonto-Sca-Session-Token"]).toBe(SCA_TOKEN);
+      });
+
+      it("returns informative error when sca_session_token is supplied without vop_proof_token (WI-K)", async () => {
+        fetchSpy.mockImplementation(() => jsonResponse({}));
+
+        const result = await mcpClient.callTool({
+          name: "transfer_create",
+          arguments: {
+            ...createArgs,
+            sca_session_token: SCA_TOKEN,
+            // vop_proof_token deliberately omitted
+          },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain("vop_proof_token is required when retrying with sca_session_token");
+        expect(text).toContain("PSD2");
+
+        // No outbound API calls should have been issued (in particular,
+        // verify_payee must NOT run — that is the whole point of the skip).
+        const calls = fetchSpy.mock.calls as [URL, RequestInit][];
+        const vopCall = calls.find((c) => c[0].pathname.includes("/verify_payee"));
+        const transferCall = calls.find((c) => c[0].pathname === "/v2/sepa/transfers");
+        expect(vopCall).toBeUndefined();
+        expect(transferCall).toBeUndefined();
+      });
     });
   });
 

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -135,7 +135,20 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
         let vopProofToken = args.vop_proof_token;
         let vopResult: VopResult | undefined;
 
-        if (vopProofToken === undefined) {
+        // WI-K decision (#437): when retrying with a caller-supplied
+        // `sca_session_token`, do NOT auto-resolve `vop_proof_token` via
+        // verifyPayee. PSD2 RTS Art. 5 (dynamic linking) binds the SCA
+        // session token to the original transfer's request body — including
+        // the `vop_proof_token` field. Re-running verifyPayee on retry would
+        // produce a fresh `vop_proof_token`, changing the request shape, and
+        // Qonto rejects the bound session with HTTP 422 ("Not found"). See
+        // docs/security/sca-token-binding.md for the empirical evidence (#438).
+        // A second concern eliminated here: if Qonto ever extends SCA
+        // protection to /v2/sepa/verify_payee, auto-resolution on retry would
+        // itself trigger a nested SCA session. Skipping forces an explicit
+        // contract: the caller MUST provide the same `vop_proof_token` used
+        // on the original attempt alongside `sca_session_token`.
+        if (vopProofToken === undefined && args.sca_session_token === undefined) {
           if (args.beneficiary !== undefined) {
             vopResult = await verifyPayee(client, {
               iban: args.beneficiary.iban,
@@ -154,6 +167,24 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
         }
 
         if (vopProofToken === undefined) {
+          if (args.sca_session_token !== undefined) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: [
+                    "vop_proof_token is required when retrying with sca_session_token.",
+                    "",
+                    "The SCA session token is bound to the original transfer's vop_proof_token (PSD2",
+                    "dynamic linking, RTS Art. 5). Auto-resolution would generate a fresh token and",
+                    "break the binding — Qonto would reject the retry. Supply the vop_proof_token",
+                    "from the original attempt, or omit sca_session_token to start a fresh flow.",
+                  ].join("\n"),
+                },
+              ],
+              isError: true,
+            };
+          }
           return {
             content: [{ type: "text" as const, text: "Could not resolve VoP proof token" }],
             isError: true,


### PR DESCRIPTION
## Summary

Pins WI-K (per `.tmp/scopes/sca-continuation.md`): when `transfer_create` is retried with caller-supplied `sca_session_token`, `vop_proof_token` auto-resolution via `verifyPayee` is now skipped.

**Why**: PSD2 RTS Art. 5 (dynamic linking, verified empirically in #438 / [`docs/security/sca-token-binding.md`](docs/security/sca-token-binding.md)) binds the SCA session token to the original transfer's request body. Re-running `verifyPayee` on retry would produce a fresh `vop_proof_token`, change the request shape, and Qonto would reject the bound session with `HTTP 422 ("Not found")`. Skipping also eliminates the theoretical nested-SCA risk if Qonto ever extends SCA protection to `/v2/sepa/verify_payee`.

## Decision

**Option chosen**: skip auto-resolution when `sca_session_token` is supplied (the AC's first option, "covered by test").

**Why not "let it re-run (status quo) as ACCEPTED_GAP"**: the status quo would silently produce a 422 on retry; the change to skip is small (one condition + improved error message); the principled choice is the same effort as the documentation choice.

## Behavior

| `vop_proof_token` | `sca_session_token` | Behavior |
|---|---|---|
| supplied | not supplied | unchanged — explicit token used directly |
| not supplied | not supplied | unchanged — auto-resolve via `verifyPayee` |
| supplied | supplied | NEW — skip auto-resolve, retry binds the explicit token |
| not supplied | supplied | NEW — return informative regulation-aware error |

## Changes

- `packages/mcp/src/tools/transfer.ts` — gate auto-resolution on `sca_session_token === undefined`; add WI-K comment block citing PSD2 RTS Art. 5 and `docs/security/sca-token-binding.md`; new error path with recovery guidance when the caller supplies `sca_session_token` without `vop_proof_token`.
- `packages/cli/src/commands/transfer/create.ts` — comment-only: documents that the CLI's inline-poll flow captures `vopProofToken` in a closure and reuses it on the post-SCA retry, so PSD2 binding holds without code change. Points readers at the MCP analogue.
- `packages/mcp/src/tools/transfer.test.ts` — two new unit tests in the SCA continuation describe block: (1) skip behavior when both tokens are supplied, (2) informative error when `sca_session_token` is supplied without `vop_proof_token`.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 333 MCP unit tests + 658 CLI unit tests pass; 2 new WI-K tests included
- [x] `pnpm lint` — clean
- [x] `pnpm license-check` — clean
- [x] `pnpm exec prettier --check` on changed files — clean
- [ ] `pnpm test:e2e` — sandbox OAuth refresh token expired across the batch (`invalid_grant`); environmental, unrelated to this change. The new code paths are not exercised by any existing E2E test (no E2E test combines `sca_session_token` and `vop_proof_token`); coverage delegated to unit tests.

Closes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)