### PR TITLE
(fix) declare QONTOCTL_* env in turbo test:e2e task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,10 @@
     },
     "test:e2e": {
       "dependsOn": ["build"],
-      "cache": false
+      "cache": false,
+      "env": [
+        "QONTOCTL_*"
+      ]
     },
     "typecheck": {
       "dependsOn": ["^build"]

--- a/turbo.json
+++ b/turbo.json
@@ -15,9 +15,7 @@
     "test:e2e": {
       "dependsOn": ["build"],
       "cache": false,
-      "env": [
-        "QONTOCTL_*"
-      ]
+      "env": ["QONTOCTL_*"]
     },
     "typecheck": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Problem

Turbo 2.x runs tasks with a strict env allowlist by default — env vars not declared in `globalEnv` or per-task `env` are stripped before the task subprocess starts. The `test:e2e` task had no `env` declaration, so the `QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`, `QONTOCTL_REFRESH_TOKEN` env vars set by the CI workflow's `e2e-sandbox` step never reached `vitest`.

**Effect**: every E2E test gated by `describe.skipIf(!hasCredentials())` (or the new `!hasStagingToken()` from #434) silently skipped in CI. Only the 5–6 tests without credential gating actually ran. "E2E (Sandbox): pass" status was mostly cosmetic — the OAuth-gated suites (transfers, transactions, beneficiaries, statements, etc.) were skipped end-to-end.

Local execution masked this because `hasCredentials()` walks upward from CWD looking for `.qontoctl.yaml`, which is present in the repo root locally but absent in the CI runner.

## Reproduction

With the fix removed (the prior state) and `.qontoctl.yaml` temporarily renamed to simulate CI's filesystem:

```sh
QONTOCTL_CLIENT_ID="fake_id" QONTOCTL_CLIENT_SECRET="fake_secret" QONTOCTL_STAGING_TOKEN="fake_st" \
  pnpm exec turbo run test:e2e --concurrency=1 --filter=@qontoctl/e2e -- src/transfers/cli.e2e.test.ts
```

→ `9 tests | 9 skipped` (env vars stripped; `hasCredentials()` returned false)

With the fix applied (this PR's change):

→ `9 failed` (tests RUN with fake creds; failure is from the API rejecting the fake credentials, not from skipping — proving the env now reaches vitest)

## Fix

Add `"env": ["QONTOCTL_*"]` to the `test:e2e` task in `turbo.json`. Pattern covers all five existing `QONTOCTL_*` secrets and any future ones with the same prefix.

## Caveat (out of scope, for awareness)

Even with this fix, CI's e2e-sandbox is fragile around OAuth refresh:

1. `QONTOCTL_REFRESH_TOKEN` is a single-use token that Qonto rotates on every `oauth/token` exchange.
2. The CI runner has no way to write the rotated token back to GitHub Secrets.
3. Each CI run that triggers a refresh "burns" the secret stored in `QONTOCTL_REFRESH_TOKEN`; the next CI run will fail with `invalid_grant` until the secret is manually re-set.

Long-term mitigation options (separate work): use api-key auth for CI (if Qonto supports api-key against sandbox), add a post-test step that updates the secret via PAT, or accept the manual re-seed cadence. Filing a follow-up issue is appropriate.

## Related

Surfaced during #434 (E2E coverage for SCA continuation flows) — the new SCA tests showed `4 of 4 skipped` in CI despite the e2e-sandbox job reporting "pass". Investigation traced to this turbo env-stripping behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>