### PR TITLE
(docs) coordinate semver, CHANGELOG, Homebrew tap for SCA continuation (#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+The next release is a coordinated bump across all four packages — `@qontoctl/core`, `@qontoctl/cli`, `@qontoctl/mcp`, and `qontoctl` (umbrella). **`@qontoctl/mcp` introduces a BREAKING change in the SCA response shape** for the eight write tools (see § Changed); **`qontoctl` (umbrella) inherits MAJOR**. See [`docs/release-runbook.md`](docs/release-runbook.md) for the full semver decision framework and worked example.
+
+### Added
+
+- **`@qontoctl/cli`**: `sca-session show <token>` subcommand to inspect SCA session status (#431).
+- **`@qontoctl/cli`**: `sca-session mock-decision <token> <allow|deny>` subcommand for sandbox-only SCA decision injection (#431).
+- **`@qontoctl/mcp`**: `sca_session_show` MCP tool to inspect SCA session status (#432).
+- **`@qontoctl/mcp`**: `sca_session_mock_decision` MCP tool for sandbox-only SCA decision injection (gated to sandbox mode) (#432).
+- **`@qontoctl/mcp`**: `executeWithMcpSca` wrapper module enabling bounded SCA polling (`wait` knob) and two-step `sca_session_token` continuation across MCP write tools (#433).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: `scaMethod` / `X-Qonto-2fa-Preference` exposure through `createClient`, the hidden `--sca-method` CLI flag, and MCP server config. Auto-defaults to `mock` when a sandbox staging token is present and no method is otherwise set; production never auto-defaults. The MCP server resolves the method from env/config only — it is intentionally not exposed as a tool input (#447).
+- **Docs**: PSD2 Article 5 SCA token request-binding verification recorded in `docs/security/sca-token-binding.md` (#438).
+- **Docs**: Release runbook (`docs/release-runbook.md`) covering semver decision framework, npm publish flow, and Homebrew tap update (#435).
+
+### Changed
+
+- **`@qontoctl/mcp`** **(BREAKING)**: SCA-required (HTTP 428) responses across the eight MCP write-tool families (`transfer_*`, `intl_transfer_*`, `internal_transfer_*`, `bulk_transfer_*`, `recurring_transfer_*`, `card_*`, `beneficiary_*`, `request_*` — every operation that triggers SCA) no longer return the legacy dead-end text response. Tools now accept optional `wait` (number 0–120, or `false`) and `sca_session_token` input parameters and return a structured SCA-pending response on poll-timeout that references the new `sca_session_show` and `sca_session_mock_decision` tools. Callers parsing the previous text response must adapt to the new shape (#428).
+
+### Fixed
+
+- **`@qontoctl/core`**: SCA-retry idempotency-key drift in `executeWithSca` — both the original 428 attempt and the SCA-approved retry now carry the same `X-Qonto-Idempotency-Key` header. Without this fix, retries without an explicit `--idempotency-key` could create duplicate operations (#429).
+- **`@qontoctl/core`**: `mockScaDecision` URL corrected and request body removed to match the Qonto sandbox API (#446).
+- **`@qontoctl/core`**: `build428Error` now throws a typed error on unknown 428 response shape, surfacing clearer diagnostics instead of silently falling through (#445).
+- **`@qontoctl/core`**: 428 responses with `code: "sca_not_enrolled"` are now distinguished from `code: "sca_required"` and surface a typed `ScaNotEnrolledError`, allowing callers to react differently (#448).
+- **`@qontoctl/core`**: Beneficiary `trust`/`untrust` operations now use `PATCH` (was incorrectly using `POST`) (#444).
+
+### Security
+
+- **`@qontoctl/core`**: SCA session token redacted from error messages and debug logs. `QontoScaRequiredError`, `ScaTimeoutError`, and `ScaDeniedError` no longer embed the token in their `.message` strings (token remains accessible via the dedicated `.scaSessionToken` field). The `sca_session_token` request-body field and `X-Qonto-Sca-Session-Token` header are added to `redactSensitiveFields` (#430).
+
+## [1.0.0] — 2026-03-26
+
 ### Added
 
 - OAuth 2.0 authentication flow with PKCE, token management, and automatic refresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Each package uses conditional exports with `types` + `import`:
 ## CI/CD
 
 - **CI**: Runs on push/PR to `main`; 3-OS matrix (ubuntu, macos, windows); builds, lints, license-checks, tests
-- **Release**: Triggered by GitHub Release publish; validates, stamps version from git tag, publishes to npm with provenance
+- **Release**: Triggered by GitHub Release publish; validates, stamps version from git tag, publishes to npm with provenance. Step-by-step procedure (with rollback): [`docs/release-runbook.md`](docs/release-runbook.md)
 - **Homebrew**: After npm publish completes, trigger the "Update Formula" workflow in `qontoctl/homebrew-tap` (`gh workflow run "Update Formula" --repo qontoctl/homebrew-tap`) to update the Homebrew formula to the latest npm version
 - **Setup**: Composite action at `.github/actions/setup/` (pnpm + Node.js 24 + frozen lockfile + Turbo cache)
 - Coverage uploaded to Codecov on ubuntu only

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,232 @@
+# Release Runbook
+
+This runbook is the canonical procedure for cutting a QontoCtl release. Read it end-to-end before tagging.
+
+## Overview
+
+QontoCtl publishes a coordinated set of npm packages from a single git tag, then republishes the Homebrew formula:
+
+| Package          | Registry     | Role                                      |
+| ---------------- | ------------ | ----------------------------------------- |
+| `@qontoctl/core` | npm (public) | Qonto API client and service layer (leaf) |
+| `@qontoctl/cli`  | npm (public) | CLI commands (depends on core)            |
+| `@qontoctl/mcp`  | npm (public) | MCP server (depends on core)              |
+| `qontoctl`       | npm (public) | Umbrella binary (composes CLI + MCP)      |
+| `qontoctl/tap`   | Homebrew tap | `brew install qontoctl/tap/qontoctl`      |
+
+All four npm packages ship under the **same version**, stamped from the git tag at release time by the `Stamp version` step in [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+
+## Release Cadence
+
+On demand. Trigger criteria: meaningful user-visible changes accumulated in `CHANGELOG.md [Unreleased]`, a security fix needing prompt distribution, or a regression that warrants a patch.
+
+## Versioning
+
+QontoCtl follows [Semantic Versioning 2.0.0](https://semver.org/) at the umbrella level, and the umbrella version is derived from the highest-impact change across the four packages.
+
+### Per-Package Decision Framework
+
+Apply semver per package, then take the **highest impact across the four** as the release version.
+
+| Change Type                               | Bump      | Examples                                                                                                                     |
+| ----------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Breaking API change in any package        | **MAJOR** | Response-shape change in MCP tool; removed CLI flag; renamed exported symbol; changed function signature; removed npm export |
+| Backwards-compatible feature              | **MINOR** | New CLI subcommand; new MCP tool; new client method; new optional config key; new exported error class                       |
+| Backwards-compatible fix                  | **PATCH** | Bug fix; performance improvement; redaction fix; documentation correction                                                    |
+| Security fix that is backwards-compatible | **PATCH** | Sensitive-field redaction; CVE patch; supply-chain dependency update                                                         |
+
+**Pre-1.0 packages** (`0.x.y`): per [semver §4](https://semver.org/#spec-item-4), breaking changes can land in MINOR bumps. After v1.0.0, each package commits to standard semver and breaking changes require MAJOR.
+
+**Coordination rule**: Because all four packages share a version, the release version is `max(per-package-implied-bump)`. The CHANGELOG entry must name the package(s) driving the bump so consumers understand the blast radius.
+
+### Worked Example: SCA Continuation Release (post-v1.0.0)
+
+The SCA continuation initiative introduces a **breaking change in `@qontoctl/mcp`**: the response shape of HTTP 428 SCA-required paths across the eight MCP write-tool families (`transfer_*`, `intl_transfer_*`, `internal_transfer_*`, `bulk_transfer_*`, `recurring_transfer_*`, `card_*`, `beneficiary_*`, `request_*`) changed (see PR #428 — `(feat) wire SCA continuation into MCP write tools`). Per the framework above:
+
+| Package               | Implied bump | Why                                                                                                           |
+| --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------- |
+| `@qontoctl/mcp`       | **MAJOR**    | Response-shape change — callers parsing the legacy text format break                                          |
+| `@qontoctl/core`      | **MINOR**    | Additive: `scaMethod` exposure (#447); new typed errors (#445, #448); assorted fixes (#429, #430, #444, #446) |
+| `@qontoctl/cli`       | **MINOR**    | Additive: new `sca-session` subcommands (#431); `--sca-method` flag (#447)                                    |
+| `qontoctl` (umbrella) | **MAJOR**    | Inherits highest impact (`@qontoctl/mcp`)                                                                     |
+
+→ **Release version: `2.0.0`** (post-v1.0.0).
+
+## Release Procedure
+
+### 1. Pre-release checks (local)
+
+```sh
+# On main, with no uncommitted changes
+git checkout main
+git pull --ff-only origin main
+pnpm install --frozen-lockfile
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm test:e2e          # required per CLAUDE.md § E2E Testing
+pnpm lint
+pnpm license-check
+pnpm publish-check
+pnpm format:check
+```
+
+All checks must pass green locally before tagging. The release workflow re-runs the same checks across ubuntu/macos/windows in CI (see step 4 below).
+
+### 2. Update CHANGELOG
+
+Promote `[Unreleased]` to a versioned heading and start a fresh empty `[Unreleased]`:
+
+```diff
+ ## [Unreleased]
+
++## [2.0.0] — 2026-MM-DD
++
+ ### Added
+ ...
+```
+
+Move the date to the same line as the heading; preserve the `### Added` / `### Changed` / `### Fixed` / `### Security` subsections under the new versioned heading.
+
+Verify each entry references a merged PR or issue. Confirm the per-package grouping convention (`**\`@qontoctl/<pkg>\`\*\*: ...`) is applied consistently.
+
+Commit on `main`:
+
+```sh
+git add CHANGELOG.md
+git commit -m "(docs) promote [Unreleased] to [2.0.0]"
+git push origin main
+```
+
+### 3. Create GitHub Release
+
+Tag and release from the `main` branch HEAD:
+
+```sh
+gh release create v2.0.0 \
+  --repo alexey-pelykh/qontoctl \
+  --title "v2.0.0" \
+  --target main \
+  --notes "$(awk '/^## \[2\.0\.0\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)"
+```
+
+The tag MUST match the regex `^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$` — see `.github/workflows/release.yml` § "Stamp version" step. Build metadata (e.g. `+build`) is rejected.
+
+For a pre-release (alpha/beta/rc), append a hyphenated suffix and pass `--prerelease`:
+
+```sh
+gh release create v2.0.0-rc.1 \
+  --repo alexey-pelykh/qontoctl \
+  --title "v2.0.0-rc.1" \
+  --target main \
+  --prerelease \
+  --notes "Pre-release for v2.0.0 — see CHANGELOG [Unreleased]."
+```
+
+### 4. npm publish (automatic)
+
+Publishing the GitHub Release triggers the [`Release` workflow](../.github/workflows/release.yml):
+
+1. **Validate** job runs `pnpm format:check && pnpm build && pnpm typecheck && pnpm lint && pnpm license-check && pnpm publish-check && pnpm test` on ubuntu/macos/windows (3-OS matrix) at version `0.0.0` (the workspace baseline). Note: the validate job intentionally tests at `0.0.0` (see workflow comment); for TypeScript projects, version rarely affects build output.
+2. **Publish to npm** job (gated by GitHub Environment `npm-publish`, restricted to `main` and `v*` tags):
+    - Stamps the version from the tag: `pnpm -r exec npm version "$VERSION" --no-git-tag-version --allow-same-version`.
+    - Builds.
+    - Dry-runs `pnpm -r publish` to verify packaging.
+    - Publishes with provenance via npm trusted publishing (OIDC, no static `NPM_TOKEN`).
+
+Watch the run:
+
+```sh
+gh run list --repo alexey-pelykh/qontoctl --workflow Release --limit 1
+gh run watch <run-id> --repo alexey-pelykh/qontoctl
+```
+
+If the run fails before publish, investigate, push a fix to `main`, delete the failed release+tag, and re-cut. If it fails mid-publish (some packages published, others not), **do not unpublish** (npm forbids re-publishing the same version after unpublish). Cut a patch release with the missing packages instead — see § Rollback.
+
+### 5. Update Homebrew tap (manual trigger)
+
+After npm publish completes, trigger the Homebrew formula update workflow in the [`qontoctl/homebrew-tap`](https://github.com/qontoctl/homebrew-tap) repository:
+
+```sh
+gh workflow run "Update Formula" --repo qontoctl/homebrew-tap
+```
+
+This workflow reads the latest `qontoctl` version from the npm registry, regenerates the Homebrew formula with the new version + sha256, and commits to `main` of `homebrew-tap`. Verify:
+
+```sh
+gh run list --repo qontoctl/homebrew-tap --workflow "Update Formula" --limit 1
+gh run watch <run-id> --repo qontoctl/homebrew-tap
+```
+
+After the workflow succeeds, end-users can install or upgrade via:
+
+```sh
+brew install qontoctl/tap/qontoctl       # fresh install
+brew upgrade qontoctl/tap/qontoctl       # existing install
+```
+
+### 6. Post-release verification
+
+```sh
+# npm packages live at the new version
+npm view qontoctl version
+npm view @qontoctl/core version
+npm view @qontoctl/cli version
+npm view @qontoctl/mcp version
+
+# Homebrew formula updated
+brew info qontoctl/tap/qontoctl
+```
+
+All five should report the new version.
+
+### 7. Announce (optional)
+
+- **GitHub Release notes** — already populated in step 3.
+- **Linked GitHub Issues** — comment closing each issue with the release version (e.g., `Released in v2.0.0`).
+- **Discussions / Slack / etc.** — at maintainer discretion.
+
+## Rollback
+
+npm publishes are **immutable** — the same version cannot be re-published after unpublish. Use `npm deprecate` for soft rollback, then ship a patch release with the fix:
+
+```sh
+# Mark the bad version deprecated (does not remove it)
+npm deprecate qontoctl@2.0.0          "Critical regression — please use 2.0.1 or downgrade to 1.x"
+npm deprecate @qontoctl/core@2.0.0    "Critical regression — please use 2.0.1 or downgrade to 1.x"
+npm deprecate @qontoctl/cli@2.0.0     "Critical regression — please use 2.0.1 or downgrade to 1.x"
+npm deprecate @qontoctl/mcp@2.0.0     "Critical regression — please use 2.0.1 or downgrade to 1.x"
+
+# Cut the patch
+git checkout main && git pull --ff-only origin main
+# ...fix, commit, push, then re-run § 1–5 above with v2.0.1
+```
+
+For Homebrew, after the patch is published on npm, re-run the `Update Formula` workflow to point users at the patched version:
+
+```sh
+gh workflow run "Update Formula" --repo qontoctl/homebrew-tap
+```
+
+## Troubleshooting
+
+| Symptom                                             | Likely cause                                                                       | Fix                                                                                                                                                |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "Tag is not a valid semver version" in workflow log | Tag missing `v` prefix or contains `+build` metadata                               | Re-tag with `vMAJOR.MINOR.PATCH` (optional `-prerelease` suffix)                                                                                   |
+| `pnpm publish` "version already exists"             | Stamping replayed an already-published version                                     | Bump and re-tag; npm forbids overwriting                                                                                                           |
+| Validate job passes but publish fails on one OS     | Likely a transient registry / OIDC issue                                           | Re-run the failed job from the workflow page; do not re-tag                                                                                        |
+| Homebrew formula points at old version              | "Update Formula" workflow did not run, ran on a non-`main` branch, or failed       | Re-run `gh workflow run "Update Formula" --repo qontoctl/homebrew-tap`; check the run log                                                          |
+| Validate job concern about `0.0.0`                  | Validate runs at workspace baseline `0.0.0`, not the release version               | Accepted trade-off documented in the workflow file. If version-dependent behavior is introduced into the pipeline, move stamping before validation |
+| `pnpm publish-check` fails                          | A `package.json` field (homepage, repository, license, etc.) is missing or invalid | See `scripts/check-publish-manifest.js` for the enforced fields                                                                                    |
+| `pnpm license-check` fails                          | A new dependency uses a non-allowed license                                        | See `scripts/check-licenses.js` for allowed list; pin/replace the dependency                                                                       |
+
+## References
+
+- [`CLAUDE.md`](../CLAUDE.md) § CI/CD — high-level pipeline summary.
+- [`.github/workflows/release.yml`](../.github/workflows/release.yml) — release workflow definition.
+- [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) — pre-release CI gate.
+- [`scripts/check-licenses.js`](../scripts/check-licenses.js) — dependency license allowlist.
+- [`scripts/check-publish-manifest.js`](../scripts/check-publish-manifest.js) — package manifest validation.
+- [Semantic Versioning 2.0.0](https://semver.org/) — versioning rules.
+- [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) — CHANGELOG conventions.
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) — OIDC-based publish flow.


### PR DESCRIPTION
## Summary

Closes #435 (WI-I per `.tmp/scopes/sca-continuation.md`). Three deliverables for the SCA continuation release:

1. **Semver decision recorded** — `@qontoctl/mcp` MAJOR (response-shape break in the eight write-tool families per #428); umbrella `qontoctl` inherits MAJOR. Documented in `docs/release-runbook.md` § "Worked Example" + flagged **(BREAKING)** in `CHANGELOG.md`.
2. **CHANGELOG entries authored** for `@qontoctl/core` (5 fixed + 1 security + 1 cross-package added), `@qontoctl/cli` (2 added + 1 cross-package), `@qontoctl/mcp` (3 added + 1 cross-package + 1 BREAKING changed), and `qontoctl` (umbrella; named in section preamble + runbook). Covers PRs #428, #429, #430, #431, #432, #433, #438, #444–#448.
3. **Release runbook** at `docs/release-runbook.md` — semver decision framework, 7-step release procedure (pre-checks → CHANGELOG promote → GitHub Release → npm publish → Homebrew tap update → verification → announce), rollback section, troubleshooting table. Verbatim `gh workflow run "Update Formula" --repo qontoctl/homebrew-tap` invocation matches CLAUDE.md § CI/CD.

Also: promoted prior `[Unreleased]` content to `[1.0.0] — 2026-03-26` (it was never promoted at v1.0.0 release time, would have made new entries unreadable next to v1.0 baseline). Cross-referenced runbook from CLAUDE.md.

## Acceptance Criteria

| AC | Evidence |
|---|---|
| Decision recorded: `@qontoctl/mcp` MAJOR for response-shape change | `docs/release-runbook.md` § "Worked Example" + `CHANGELOG.md` `### Changed` BREAKING entry |
| CHANGELOG entries for `core`, `cli`, `mcp`, `qontoctl` (umbrella) | `CHANGELOG.md` `[Unreleased]` — preamble + per-package-tagged entries across `### Added` / `### Changed` / `### Fixed` / `### Security` |
| Umbrella version coordinates with highest sub-package bump | `docs/release-runbook.md` § "Per-Package Decision Framework" + worked example |
| `gh workflow run "Update Formula"` documented in runbook | `docs/release-runbook.md` § "5. Update Homebrew tap" line 151 (verbatim from CLAUDE.md:148) |

## Test plan

- [x] `pnpm format:check` — green
- [x] `pnpm build` — 5 packages cached green
- [x] `pnpm typecheck` — green (via build)
- [x] `pnpm lint` — 8 packages green
- [x] `pnpm license-check` — 96 deps, all allowed
- [x] `pnpm publish-check` — 4 packages verified
- [x] `pnpm test` — 84 files / 658 tests green
- [x] E2E — not required (docs-only chore; no source code changed)
- [x] Adversarial AC review — all 4 AC PASS (1 improvement applied during validation: added umbrella preamble to CHANGELOG)
- [x] Polish review — 1 improvement applied (clarified "eight MCP write tools" → "eight write-tool families" with explicit family names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)