### PR TITLE
(refactor) scope CI E2E to api-key-only suites; gate OAuth/sandbox tests as local-only (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,8 @@ jobs:
         id: publish-github-pages
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
-  e2e-sandbox:
-    name: E2E (Sandbox)
+  e2e:
+    name: E2E
     timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
@@ -113,11 +113,8 @@ jobs:
       - run: pnpm build
       - run: pnpm test:e2e
         env:
-          QONTOCTL_STAGING_TOKEN: ${{ secrets.QONTOCTL_STAGING_TOKEN }}
-          QONTOCTL_CLIENT_ID: ${{ secrets.QONTOCTL_CLIENT_ID }}
-          QONTOCTL_CLIENT_SECRET: ${{ secrets.QONTOCTL_CLIENT_SECRET }}
-          QONTOCTL_ACCESS_TOKEN: ${{ secrets.QONTOCTL_ACCESS_TOKEN }}
-          QONTOCTL_REFRESH_TOKEN: ${{ secrets.QONTOCTL_REFRESH_TOKEN }}
+          QONTOCTL_ORGANIZATION_SLUG: ${{ secrets.QONTOCTL_ORGANIZATION_SLUG }}
+          QONTOCTL_SECRET_KEY: ${{ secrets.QONTOCTL_SECRET_KEY }}
 
   ci-gate:
     name: CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,15 +94,23 @@ ESLint enforces this via `eslint-plugin-header`.
 
 **When to run:** E2E tests MUST be run locally and pass before submitting a PR or preparing a release. Also run after implementing or modifying code that touches Qonto API interactions, CLI commands, MCP tools, or any behavior covered by E2E tests.
 
-**Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with API key credentials. The config resolver picks this up from CWD automatically — no env var overrides needed.
+**Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with both api-key and OAuth credentials. The config resolver picks this up from CWD automatically — no env var overrides needed.
 
-**Sandbox note:** The Qonto sandbox environment (`thirdparty-sandbox.staging.qonto.co`) is only for OAuth-based integrations. API key authentication uses the production endpoint (`thirdparty.qonto.com`) directly — there is no separate sandbox for API key auth. E2E tests run against production.
+**Test taxonomy:** Each suite is gated on the credential type its endpoints require, per the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction). Three categories:
+
+- **API-key-compatible** (`describe.skipIf(!hasApiKeyCredentials())`) — runs in CI and locally when api-key is configured.
+- **OAuth-required** (`describe.skipIf(!hasOAuthCredentials())`) — local-only; CI has no OAuth credentials so these skip naturally.
+- **OAuth + sandbox** (`describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())`) — local-only, currently only `sca-continuation/`.
+
+Gates are capability-based, not environment-based: tests run when their required credentials are present, full stop. See [`docs/e2e-testing.md`](docs/e2e-testing.md) for the full per-suite categorization and operational guidance.
+
+**Sandbox note:** The Qonto sandbox environment (`thirdparty-sandbox.staging.qonto.co`) is only for OAuth-based integrations. API key authentication uses the production endpoint (`thirdparty.qonto.com`) directly — there is no separate sandbox for API key auth. The CI E2E job runs against production with api-key only.
 
 **Staging token:** The `oauth.staging-token` config field (or `QONTOCTL_STAGING_TOKEN` env var) injects an `X-Qonto-Staging-Token` header into all API requests, routing them to the Qonto sandbox environment. The staging token lives inside the `oauth` section because the sandbox is OAuth-only. When a staging token is present, sandbox URLs are used automatically. The staging token is also sent with OAuth token exchange, refresh, and revocation requests.
 
 **SCA method:** The `sca.method` config field (or `QONTOCTL_SCA_METHOD` env var, or hidden `--sca-method <value>` CLI flag) sets the `X-Qonto-2fa-Preference` header on write requests. Production accepts `paired-device`, `passkey`, `sms-otp`; sandbox additionally accepts `mock`. When a staging token is present and no method is otherwise set, QontoCtl auto-defaults to `"mock"` so sandbox writes work without a paired-device enrollment. **Production never auto-defaults.** The MCP server resolves the method from env/config only — it is intentionally NOT exposed as a tool input, so an LLM client cannot pick the SCA method on a write. See `docs/sandbox-testing.md`.
 
-**E2E sandbox in CI:** When `QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`, and `QONTOCTL_REFRESH_TOKEN` secrets are configured in the repository, the `e2e-sandbox` CI job runs E2E tests against the sandbox environment after the main CI job passes. This job is not part of the CI gate and does not block merging.
+**E2E in CI:** When `QONTOCTL_ORGANIZATION_SLUG` and `QONTOCTL_SECRET_KEY` repository secrets are configured, the `e2e` CI job runs the api-key-compatible E2E suites against production after the main CI job passes. OAuth and sandbox suites skip automatically (their gates require credentials CI doesn't have). The `e2e` job is not part of the CI gate and does not block merging.
 
 **Running:**
 

--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ The pending response's textual format is stable, so callers that need to extract
 
 QontoCtl supports two authentication methods:
 
-- **API Key** — read-only access using your organization slug and secret key
-- **OAuth 2.0** — full access including write operations and SCA; see the [OAuth App Setup Guide](docs/oauth-setup.md)
+- **API Key** — production-only access using your organization slug and secret key. Supports the endpoints listed as "API key ✔" in the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction) (most reads plus many writes — internal transfers, clients, attachments, …). Cannot be used against the Qonto sandbox.
+- **OAuth 2.0** — full access including OAuth-only endpoints (cards, teams, webhooks, e-invoicing, payment links, insurance, international transfers, recurring transfers, SCA flows) and the Qonto sandbox via staging-token; see the [OAuth App Setup Guide](docs/oauth-setup.md).
 
 ### Profile Format
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,137 @@
+# E2E Testing Guide
+
+QontoCtl's E2E suites live in `packages/e2e/src/` and are organized per Qonto API
+domain (clients, transfers, attachments, …). Each suite runs against a real Qonto
+backend and is gated on the credential type its endpoints require, per the
+[Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction).
+
+## Test taxonomy
+
+Three suite categories, each gated on a different capability check from
+`packages/e2e/src/sandbox.ts`:
+
+| Category               | Gate                                                              | Runs in CI?              | Runs locally?                                    |
+| ---------------------- | ----------------------------------------------------------------- | ------------------------ | ------------------------------------------------ |
+| **API-key-compatible** | `describe.skipIf(!hasApiKeyCredentials())`                        | yes (CI is api-key-only) | yes when api-key configured                      |
+| **OAuth-required**     | `describe.skipIf(!hasOAuthCredentials())`                         | no (CI has no OAuth)     | yes when OAuth configured                        |
+| **OAuth + sandbox**    | `describe.skipIf(!hasOAuthCredentials() \|\| !hasStagingToken())` | no                       | yes when both OAuth and staging-token configured |
+
+The gates are **capability-based**, not environment-based: a suite runs whenever
+its required credentials are present, regardless of whether you're on a developer
+laptop or in CI. CI naturally has only api-key credentials, so OAuth and sandbox
+suites skip automatically — no `CI=true` check needed.
+
+The categorization for each suite was derived from the Qonto auth table.
+Endpoints listed as **"Both methods"** mark a suite as api-key-compatible;
+endpoints listed as **"OAuth 2.0 only"** mark a suite as OAuth-required. Mixed
+suites (e.g. `bulk-transfers`, which lists/retrieves with api-key but creates
+with OAuth + SCA) are gated as OAuth-required overall, because a suite is
+considered OAuth-required if **any** of its operations requires OAuth.
+
+### Current categorization
+
+**API-key-compatible** (run in CI):
+
+attachments · clients · client-invoices · commands/beneficiary ·
+commands/credit-note · commands/label · commands/membership ·
+commands/mcp-beneficiaries · commands/mcp-labels-memberships ·
+commands/mcp-requests · commands/request · internal-transfers ·
+mcp/server (live block) · org-accounts · profile (live block) · statements ·
+supplier-invoices · transactions · transfers
+
+**OAuth-required** (local-only):
+
+bulk-transfers · cards · einvoicing · insurance · international ·
+intl-beneficiaries · intl-transfers · commands/payment-link ·
+commands/mcp-payment-links · quotes · recurring-transfers · teams · webhooks
+
+**OAuth + sandbox** (local-only, requires staging-token):
+
+sca-continuation
+
+**No credentials needed** (run anywhere):
+
+auth · completions · profile (structural) · mcp/server (structural)
+
+## CI behavior
+
+The `e2e` job in `.github/workflows/ci.yml` runs against **production** with
+api-key credentials:
+
+```yaml
+e2e:
+    name: E2E
+    needs: [ci]
+    steps:
+        - run: pnpm test:e2e
+          env:
+              QONTOCTL_ORGANIZATION_SLUG: ${{ secrets.QONTOCTL_ORGANIZATION_SLUG }}
+              QONTOCTL_SECRET_KEY: ${{ secrets.QONTOCTL_SECRET_KEY }}
+```
+
+API key credentials never rotate (unlike OAuth refresh tokens, which Qonto
+rotates on every `oauth/token` exchange — burning the GH-stored secret on
+every run). The previous OAuth-based `e2e-sandbox` job was inherently fragile
+for this reason; switching to api-key-only CI makes the E2E gate sustainable.
+
+The `e2e` job is **not** part of the merge gate (only `ci-gate` is required by
+branch protection). It runs informationally — failures surface but don't block
+merging.
+
+### Required GitHub secrets
+
+To enable the `e2e` CI job, configure these repository secrets:
+
+| Secret                       | Purpose          |
+| ---------------------------- | ---------------- |
+| `QONTOCTL_ORGANIZATION_SLUG` | api-key org slug |
+| `QONTOCTL_SECRET_KEY`        | api-key secret   |
+
+Old OAuth-related secrets (`QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`,
+`QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`, `QONTOCTL_REFRESH_TOKEN`) are
+no longer used by the CI workflow and can be removed from repository settings.
+
+## Running locally
+
+`pnpm test:e2e` runs the full suite. Suites gate themselves based on what's
+configured in `.qontoctl.yaml` (auto-discovered by walking up from CWD) or
+`QONTOCTL_*` environment variables.
+
+To run **api-key-compatible suites only** (mirroring CI behavior):
+
+```sh
+QONTOCTL_ORGANIZATION_SLUG=<slug> QONTOCTL_SECRET_KEY=<key> pnpm test:e2e
+# OR via .qontoctl.yaml with only the `api-key:` section
+```
+
+To run **everything including OAuth and sandbox** (typical developer flow):
+
+```yaml
+# .qontoctl.yaml
+api-key:
+    organization-slug: <slug>
+    secret-key: <key>
+oauth:
+    client-id: <id>
+    client-secret: <secret>
+    staging-token: <token> # enables sandbox routing + sca-continuation suite
+```
+
+Then:
+
+```sh
+pnpm test:e2e
+```
+
+## When to use which credential type
+
+- **api-key**: read-only access by default; supports many writes per the Qonto
+  auth table (clients CRUD, internal transfers, attachments, …). Production
+  endpoint only — there is no api-key-against-sandbox.
+- **OAuth**: full access including OAuth-only endpoints (cards, teams, webhooks,
+  e-invoicing, payment-links, insurance, international transfers, recurring
+  transfers, bulk transfers' SCA-create flow, …) and sandbox via staging-token.
+
+See [`docs/oauth-setup.md`](./oauth-setup.md) for OAuth app registration and
+[`docs/sandbox-testing.md`](./sandbox-testing.md) for sandbox setup including
+the `mock` SCA flow.

--- a/packages/e2e/src/attachments/cli.e2e.test.ts
+++ b/packages/e2e/src/attachments/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { AttachmentSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -51,7 +51,7 @@ function findTransactionWithAttachments(): TransactionItem | undefined {
   return transactions[0];
 }
 
-describe.skipIf(!hasCredentials())("attachment CLI commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => {
   describe("transaction attachment list", () => {
     it("lists attachments for a transaction and validates through schema", () => {
       const txn = findTransactionWithAttachments();

--- a/packages/e2e/src/attachments/mcp.e2e.test.ts
+++ b/packages/e2e/src/attachments/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { AttachmentSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -37,7 +37,7 @@ interface AttachmentListResponse {
   readonly attachments: AttachmentItem[];
 }
 
-describe.skipIf(!hasCredentials())("attachment MCP tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -8,7 +8,7 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials, hasStagingToken } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -49,7 +49,7 @@ interface BulkTransferRecord {
   readonly updated_at: string;
 }
 
-describe.skipIf(!hasCredentials())("bulk-transfer CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () => {
   describe("bulk-transfer list", () => {
     it("lists bulk transfers with default output", () => {
       const output = cli("bulk-transfer", "list", "--no-paginate");

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials, hasStagingToken } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -40,7 +40,7 @@ interface BulkTransferListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("bulk-transfer MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
   let stderrBuffer: string;

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { CardSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -32,7 +32,7 @@ interface CardItem {
   readonly holder_id: string;
 }
 
-describe.skipIf(!hasCredentials())("card CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
   describe("card list", () => {
     it("lists cards with default output", () => {
       const output = cli("card", "list");

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { CardListResponseSchema, CardSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -33,7 +33,7 @@ interface CardListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("card MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { ClientInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("client-invoice commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => {
   describe("client-invoice list", () => {
     it("lists client invoices", () => {
       const output = cli("client-invoice", "list");

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientInvoiceListResponseSchema, ClientInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP client invoice tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/clients/cli.e2e.test.ts
+++ b/packages/e2e/src/clients/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { ClientSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("client commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("client commands (e2e)", () => {
   describe("client list", () => {
     it("lists clients", () => {
       const output = cli("client", "list");

--- a/packages/e2e/src/clients/mcp.e2e.test.ts
+++ b/packages/e2e/src/clients/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientListResponseSchema, ClientSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP client tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/beneficiary.e2e.test.ts
+++ b/packages/e2e/src/commands/beneficiary.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { BeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -22,7 +22,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("beneficiary commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("beneficiary commands (e2e)", () => {
   describe("beneficiary list", () => {
     it("lists beneficiaries with id, name, iban, status, trusted", () => {
       const output = cli("beneficiary", "list");

--- a/packages/e2e/src/commands/credit-note.e2e.test.ts
+++ b/packages/e2e/src/commands/credit-note.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { CreditNoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -22,7 +22,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("credit-note commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("credit-note commands (e2e)", () => {
   describe("credit-note list", () => {
     it("lists credit notes without error", () => {
       const output = cli("credit-note", "list");

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { LabelSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -22,7 +22,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("label commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("label commands (e2e)", () => {
   describe("label list", () => {
     it("lists labels with id, name, parent_id", () => {
       const output = cli("label", "list");

--- a/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BeneficiaryListResponseSchema, BeneficiarySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -21,7 +21,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP beneficiary tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP beneficiary tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { LabelListResponseSchema, LabelSchema, MembershipListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -21,7 +21,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP label & membership tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP label & membership tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PaymentLinkListResponseSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP payment link tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/mcp-requests.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-requests.e2e.test.ts
@@ -6,11 +6,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RequestListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-describe.skipIf(!hasCredentials())("MCP request tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP request tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { MembershipSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -22,7 +22,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("membership commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("membership commands (e2e)", () => {
   describe("membership list", () => {
     it("lists memberships with expected fields", () => {
       const output = cli("membership", "list");

--- a/packages/e2e/src/commands/payment-link.e2e.test.ts
+++ b/packages/e2e/src/commands/payment-link.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { PaymentLinkSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("payment-link commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
   describe("payment-link list", () => {
     it("lists payment links", () => {
       const output = cli("payment-link", "list");

--- a/packages/e2e/src/commands/request.e2e.test.ts
+++ b/packages/e2e/src/commands/request.e2e.test.ts
@@ -5,7 +5,7 @@ import { type ExecFileSyncOptionsWithStringEncoding, execFileSync } from "node:c
 import { resolve } from "node:path";
 import { RequestSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -29,7 +29,7 @@ function cli(...args: string[]): string | null {
   }
 }
 
-describe.skipIf(!hasCredentials())("request commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("request commands (e2e)", () => {
   describe("request list", () => {
     it("lists requests or returns gracefully on 403", () => {
       const output = cli("request", "list");

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,7 @@ function cli(args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("e-invoicing CLI (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("e-invoicing CLI (e2e)", () => {
   it("einvoicing settings displays settings in table format", () => {
     const output = cli(["einvoicing", "settings"]);
     expect(output).toContain("sending_status");

--- a/packages/e2e/src/einvoicing/mcp.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/mcp.e2e.test.ts
@@ -6,11 +6,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-describe.skipIf(!hasCredentials())("e-invoicing MCP (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("e-invoicing MCP (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("insurance CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
   describe("insurance CRUD lifecycle", () => {
     let createdId: string | undefined;
 

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("insurance MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("internal-transfer CLI commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("internal-transfer CLI commands (e2e)", () => {
   describe("internal-transfer create", () => {
     it("rejects create with missing required options", () => {
       try {

--- a/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
@@ -5,11 +5,11 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-describe.skipIf(!hasCredentials())("internal-transfer MCP tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -28,7 +28,7 @@ interface IntlCurrencyItem {
   readonly name: string;
 }
 
-describe.skipIf(!hasCredentials())("international CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("international CLI commands (e2e)", () => {
   describe("intl eligibility", () => {
     it("returns eligibility status with default output", () => {
       const output = cli("intl", "eligibility");

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlEligibilityResponseSchema, IntlCurrencySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("international MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlBeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -30,7 +30,7 @@ interface IntlBeneficiaryItem {
   readonly country: string;
 }
 
-describe.skipIf(!hasCredentials())("intl-beneficiary CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", () => {
   describe("intl-beneficiary list", () => {
     it("lists international beneficiaries with default output", () => {
       const output = cli("intl-beneficiary", "list");

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("intl-beneficiary MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -22,7 +22,7 @@ function cliJson<T>(...args: string[]): T {
   return JSON.parse(output) as T;
 }
 
-describe.skipIf(!hasCredentials())("intl-transfer CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () => {
   describe("intl-transfer requirements", () => {
     it("returns requirements for a beneficiary", () => {
       // First list intl beneficiaries to get an ID

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("intl-transfer MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -7,7 +7,7 @@ import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -193,7 +193,7 @@ describe("MCP server via stdio (e2e)", () => {
     });
   });
 
-  describe.skipIf(!hasCredentials())("tool call with valid credentials", () => {
+  describe.skipIf(!hasApiKeyCredentials())("tool call with valid credentials", () => {
     it("org_show returns organization data in MCP content format", async () => {
       const result = await client.callTool({ name: "org_show", arguments: {} });
 

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,7 @@ function cli(args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("organization & accounts CLI (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", () => {
   let knownAccountId: string;
 
   beforeAll(() => {

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -6,11 +6,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-describe.skipIf(!hasCredentials())("organization & accounts MCP (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/profile/profile.e2e.test.ts
+++ b/packages/e2e/src/profile/profile.e2e.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { getCredentials, hasCredentials } from "../sandbox.js";
+import { getCredentials, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -219,10 +219,10 @@ describe("profile commands (e2e)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// profile test — requires sandbox API access
+// profile test — requires api-key credentials
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!hasCredentials())("profile test (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("profile test (e2e)", () => {
   let tempDir: string;
 
   beforeAll(() => {

--- a/packages/e2e/src/quotes/cli.e2e.test.ts
+++ b/packages/e2e/src/quotes/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { QuoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("quote commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("quote commands (e2e)", () => {
   describe("quote list", () => {
     it("lists quotes", () => {
       const output = cli("quote", "list");

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { QuoteListResponseSchema, QuoteSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP quote tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -35,7 +35,7 @@ interface RecurringTransferItem {
   readonly status: string;
 }
 
-describe.skipIf(!hasCredentials())("recurring-transfer CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)", () => {
   describe("recurring-transfer list", () => {
     it("lists recurring transfers with default output", () => {
       const output = cli("recurring-transfer", "list", "--no-paginate");

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -29,7 +29,7 @@ interface RecurringTransferListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("recurring-transfer MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -89,20 +89,47 @@ function tryReadConfigFile(path: string): ConfigCredentials | undefined {
 }
 
 /**
- * Check whether Qonto API credentials are available — either via
- * environment variables or via `.qontoctl.yaml` in the working directory.
+ * Check whether Qonto **api-key** credentials (organization slug +
+ * secret key) are available — via `QONTOCTL_ORGANIZATION_SLUG` +
+ * `QONTOCTL_SECRET_KEY` env vars or via `api-key.organization-slug`
+ * + `api-key.secret-key` in `.qontoctl.yaml`.
  *
- * Used by `describe.skipIf(!hasCredentials())` guards in E2E tests so
- * that API-dependent suites are skipped when no credentials are present.
+ * Used by `describe.skipIf(!hasApiKeyCredentials())` guards on suites
+ * whose exercised endpoints work with api-key auth per the
+ * [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction).
+ * Such suites run in CI (which is api-key-only) and locally.
  */
-export function hasCredentials(): boolean {
-  if (process.env["QONTOCTL_ORGANIZATION_SLUG"] !== undefined && process.env["QONTOCTL_SECRET_KEY"] !== undefined) {
+export function hasApiKeyCredentials(): boolean {
+  // Use truthy check rather than `!== undefined`: in GitHub Actions, an
+  // unconfigured `${{ secrets.X }}` materializes as an empty-string env var,
+  // which would falsely indicate creds are present.
+  if (process.env["QONTOCTL_ORGANIZATION_SLUG"] && process.env["QONTOCTL_SECRET_KEY"]) {
     return true;
   }
-  if (process.env["QONTOCTL_CLIENT_ID"] !== undefined && process.env["QONTOCTL_CLIENT_SECRET"] !== undefined) {
+  const fileCreds = readConfigFileCredentials();
+  return fileCreds !== undefined && Boolean(fileCreds.organizationSlug) && Boolean(fileCreds.secretKey);
+}
+
+/**
+ * Check whether Qonto **OAuth** credentials (client id + client secret)
+ * are available — via `QONTOCTL_CLIENT_ID` + `QONTOCTL_CLIENT_SECRET`
+ * env vars or via `oauth.client-id` + `oauth.client-secret` in
+ * `.qontoctl.yaml`.
+ *
+ * Used by `describe.skipIf(!hasOAuthCredentials())` guards on suites
+ * whose endpoints require OAuth per the
+ * [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction)
+ * (international transfers, cards, teams, webhooks, e-invoicing,
+ * payment links, insurance, recurring transfers, bulk transfers,
+ * quotes, SCA flows, …). These suites only run locally where OAuth
+ * is configured; CI is api-key-only and skips them naturally.
+ */
+export function hasOAuthCredentials(): boolean {
+  if (process.env["QONTOCTL_CLIENT_ID"] && process.env["QONTOCTL_CLIENT_SECRET"]) {
     return true;
   }
-  return readConfigFileCredentials() !== undefined;
+  const fileCreds = readConfigFileCredentials();
+  return fileCreds !== undefined && Boolean(fileCreds.clientId) && Boolean(fileCreds.clientSecret);
 }
 
 /**
@@ -112,19 +139,20 @@ export function hasCredentials(): boolean {
  *
  * Used by `describe.skipIf(!hasStagingToken())` guards in E2E tests for
  * sandbox-only behavior (e.g., `mockScaDecision` is only available in the
- * Qonto sandbox environment).
+ * Qonto sandbox environment). Pair with `!hasOAuthCredentials()` since
+ * the sandbox is OAuth-only.
  */
 export function hasStagingToken(): boolean {
-  if (process.env["QONTOCTL_STAGING_TOKEN"] !== undefined) {
+  if (process.env["QONTOCTL_STAGING_TOKEN"]) {
     return true;
   }
-  return readConfigFileCredentials()?.stagingToken !== undefined;
+  return Boolean(readConfigFileCredentials()?.stagingToken);
 }
 
 /**
  * Retrieve credentials from environment variables or `.qontoctl.yaml`.
  * Throws if no credentials are available (callers should be guarded by
- * `hasCredentials()`).
+ * `hasApiKeyCredentials()` or `hasOAuthCredentials()` as appropriate).
  */
 export function getCredentials(): ConfigCredentials {
   const envSlug = process.env["QONTOCTL_ORGANIZATION_SLUG"];

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials, hasStagingToken } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -53,7 +53,7 @@ function cliJson<T>(...args: string[]): T {
   return JSON.parse(cliSync("--output", "json", ...args)) as T;
 }
 
-describe.skipIf(!hasCredentials() || !hasStagingToken())("SCA continuation CLI (e2e, sandbox)", () => {
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation CLI (e2e, sandbox)", () => {
   let beneficiaryId: string;
   let bankAccountId: string;
   let vopProofToken: string;

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -8,7 +8,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials, hasStagingToken } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -58,7 +58,7 @@ function firstText(content: unknown): string {
   return first.text;
 }
 
-describe.skipIf(!hasCredentials() || !hasStagingToken())("SCA continuation MCP (e2e, sandbox)", () => {
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation MCP (e2e, sandbox)", () => {
   let client: Client;
   let transport: StdioClientTransport;
   let stderrBuffer: string;

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,7 @@ function listStatements(): Record<string, unknown>[] {
   return JSON.parse(output) as Record<string, unknown>[];
 }
 
-describe.skipIf(!hasCredentials())("statement CLI commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
   // -- statement list --
 
   describe("statement list", () => {

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -6,11 +6,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StatementListResponseSchema, StatementSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
-describe.skipIf(!hasCredentials())("statement MCP tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { SupplierInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function cli(...args: string[]): string {
   });
 }
 
-describe.skipIf(!hasCredentials())("supplier-invoice commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("supplier-invoice commands (e2e)", () => {
   describe("supplier-invoice list", () => {
     it("lists supplier invoices", () => {
       const output = cli("supplier-invoice", "list");

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SupplierInvoiceListResponseSchema, SupplierInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,7 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
   return entry.text;
 }
 
-describe.skipIf(!hasCredentials())("MCP supplier invoice tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/teams/cli.e2e.test.ts
+++ b/packages/e2e/src/teams/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TeamSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -28,7 +28,7 @@ interface TeamItem {
   readonly name: string;
 }
 
-describe.skipIf(!hasCredentials())("team CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("team CLI commands (e2e)", () => {
   describe("team list", () => {
     it("lists teams with default output", () => {
       const output = cli("team", "list");

--- a/packages/e2e/src/teams/mcp.e2e.test.ts
+++ b/packages/e2e/src/teams/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TeamListResponseSchema, TeamSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -32,7 +32,7 @@ interface TeamListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("team MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TransactionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -45,7 +45,7 @@ function firstTransaction(transactions: readonly TransactionItem[]): Transaction
   return transactions[0];
 }
 
-describe.skipIf(!hasCredentials())("transaction CLI commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () => {
   describe("transaction list", () => {
     it("lists transactions with default output", () => {
       const output = cli("transaction", "list", "--no-paginate");

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransactionListResponseSchema, TransactionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -30,7 +30,7 @@ interface TransactionListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("transaction MCP tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -39,7 +39,7 @@ function firstTransfer(transfers: readonly TransferItem[]): TransferItem | undef
   return transfers[0];
 }
 
-describe.skipIf(!hasCredentials())("transfer CLI commands (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("transfer CLI commands (e2e)", () => {
   describe("transfer list", () => {
     it("lists transfers with default output", () => {
       const output = cli("transfer", "list", "--no-paginate");

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -29,7 +29,7 @@ interface TransferListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("transfer MCP tools (e2e)", () => {
+describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { WebhookSubscriptionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -29,7 +29,7 @@ interface WebhookItem {
   readonly types: string[];
 }
 
-describe.skipIf(!hasCredentials())("webhook CLI commands (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
   describe("webhook list", () => {
     it("lists webhooks with default output", () => {
       const output = cli("webhook", "list");

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasCredentials } from "../sandbox.js";
+import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -33,7 +33,7 @@ interface WebhookListResponse {
   };
 }
 
-describe.skipIf(!hasCredentials())("webhook MCP tools (e2e)", () => {
+describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
   let client: Client;
   let transport: StdioClientTransport;
 


### PR DESCRIPTION
## Summary

- Resolves #477. Switches CI E2E from OAuth+sandbox (fragile — Qonto rotates refresh tokens on every `oauth/token` exchange, burning the GH-stored secret) to api-key against production.
- Categorizes ~50 E2E suites per the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction): api-key-compatible (28 files, gate on `!hasApiKeyCredentials()`), OAuth-required (24, gate on `!hasOAuthCredentials()`), sandbox (2, gate on `!hasOAuthCredentials() || !hasStagingToken()`).
- Renames `e2e-sandbox` CI job to `e2e`, drops all 5 OAuth-related secrets, adds `QONTOCTL_ORGANIZATION_SLUG` + `QONTOCTL_SECRET_KEY` instead.

## Design notes

Gates are **capability-based**, not environment-based — a suite runs when its required credentials are present. CI naturally has only api-key credentials, so OAuth and sandbox suites skip without any `CI=true` detection. This is more robust than environment proxies and stays correct as the matrix evolves.

The README's outdated "API Key — read-only" claim is corrected (api-key supports many writes per the Qonto auth table — clients CRUD, internal transfers, attachments, etc.).

## Required follow-up (manual, before CI runs green)

The CI job's new env vars need their corresponding repo secrets configured:

- `QONTOCTL_ORGANIZATION_SLUG`
- `QONTOCTL_SECRET_KEY`

Old OAuth-related secrets (`QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`, `QONTOCTL_REFRESH_TOKEN`) are no longer used by CI and can be removed.

Until the new secrets are configured, the `e2e` job will run but every credential-gated suite will skip (`hasApiKeyCredentials()` returns false). The job is informational only — it is not part of the merge gate.

## Test plan

- [x] Unit tests: 682 passed across 84 files
- [x] Typecheck (`pnpm typecheck`): 8/8 packages pass
- [x] Lint (`pnpm lint`): 8/8 packages pass
- [x] Format (`pnpm format:check`): clean (one pre-existing warning on `.claude/memory/` is unrelated to this PR)
- [x] E2E locally with current `.qontoctl.yaml` (only OAuth tokens — no client-id/secret/api-key/staging): 5 suites pass, 53 skip per gates, 0 fail. Verifies gates fire correctly when neither OAuth-creds nor api-key are present.
- [ ] **AC #6 (api-key against production)**: deferred to CI run by explicit user choice (avoids touching the user's production account locally). The CI `e2e` job will exercise this empirically once the repo secrets are configured.

## Out of scope

- Per-test read/write classification within a suite (`bulk-transfers` lists/retrieves with api-key but creates with OAuth+SCA — currently the entire suite is gated as OAuth-required for conservatism). If write-failures surface in CI for any api-key-OK suite, finer-grained gating can be added in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)