### PR TITLE
(refactor) deterministic config path resolution; atomic writes + locking (#479)

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,9 @@
+# Example direnv configuration for QontoCtl repo-local development.
+#
+# Copy to `.envrc` (gitignored), then run `direnv allow` to activate.
+# This points the CLI/MCP at the repo's `.qontoctl.yaml` without relying
+# on CWD discovery (which the config resolver no longer performs — see #479).
+#
+# direnv: https://direnv.net/
+
+export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 ## Project-specific
 .qontoctl.yaml
+.qontoctl.yaml.lock
+.qontoctl.yaml.tmp.*
 *.local.*
 build/
 .tmp/
+
+# direnv local override (template at .envrc.example)
+.envrc
 
 # MCP Registry publisher tokens
 .mcpregistry_*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,13 @@ ESLint enforces this via `eslint-plugin-header`.
 
 **When to run:** E2E tests MUST be run locally and pass before submitting a PR or preparing a release. Also run after implementing or modifying code that touches Qonto API interactions, CLI commands, MCP tools, or any behavior covered by E2E tests.
 
-**Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with both api-key and OAuth credentials. The config resolver picks this up from CWD automatically — no env var overrides needed.
+**Credentials:** The repo contains `.qontoctl.yaml` (gitignored) with both api-key and OAuth credentials. The config resolver does **not** auto-discover from CWD (per #479) — point at the file via one of:
+
+- `direnv` shim: copy `.envrc.example` → `.envrc` (gitignored), run `direnv allow`. Exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` automatically when you `cd` into the repo. **Recommended** for daily development.
+- Per-shell env: `export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`
+- (After #480 ships) Per-invocation: `qontoctl --config ./.qontoctl.yaml ...`
+
+The E2E test harness already injects `QONTOCTL_CONFIG_FILE` for spawned CLI subprocesses (see `packages/e2e/src/sandbox.ts`), so `pnpm test:e2e` works without any of the above.
 
 **Test taxonomy:** Each suite is gated on the credential type its endpoints require, per the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction). Three categories:
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -23,7 +23,7 @@ import type { GlobalOptions } from "./options.js";
  * Auth precedence: OAuth (with auto-refresh) > API key.
  */
 export async function createClient(options: GlobalOptions): Promise<HttpClient> {
-  const { config, endpoint, warnings, oauthAccessTokenFromEnv } = await resolveConfig({
+  const { config, endpoint, warnings, path, oauthAccessTokenFromEnv } = await resolveConfig({
     profile: options.profile,
   });
 
@@ -38,7 +38,8 @@ export async function createClient(options: GlobalOptions): Promise<HttpClient> 
     authorization = createOAuthAuthorization({
       oauth: config.oauth,
       tokenUrl: config.oauth.stagingToken !== undefined ? OAUTH_TOKEN_SANDBOX_URL : OAUTH_TOKEN_URL,
-      profile: options.profile,
+      ...(path !== undefined ? { path } : {}),
+      ...(options.profile !== undefined ? { profile: options.profile } : {}),
       readOnly: oauthAccessTokenFromEnv,
     });
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -244,15 +244,36 @@ function resolveOAuthEndpoints(stagingToken?: string): OAuthEndpoints {
   };
 }
 
-async function resolveOAuthConfig(profile: string | undefined): Promise<{ oauth: OAuthCredentials }> {
-  const { config } = await resolveConfig({ profile });
+async function resolveOAuthConfig(
+  profile: string | undefined,
+): Promise<{ oauth: OAuthCredentials; path: string | undefined }> {
+  const { config, path } = await resolveConfig({ profile });
   if (config.oauth === undefined) {
     throw new Error(
       "No OAuth credentials found in configuration. " +
         'Add "oauth.client-id" and "oauth.client-secret" to your config file.',
     );
   }
-  return { oauth: config.oauth };
+  return { oauth: config.oauth, path };
+}
+
+/**
+ * Builds writer options that round-trip the loaded `path` when available,
+ * falling back to profile-based resolution otherwise. Used by all `auth`
+ * sub-commands so writes hit the exact file the loader read from — no
+ * silent divergence between load and write under #479's no-CWD model.
+ */
+function buildWriteOptions(
+  path: string | undefined,
+  profile: string | undefined,
+): { path: string } | { profile: string } | undefined {
+  if (path !== undefined) {
+    return { path };
+  }
+  if (profile !== undefined) {
+    return { profile };
+  }
+  return undefined;
 }
 
 function openBrowser(url: string): void {
@@ -378,13 +399,18 @@ export function registerAuthCommands(program: Command): void {
       "Setup Instructions",
     );
 
-    // Load existing config for defaults on re-run
+    // Load existing config for defaults on re-run. Capture `path` so the
+    // ensuing writes round-trip to the same file the loader read from
+    // (preventing load/write divergence under #479's no-CWD model).
     let existingOAuth: OAuthCredentials | undefined;
+    let loadedPath: string | undefined;
     try {
-      const { config } = await resolveConfig({ profile: opts.profile });
-      existingOAuth = config.oauth;
+      const result = await resolveConfig({ profile: opts.profile });
+      existingOAuth = result.config.oauth;
+      loadedPath = result.path;
     } catch {
-      // No existing config, start fresh
+      // No existing config, start fresh — `loadedPath` stays undefined
+      // and writes fall back to profile/home resolution below.
     }
 
     const clientId = await text({
@@ -425,9 +451,9 @@ export function registerAuthCommands(program: Command): void {
     // Ensure offline_access is always included
     const scopes = selectedScopes.includes("offline_access") ? selectedScopes : ["offline_access", ...selectedScopes];
 
-    const profileOpts = opts.profile !== undefined ? { profile: opts.profile } : undefined;
-    await saveOAuthClientCredentials({ clientId: clientId.trim(), clientSecret: clientSecret.trim() }, profileOpts);
-    await saveOAuthScopes(scopes, profileOpts);
+    const writeOpts = buildWriteOptions(loadedPath, opts.profile);
+    await saveOAuthClientCredentials({ clientId: clientId.trim(), clientSecret: clientSecret.trim() }, writeOpts);
+    await saveOAuthScopes(scopes, writeOpts);
 
     outro('Credentials saved. Run "qontoctl auth login" to authenticate.');
   });
@@ -447,7 +473,7 @@ export function registerAuthCommands(program: Command): void {
     const port = Number.parseInt(opts.port, 10);
     const redirectUri = `http://localhost:${port}/callback`;
 
-    const { oauth } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
     const { authUrl, tokenUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     // Scopes must be configured beforehand (via `auth setup`). `auth login` is
@@ -522,14 +548,15 @@ export function registerAuthCommands(program: Command): void {
       // Calculate expiration time
       const expiresAt = new Date(Date.now() + tokens.expiresIn * 1000).toISOString();
 
-      // Save tokens
+      // Save tokens — round-trip the loaded path so writer hits the same
+      // file the loader read from (no load/write divergence).
       await saveOAuthTokens(
         {
           accessToken: tokens.accessToken,
           ...(tokens.refreshToken !== undefined ? { refreshToken: tokens.refreshToken } : {}),
           accessTokenExpiresAt: expiresAt,
         },
-        opts.profile !== undefined ? { profile: opts.profile } : undefined,
+        buildWriteOptions(loadedPath, opts.profile),
       );
 
       s.stop("Login successful! Tokens saved.");
@@ -550,7 +577,7 @@ export function registerAuthCommands(program: Command): void {
   addInheritableOptions(refresh);
   refresh.action(async (_options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
-    const { oauth } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
     const { tokenUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     if (!oauth.refreshToken) {
@@ -574,7 +601,7 @@ export function registerAuthCommands(program: Command): void {
         refreshToken: tokens.refreshToken ?? oauth.refreshToken,
         accessTokenExpiresAt: expiresAt,
       },
-      opts.profile !== undefined ? { profile: opts.profile } : undefined,
+      buildWriteOptions(loadedPath, opts.profile),
     );
 
     process.stderr.write("Access token refreshed successfully.\n");
@@ -631,7 +658,7 @@ export function registerAuthCommands(program: Command): void {
   addInheritableOptions(revoke);
   revoke.action(async (_options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
-    const { oauth } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
     const { revokeUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     if (oauth.accessToken) {
@@ -652,7 +679,7 @@ export function registerAuthCommands(program: Command): void {
       }
     }
 
-    await clearOAuthTokens(opts.profile !== undefined ? { profile: opts.profile } : undefined);
+    await clearOAuthTokens(buildWriteOptions(loadedPath, opts.profile));
     process.stderr.write("OAuth tokens revoked and cleared.\n");
   });
 }

--- a/packages/cli/src/error-handler.test.ts
+++ b/packages/cli/src/error-handler.test.ts
@@ -29,14 +29,14 @@ describe("handleCliError", () => {
 
   describe("ConfigError", () => {
     it("shows configuration guidance", () => {
-      const error = new ConfigError("No credentials found.");
+      const error = new ConfigError("No credentials found.", "NO_CREDS");
 
       handleCliError(error, false);
 
       const output = stderrSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("Configuration error: No credentials found.");
       expect(output).toContain("~/.qontoctl.yaml");
-      expect(output).toContain("organization-slug");
+      expect(output).toContain("QONTOCTL_ORGANIZATION_SLUG");
       expect(output).toContain("QONTOCTL_ORGANIZATION_SLUG");
       expect(process.exitCode).toBe(1);
     });

--- a/packages/cli/src/error-handler.ts
+++ b/packages/cli/src/error-handler.ts
@@ -21,21 +21,7 @@ import {
  */
 export function handleCliError(error: unknown, debug: boolean): void {
   if (error instanceof ConfigError) {
-    process.stderr.write(
-      [
-        `Configuration error: ${error.message}`,
-        "",
-        "To configure credentials, create ~/.qontoctl.yaml:",
-        "",
-        "  api-key:",
-        "    organization-slug: <your-org-slug>",
-        "    secret-key: <your-secret-key>",
-        "",
-        "Or set environment variables:",
-        "  QONTOCTL_ORGANIZATION_SLUG=<your-org-slug>",
-        "  QONTOCTL_SECRET_KEY=<your-secret-key>",
-      ].join("\n") + "\n",
-    );
+    process.stderr.write(formatConfigError(error) + "\n");
     process.exitCode = 1;
     return;
   }
@@ -45,7 +31,7 @@ export function handleCliError(error: unknown, debug: boolean): void {
       [
         `Authentication error: ${error.message}`,
         "",
-        "Verify your API key credentials in ~/.qontoctl.yaml or environment variables.",
+        "Verify your API key credentials in ~/.qontoctl.yaml, via QONTOCTL_CONFIG_FILE, or via environment variables.",
       ].join("\n") + "\n",
     );
     process.exitCode = 1;
@@ -134,4 +120,58 @@ export function handleCliError(error: unknown, debug: boolean): void {
     process.stderr.write(`Error: ${message}\n`);
   }
   process.exitCode = 1;
+}
+
+/**
+ * Formats a {@link ConfigError} for stderr, dispatching on the error's
+ * discriminator code so each cause gets actionable guidance instead of a
+ * generic "create ~/.qontoctl.yaml" hint that doesn't apply to most cases.
+ */
+function formatConfigError(error: ConfigError): string {
+  switch (error.code) {
+    case "NO_CREDS":
+      return [
+        `Configuration error: ${error.message}`,
+        "",
+        "Set credentials via one of:",
+        "  • A config file at ~/.qontoctl.yaml (or pass --profile <name>)",
+        "  • The QONTOCTL_CONFIG_FILE env var pointing at an absolute path",
+        "  • Env vars QONTOCTL_ORGANIZATION_SLUG + QONTOCTL_SECRET_KEY (api-key)",
+        "  • Env vars QONTOCTL_CLIENT_ID + QONTOCTL_CLIENT_SECRET (oauth)",
+        "",
+        "For repo-local config, a direnv .envrc with",
+        '  export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"',
+        "lets you keep a project-scoped credentials file without --config on every invocation.",
+      ].join("\n");
+    case "PARSE":
+      return [
+        `Configuration error: ${error.message}`,
+        "",
+        "The YAML file could not be parsed. Check indentation, quoting, and special characters.",
+      ].join("\n");
+    case "VALIDATION":
+      return [
+        `Configuration error: ${error.message}`,
+        "",
+        "Fix the offending field and retry. Run with --debug for the original location.",
+      ].join("\n");
+    case "PERMISSION":
+      return [
+        `Configuration error: ${error.message}`,
+        "",
+        "Check file ownership and permissions. OAuth-bearing files should be 0600 (chmod 600 <path>).",
+      ].join("\n");
+    case "CONFLICT":
+      return [
+        `Configuration error: ${error.message}`,
+        "",
+        "Another qontoctl process is writing to the same config file.",
+        "Wait for it to finish, or kill it if it's stuck (a stale lock is reaped after 10 seconds).",
+      ].join("\n");
+    default:
+      // Future-proof: any unrecognized code (e.g., a new ConfigErrorCode
+      // variant added without updating this switch) still produces a
+      // legible message rather than crashing the caller.
+      return `Configuration error: ${error.message}`;
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,12 +53,14 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/proper-lockfile": "^4.1.4",
     "eslint": "catalog:",
     "typedoc": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
+    "proper-lockfile": "^4.1.2",
     "yaml": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/core/src/auth/api-key-flow.test.ts
+++ b/packages/core/src/auth/api-key-flow.test.ts
@@ -46,7 +46,7 @@ describe("API key auth flow", () => {
       );
 
       const { config } = await resolveConfig({
-        cwd: testDir,
+        path: join(testDir, ".qontoctl.yaml"),
         home: testHome,
         env: {},
       });
@@ -66,7 +66,6 @@ describe("API key auth flow", () => {
 
       const { config } = await resolveConfig({
         profile: "production",
-        cwd: testDir,
         home: testHome,
         env: {},
       });
@@ -83,7 +82,6 @@ describe("API key auth flow", () => {
   describe("missing credentials error guidance", () => {
     it("describes default search locations when no config exists", async () => {
       const error = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: {},
       }).catch((e: unknown) => e);
@@ -97,7 +95,6 @@ describe("API key auth flow", () => {
     it("describes profile-specific search locations for named profiles", async () => {
       const error = await resolveConfig({
         profile: "staging",
-        cwd: testDir,
         home: testHome,
         env: {},
       }).catch((e: unknown) => e);
@@ -108,19 +105,20 @@ describe("API key auth flow", () => {
       expect(message).toMatch(/QONTOCTL_STAGING_\*/);
     });
 
-    it("notes found config file when it lacks api-key section", async () => {
+    it("notes found config file when it lacks credentials", async () => {
       await writeFile(join(testDir, ".qontoctl.yaml"), "future-feature: true\n");
 
       const error = await resolveConfig({
-        cwd: testDir,
+        path: join(testDir, ".qontoctl.yaml"),
         home: testHome,
         env: {},
       }).catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(ConfigError);
       const message = (error as ConfigError).message;
-      expect(message).toMatch(/Found config at/);
-      expect(message).toMatch(/no api-key credentials/);
+      // Explicit-path message is now produced (path was given).
+      expect(message).toMatch(/Explicit path/);
+      expect(message).toMatch(/no credentials/);
     });
   });
 
@@ -130,7 +128,7 @@ describe("API key auth flow", () => {
   describe("env var overrides flow through to auth header", () => {
     it("builds auth header from env-only credentials", async () => {
       const { config } = await resolveConfig({
-        cwd: testDir,
+        path: join(testDir, ".qontoctl.yaml"),
         home: testHome,
         env: {
           QONTOCTL_ORGANIZATION_SLUG: "env-org",
@@ -150,7 +148,7 @@ describe("API key auth flow", () => {
       );
 
       const { config } = await resolveConfig({
-        cwd: testDir,
+        path: join(testDir, ".qontoctl.yaml"),
         home: testHome,
         env: {
           QONTOCTL_ORGANIZATION_SLUG: "override-org",
@@ -170,7 +168,7 @@ describe("API key auth flow", () => {
       );
 
       const { config } = await resolveConfig({
-        cwd: testDir,
+        path: join(testDir, ".qontoctl.yaml"),
         home: testHome,
         env: { QONTOCTL_SECRET_KEY: "env-secret" },
       });
@@ -183,7 +181,6 @@ describe("API key auth flow", () => {
     it("builds auth header from named profile env vars", async () => {
       const { config } = await resolveConfig({
         profile: "staging",
-        cwd: testDir,
         home: testHome,
         env: {
           QONTOCTL_STAGING_ORGANIZATION_SLUG: "staging-org",

--- a/packages/core/src/auth/oauth-authorization-factory.ts
+++ b/packages/core/src/auth/oauth-authorization-factory.ts
@@ -14,7 +14,22 @@ export interface CreateOAuthAuthorizationOptions {
   readonly oauth: OAuthCredentials;
   /** OAuth token endpoint URL. */
   readonly tokenUrl: string;
-  /** Optional profile name for persisting refreshed tokens. */
+  /**
+   * Absolute path to the config file the loader read from. Round-tripped
+   * to the writer on token refresh so the persistence target matches
+   * exactly — no re-resolution, no chance of writing to a different file
+   * than the one tokens were loaded from. Pair with the `path` field
+   * returned by {@link import("../config/index.js").resolveConfig}.
+   *
+   * When `undefined`, the writer falls back to its own resolution rules
+   * (`profile` if set, else home default). Callers that loaded from a
+   * file SHOULD pass `path` to keep load/write consistent.
+   */
+  readonly path?: string | undefined;
+  /**
+   * Optional profile name. Used by the writer's resolution chain when
+   * `path` is not provided. Has no effect when `path` is set.
+   */
   readonly profile?: string | undefined;
   /**
    * When `true`, the access token is treated as **read-only /
@@ -51,7 +66,7 @@ export interface CreateOAuthAuthorizationOptions {
  * is left untouched.
  */
 export function createOAuthAuthorization(options: CreateOAuthAuthorizationOptions): () => Promise<string> {
-  const { oauth, tokenUrl, profile, readOnly = false } = options;
+  const { oauth, tokenUrl, path, profile, readOnly = false } = options;
 
   return async () => {
     if (!readOnly && oauth.accessTokenExpiresAt && oauth.refreshToken) {
@@ -71,13 +86,18 @@ export function createOAuthAuthorization(options: CreateOAuthAuthorizationOption
         }
         oauth.accessTokenExpiresAt = new Date(Date.now() + tokens.expiresIn * 1000).toISOString();
 
+        // Round-trip the loaded `path` so the writer hits the same file
+        // the loader read from. When `path` is undefined (caller did not
+        // round-trip), fall back to profile-based resolution.
+        const writeOptions = path !== undefined ? { path } : profile !== undefined ? { profile } : undefined;
+
         await saveOAuthTokens(
           {
             accessToken: oauth.accessToken,
             refreshToken: oauth.refreshToken,
             accessTokenExpiresAt: oauth.accessTokenExpiresAt,
           },
-          profile !== undefined ? { profile } : undefined,
+          writeOptions,
         );
       }
     }

--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -177,32 +177,62 @@ describe("applyEnvOverlay", () => {
     expect(result.endpoint).toBe("https://env.example.com");
   });
 
-  it("overlays QONTOCTL_STAGING_TOKEN env var into oauth section", () => {
-    const config = {};
+  it("overlays QONTOCTL_STAGING_TOKEN env var when file supplies client creds", () => {
+    // Post-#479: a staging token without resolvable client creds is
+    // dropped (the resolver surfaces NO_CREDS). With file-supplied client
+    // creds, the env staging token attaches as expected.
+    const config = {
+      oauth: { clientId: "cid", clientSecret: "csecret" },
+    };
     const { config: result } = applyEnvOverlay(config, {
       env: { QONTOCTL_STAGING_TOKEN: "tok_abc123" },
     });
     expect(result.oauth?.stagingToken).toBe("tok_abc123");
   });
 
-  it("creates oauth section when staging token env var is set but no oauth in config", () => {
+  it("does NOT create an oauth section when only staging-token env var is set (issue #479)", () => {
+    // A staging token alone is meaningless — the sandbox endpoint is
+    // OAuth-only. Attaching it to a synthesized oauth block with empty
+    // client creds would produce an unusable record and surface a
+    // misleading "missing client-id" downstream. Drop instead.
     const config = {};
     const { config: result } = applyEnvOverlay(config, {
       env: { QONTOCTL_STAGING_TOKEN: "tok_abc123" },
     });
-    expect(result.oauth).toBeDefined();
-    expect(result.oauth?.clientId).toBe("");
-    expect(result.oauth?.clientSecret).toBe("");
-    expect(result.oauth?.stagingToken).toBe("tok_abc123");
+    expect(result.oauth).toBeUndefined();
   });
 
-  it("overlays profile-scoped staging token env var into oauth section", () => {
+  it("staging-token env var attaches when file supplies client creds", () => {
+    const config = {
+      oauth: { clientId: "cid", clientSecret: "csecret" },
+    };
+    const { config: result } = applyEnvOverlay(config, {
+      env: { QONTOCTL_STAGING_TOKEN: "tok_abc123" },
+    });
+    expect(result.oauth?.stagingToken).toBe("tok_abc123");
+    expect(result.oauth?.clientId).toBe("cid");
+  });
+
+  it("staging-token env var attaches when env supplies client creds in same overlay", () => {
+    const config = {};
+    const { config: result } = applyEnvOverlay(config, {
+      env: {
+        QONTOCTL_CLIENT_ID: "cid",
+        QONTOCTL_CLIENT_SECRET: "csecret",
+        QONTOCTL_STAGING_TOKEN: "tok_abc123",
+      },
+    });
+    expect(result.oauth?.stagingToken).toBe("tok_abc123");
+    expect(result.oauth?.clientId).toBe("cid");
+  });
+
+  it("does NOT attach profile-scoped staging-token without client creds (issue #479)", () => {
     const config = {};
     const { config: result } = applyEnvOverlay(config, {
       profile: "staging",
       env: { QONTOCTL_STAGING_STAGING_TOKEN: "tok_staging" },
     });
-    expect(result.oauth?.stagingToken).toBe("tok_staging");
+    expect(result.oauth).toBeUndefined();
   });
 
   it("staging token env var overrides file staging token in oauth", () => {
@@ -232,16 +262,22 @@ describe("applyEnvOverlay", () => {
     expect(result.oauth?.stagingToken).toBe("tok_abc123");
   });
 
-  it("overlays QONTOCTL_ACCESS_TOKEN env var", () => {
+  it("does NOT synthesize oauth when only QONTOCTL_ACCESS_TOKEN is set (issue #479)", () => {
+    // Pre-#479: synthesized oauth { clientId: '', clientSecret: '',
+    // accessToken } which then surfaced "Missing required field
+    // 'client-id'" downstream — misleading: the user only wanted an
+    // access-token override. Post-#479: leave oauth undefined; downstream
+    // NO_CREDS surfaces accurately. The flag is still raised so a caller
+    // that DOES have file oauth identity can honor read-only semantics.
     const config = {};
     const { config: result, accessTokenFromEnv } = applyEnvOverlay(config, {
       env: { QONTOCTL_ACCESS_TOKEN: "at_env123" },
     });
-    expect(result.oauth?.accessToken).toBe("at_env123");
+    expect(result.oauth).toBeUndefined();
     expect(accessTokenFromEnv).toBe(true);
   });
 
-  it("access token env var overrides file access token", () => {
+  it("access-token env var overrides file access token when file supplies client creds", () => {
     const config = {
       oauth: { clientId: "cid", clientSecret: "csecret", accessToken: "file_at" },
     };
@@ -249,16 +285,31 @@ describe("applyEnvOverlay", () => {
       env: { QONTOCTL_ACCESS_TOKEN: "env_at" },
     });
     expect(result.oauth?.accessToken).toBe("env_at");
+    expect(result.oauth?.clientId).toBe("cid");
     expect(accessTokenFromEnv).toBe(true);
   });
 
-  it("overlays profile-scoped access token", () => {
+  it("access-token env var combines with env client creds in same overlay", () => {
+    const config = {};
+    const { config: result, accessTokenFromEnv } = applyEnvOverlay(config, {
+      env: {
+        QONTOCTL_CLIENT_ID: "cid",
+        QONTOCTL_CLIENT_SECRET: "csecret",
+        QONTOCTL_ACCESS_TOKEN: "env_at",
+      },
+    });
+    expect(result.oauth?.accessToken).toBe("env_at");
+    expect(result.oauth?.clientId).toBe("cid");
+    expect(accessTokenFromEnv).toBe(true);
+  });
+
+  it("does NOT synthesize oauth from profile-scoped access-token alone (issue #479)", () => {
     const config = {};
     const { config: result, accessTokenFromEnv } = applyEnvOverlay(config, {
       profile: "staging",
       env: { QONTOCTL_STAGING_ACCESS_TOKEN: "at_staging" },
     });
-    expect(result.oauth?.accessToken).toBe("at_staging");
+    expect(result.oauth).toBeUndefined();
     expect(accessTokenFromEnv).toBe(true);
   });
 

--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -123,16 +123,40 @@ export function applyEnvOverlay(
 
   if (clientId !== undefined || clientSecret !== undefined || accessToken !== undefined) {
     const existing = result.oauth;
+    const mergedClientId = clientId ?? existing?.clientId;
+    const mergedClientSecret = clientSecret ?? existing?.clientSecret;
     const mergedAccessToken = accessToken ?? existing?.accessToken;
-    result = {
-      ...result,
-      oauth: {
-        clientId: clientId ?? existing?.clientId ?? "",
-        clientSecret: clientSecret ?? existing?.clientSecret ?? "",
-        ...(mergedAccessToken !== undefined ? { accessToken: mergedAccessToken } : {}),
-        ...(existing?.stagingToken !== undefined ? { stagingToken: existing.stagingToken } : {}),
-      },
-    };
+
+    // Only synthesize/merge an oauth block when client credentials can be
+    // fully resolved from some combination of env + file. Without
+    // client-id + client-secret, an oauth block is unusable: the bearer
+    // cannot be refreshed, and downstream resolution would throw a
+    // misleading "missing client-id" error pointing at credentials the
+    // user never asked to set. The pre-#479 behavior synthesized an oauth
+    // object with empty-string client-id when env supplied only an
+    // access-token override — surfacing the wrong error class to the user
+    // who simply wanted to override the bearer for one invocation.
+    //
+    // When client credentials cannot be resolved (e.g., env-only
+    // QONTOCTL_ACCESS_TOKEN with no file `oauth` section), leave
+    // `result.oauth` as-is. The downstream NO_CREDS error then
+    // accurately reflects what the resolver actually saw.
+    if (
+      mergedClientId !== undefined &&
+      mergedClientId !== "" &&
+      mergedClientSecret !== undefined &&
+      mergedClientSecret !== ""
+    ) {
+      result = {
+        ...result,
+        oauth: {
+          clientId: mergedClientId,
+          clientSecret: mergedClientSecret,
+          ...(mergedAccessToken !== undefined ? { accessToken: mergedAccessToken } : {}),
+          ...(existing?.stagingToken !== undefined ? { stagingToken: existing.stagingToken } : {}),
+        },
+      };
+    }
   }
 
   if (endpoint !== undefined) {
@@ -141,15 +165,21 @@ export function applyEnvOverlay(
 
   if (stagingToken !== undefined) {
     const existingOAuth = result.oauth;
-    result = {
-      ...result,
-      oauth: {
-        clientId: existingOAuth?.clientId ?? "",
-        clientSecret: existingOAuth?.clientSecret ?? "",
-        ...(existingOAuth?.accessToken !== undefined ? { accessToken: existingOAuth.accessToken } : {}),
-        stagingToken,
-      },
-    };
+    // Mirror the partial-overlay-on-loaded-file rule: a staging token is
+    // only meaningful in the context of full OAuth credentials. Without
+    // resolvable client-id + client-secret, attaching a staging token
+    // would synthesize an unusable oauth block — surface NO_CREDS
+    // downstream instead. When client creds ARE available (file or env),
+    // attach the staging token onto the existing/synthesized oauth.
+    if (existingOAuth !== undefined && existingOAuth.clientId !== "" && existingOAuth.clientSecret !== "") {
+      result = {
+        ...result,
+        oauth: {
+          ...existingOAuth,
+          stagingToken,
+        },
+      };
+    }
   }
 
   if (scaMethod !== undefined) {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -9,12 +9,13 @@ export type {
   ResolveOptions,
   ScaConfig,
 } from "./types.js";
-export { resolveConfig, resolveScaMethod, ConfigError } from "./resolve.js";
-export { loadConfigFile } from "./loader.js";
-export type { LoadResult } from "./loader.js";
+export { resolveConfig, resolveConfigPath, resolveScaMethod, ConfigError } from "./resolve.js";
+export type { ConfigErrorCode } from "./resolve.js";
+export { loadConfigFile, resolveConfigFilePath } from "./loader.js";
+export type { LoadOptions, LoadResult } from "./loader.js";
 export { isValidProfileName, validateConfig } from "./validate.js";
 export type { ValidationResult } from "./validate.js";
 export { applyEnvOverlay } from "./env.js";
 export type { EnvOverlayConfig, EnvOverlayResult, StaticOAuthFields } from "./env.js";
 export { saveOAuthTokens, saveOAuthClientCredentials, clearOAuthTokens, saveOAuthScopes } from "./writer.js";
-export type { TokenUpdate } from "./writer.js";
+export type { TokenUpdate, WriteOptions } from "./writer.js";

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -6,7 +6,8 @@ import { mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { loadConfigFile } from "./loader.js";
+import { loadConfigFile, resolveConfigFilePath } from "./loader.js";
+import { ConfigError } from "./resolve.js";
 
 describe("loadConfigFile", () => {
   let baseDir: string;
@@ -25,47 +26,42 @@ describe("loadConfigFile", () => {
     await rm(baseDir, { recursive: true, force: true });
   });
 
-  it("returns undefined when no config file exists", async () => {
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+  it("returns undefined when home default does not exist and no other source is provided", async () => {
+    const result = await loadConfigFile({ home: testHome });
     expect(result.raw).toBeUndefined();
     expect(result.path).toBeUndefined();
   });
 
-  it("loads .qontoctl.yaml from CWD", async () => {
-    const configPath = join(testDir, ".qontoctl.yaml");
-    await writeFile(configPath, "api-key:\n  organization-slug: cwd-org\n  secret-key: cwd-secret\n");
+  it("loads explicit path when provided", async () => {
+    const explicitPath = join(testDir, "custom.yaml");
+    await writeFile(explicitPath, "api-key:\n  organization-slug: explicit-org\n  secret-key: x\n");
 
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
-    expect(result.path).toBe(configPath);
+    const result = await loadConfigFile({ path: explicitPath, home: testHome });
+    expect(result.path).toBe(explicitPath);
     expect(result.raw).toEqual({
-      "api-key": { "organization-slug": "cwd-org", "secret-key": "cwd-secret" },
+      "api-key": { "organization-slug": "explicit-org", "secret-key": "x" },
     });
   });
 
-  it("falls back to ~/.qontoctl.yaml when CWD has no config", async () => {
+  it("loads ~/.qontoctl.yaml as the home default", async () => {
     const homePath = join(testHome, ".qontoctl.yaml");
     await writeFile(homePath, "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n");
 
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    const result = await loadConfigFile({ home: testHome });
     expect(result.path).toBe(homePath);
     expect(result.raw).toEqual({
       "api-key": { "organization-slug": "home-org", "secret-key": "home-secret" },
     });
   });
 
-  it("prefers CWD config over home config", async () => {
-    await writeFile(
-      join(testDir, ".qontoctl.yaml"),
-      "api-key:\n  organization-slug: cwd-org\n  secret-key: cwd-secret\n",
-    );
-    await writeFile(
-      join(testHome, ".qontoctl.yaml"),
-      "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n",
-    );
+  it("loads from QONTOCTL_CONFIG_FILE env var when set", async () => {
+    const envPath = join(testDir, "env-config.yaml");
+    await writeFile(envPath, "api-key:\n  organization-slug: env-org\n  secret-key: x\n");
 
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    const result = await loadConfigFile({ env: { QONTOCTL_CONFIG_FILE: envPath }, home: testHome });
+    expect(result.path).toBe(envPath);
     expect(result.raw).toEqual({
-      "api-key": { "organization-slug": "cwd-org", "secret-key": "cwd-secret" },
+      "api-key": { "organization-slug": "env-org", "secret-key": "x" },
     });
   });
 
@@ -77,7 +73,6 @@ describe("loadConfigFile", () => {
 
     const result = await loadConfigFile({
       profile: "staging",
-      cwd: testDir,
       home: testHome,
     });
     expect(result.path).toBe(profilePath);
@@ -92,72 +87,109 @@ describe("loadConfigFile", () => {
   it("returns undefined when named profile file does not exist", async () => {
     const result = await loadConfigFile({
       profile: "nonexistent",
-      cwd: testDir,
       home: testHome,
     });
     expect(result.raw).toBeUndefined();
     expect(result.path).toBeUndefined();
   });
 
-  it("treats empty CWD file the same as missing file (raw undefined when no home file either)", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "");
-
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
-    // Both CWD and home are empty/missing → no-hit
+  it("does NOT inspect process.cwd at any stage", async () => {
+    // The loader must not fall through to process.cwd when the home default
+    // is empty. With only `home` (pointing at an empty dir) supplied, the
+    // result must be no-hit — even when running from the qontoctl repo root
+    // where a real `.qontoctl.yaml` sits in process.cwd. If the loader ever
+    // regresses to walking up from cwd, this assertion fails locally (where
+    // a real cwd config exists). In CI without a cwd config it passes
+    // vacuously; the resolve.test.ts companion is the stronger guard there.
+    const result = await loadConfigFile({ home: testHome });
     expect(result.raw).toBeUndefined();
     expect(result.path).toBeUndefined();
   });
 
-  it("treats comment-only CWD file the same as missing file", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "# only a comment\n# nothing else here\n");
+  it("throws ConfigError PARSE on malformed YAML", async () => {
+    const badPath = join(testHome, ".qontoctl.yaml");
+    await writeFile(badPath, ":\n  :\n  invalid: [unclosed");
 
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
+    await expect(loadConfigFile({ home: testHome })).rejects.toMatchObject({
+      name: "ConfigError",
+      code: "PARSE",
+    });
+  });
+
+  it("ConfigError PARSE includes the path in the message", async () => {
+    const badPath = join(testHome, ".qontoctl.yaml");
+    await writeFile(badPath, ":\n  :\n  invalid: [unclosed");
+
+    await expect(loadConfigFile({ home: testHome })).rejects.toThrow(badPath);
+  });
+
+  it("explicit path: nonexistent file returns no-hit (no error)", async () => {
+    const result = await loadConfigFile({ path: join(testDir, "missing.yaml"), home: testHome });
     expect(result.raw).toBeUndefined();
     expect(result.path).toBeUndefined();
   });
 
-  it("falls back to home when CWD .qontoctl.yaml is empty", async () => {
-    // Empty CWD file (parseYaml -> null) should not short-circuit; home wins.
-    await writeFile(join(testDir, ".qontoctl.yaml"), "");
-    const homePath = join(testHome, ".qontoctl.yaml");
-    await writeFile(homePath, "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n");
+  it("ConfigError thrown by loader survives the wrapping (instance-of check)", async () => {
+    const badPath = join(testHome, ".qontoctl.yaml");
+    // Unclosed flow sequence — yaml parser rejects this with a syntax error.
+    await writeFile(badPath, "api-key:\n  foo: [unclosed\n");
 
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
-    expect(result.path).toBe(homePath);
-    expect(result.raw).toEqual({
-      "api-key": { "organization-slug": "home-org", "secret-key": "home-secret" },
-    });
+    await expect(loadConfigFile({ home: testHome })).rejects.toBeInstanceOf(ConfigError);
+  });
+});
+
+describe("resolveConfigFilePath", () => {
+  // Use platform-native path separators so the assertions hold on
+  // Windows (`\`) and POSIX (`/`) alike — `node:path/join` returns
+  // platform-specific separators.
+  const HOME = join("home", "u");
+
+  it("returns explicit path", () => {
+    expect(resolveConfigFilePath({ path: "/abs/path.yaml" })).toBe("/abs/path.yaml");
   });
 
-  it("falls back to home when CWD .qontoctl.yaml is comment-only", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "# placeholder, not real config\n");
-    const homePath = join(testHome, ".qontoctl.yaml");
-    await writeFile(homePath, "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n");
-
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
-    expect(result.path).toBe(homePath);
-    expect(result.raw).toEqual({
-      "api-key": { "organization-slug": "home-org", "secret-key": "home-secret" },
-    });
+  it("returns env var value when no explicit path", () => {
+    expect(
+      resolveConfigFilePath({
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        home: HOME,
+      }),
+    ).toBe("/from-env.yaml");
   });
 
-  it("falls back to home when CWD .qontoctl.yaml has top-level oauth: null", async () => {
-    // YAML "oauth: null" parses to {oauth: null}, which IS a non-null value, so
-    // CWD short-circuits as expected. This complements the "raw === null" test
-    // and documents that null-parsing only fires at the document root level.
-    await writeFile(join(testDir, ".qontoctl.yaml"), "oauth: null\n");
-    const homePath = join(testHome, ".qontoctl.yaml");
-    await writeFile(homePath, "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n");
-
-    const result = await loadConfigFile({ cwd: testDir, home: testHome });
-    // CWD wins because raw is {oauth: null}, not null itself.
-    expect(result.path).toBe(join(testDir, ".qontoctl.yaml"));
-    expect(result.raw).toEqual({ oauth: null });
+  it("ignores empty-string env var (treats as unset)", () => {
+    expect(
+      resolveConfigFilePath({
+        env: { QONTOCTL_CONFIG_FILE: "" },
+        home: HOME,
+      }),
+    ).toBe(join(HOME, ".qontoctl.yaml"));
   });
 
-  it("throws on malformed YAML", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), ":\n  :\n  invalid: [unclosed");
+  it("returns profile-derived path when profile is set", () => {
+    expect(resolveConfigFilePath({ profile: "prod", home: HOME })).toBe(join(HOME, ".qontoctl", "prod.yaml"));
+  });
 
-    await expect(loadConfigFile({ cwd: testDir, home: testHome })).rejects.toThrow(/Failed to read config file/);
+  it("falls through to home default", () => {
+    expect(resolveConfigFilePath({ home: HOME })).toBe(join(HOME, ".qontoctl.yaml"));
+  });
+
+  it("explicit path beats env-var beats profile", () => {
+    expect(
+      resolveConfigFilePath({
+        path: "/from-arg.yaml",
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        profile: "prod",
+        home: HOME,
+      }),
+    ).toBe("/from-arg.yaml");
+
+    expect(
+      resolveConfigFilePath({
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        profile: "prod",
+        home: HOME,
+      }),
+    ).toBe("/from-env.yaml");
   });
 });

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -6,62 +6,100 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
 import { CONFIG_DIR } from "../constants.js";
+import { ConfigError } from "./resolve.js";
 
 const CONFIG_FILENAME = ".qontoctl.yaml";
+const CONFIG_FILE_ENV = "QONTOCTL_CONFIG_FILE";
 
 export interface LoadResult {
   /** Parsed YAML content, or `undefined` if no file was found. */
   raw: unknown;
-  /** Path of the file that was loaded, or `undefined` if none found. */
+  /** Absolute path of the file that was loaded, or `undefined` if none found. */
   path: string | undefined;
+}
+
+export interface LoadOptions {
+  /**
+   * Explicit path to load. Highest-priority resolution input; bypasses env
+   * and profile/home defaults entirely.
+   */
+  path?: string | undefined;
+  /** Named profile — derives `~/.qontoctl/{profile}.yaml`. */
+  profile?: string | undefined;
+  /** Override home directory for resolution (useful for testing). */
+  home?: string | undefined;
+  /** Override environment variables (useful for testing). */
+  env?: Record<string, string | undefined> | undefined;
 }
 
 /**
  * Resolves and loads the appropriate config file.
  *
- * - With `profile`: loads `~/.qontoctl/{profile}.yaml`
- * - Without `profile`: tries CWD `.qontoctl.yaml`, then `~/.qontoctl.yaml`
+ * Precedence (highest first):
+ *   1. `path` option — explicit path
+ *   2. `QONTOCTL_CONFIG_FILE` env var
+ *   3. `~/.qontoctl/{profile}.yaml` (when `profile` is set)
+ *   4. `~/.qontoctl.yaml` (home default)
+ *
+ * No CWD inspection. Local-config workflows must use `path`, the env var,
+ * or a direnv shim that exports the env var.
  */
-export async function loadConfigFile(options?: {
-  profile?: string | undefined;
-  cwd?: string | undefined;
-  home?: string | undefined;
-}): Promise<LoadResult> {
+export async function loadConfigFile(options?: LoadOptions): Promise<LoadResult> {
+  const path = resolveConfigFilePath(options);
+  return loadFromPath(path);
+}
+
+/**
+ * Resolves the absolute path that {@link loadConfigFile} would load from.
+ *
+ * Same precedence as {@link loadConfigFile}, but performs no I/O. Useful
+ * for writers that must round-trip the loader's path (preventing load/write
+ * divergence) and for first-time-write callers that need to know the
+ * destination before any file exists.
+ */
+export function resolveConfigFilePath(options?: LoadOptions): string {
+  if (options?.path !== undefined) {
+    return options.path;
+  }
+
+  const env = options?.env ?? (process.env as Record<string, string | undefined>);
+  const envPath = env[CONFIG_FILE_ENV];
+  if (envPath !== undefined && envPath !== "") {
+    return envPath;
+  }
+
   const home = options?.home ?? homedir();
-  const profile = options?.profile;
-
-  if (profile !== undefined) {
-    const path = join(home, CONFIG_DIR, `${profile}.yaml`);
-    return loadFromPath(path);
+  if (options?.profile !== undefined) {
+    return join(home, CONFIG_DIR, `${options.profile}.yaml`);
   }
 
-  const cwd = options?.cwd ?? process.cwd();
-
-  // Try CWD first. An empty file or a file with only comments parses to
-  // `null` — treat that the same as a missing file (no-hit) so we fall
-  // through to the home directory rather than short-circuiting on a
-  // semantically empty CWD config.
-  const cwdPath = join(cwd, CONFIG_FILENAME);
-  const cwdResult = await loadFromPath(cwdPath);
-  if (cwdResult.raw !== undefined && cwdResult.raw !== null) {
-    return cwdResult;
-  }
-
-  // Fall back to home directory
-  const homePath = join(home, CONFIG_FILENAME);
-  return loadFromPath(homePath);
+  return join(home, CONFIG_FILENAME);
 }
 
 async function loadFromPath(path: string): Promise<LoadResult> {
   try {
     const content = await readFile(path, "utf-8");
-    const raw: unknown = parseYaml(content);
+    let raw: unknown;
+    try {
+      raw = parseYaml(content);
+    } catch (parseError: unknown) {
+      const detail = parseError instanceof Error ? parseError.message : String(parseError);
+      throw new ConfigError(`Failed to parse YAML at "${path}": ${detail}`, "PARSE");
+    }
     return { raw, path };
   } catch (error: unknown) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return { raw: undefined, path: undefined };
+    if (error instanceof ConfigError) {
+      throw error;
     }
-    throw new Error(`Failed to read config file "${path}": ${String(error)}`);
+    if (isNodeError(error)) {
+      if (error.code === "ENOENT") {
+        return { raw: undefined, path: undefined };
+      }
+      if (error.code === "EACCES" || error.code === "EPERM") {
+        throw new ConfigError(`Permission denied reading config file "${path}".`, "PERMISSION");
+      }
+    }
+    throw new ConfigError(`Failed to read config file "${path}": ${String(error)}`, "PARSE");
   }
 }
 

--- a/packages/core/src/config/resolve.test.ts
+++ b/packages/core/src/config/resolve.test.ts
@@ -6,7 +6,7 @@ import { mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { resolveConfig, resolveScaMethod, ConfigError } from "./resolve.js";
+import { resolveConfig, resolveConfigPath, resolveScaMethod, ConfigError } from "./resolve.js";
 
 describe("resolveConfig", () => {
   let testDir: string;
@@ -25,14 +25,12 @@ describe("resolveConfig", () => {
     await rm(baseDir, { recursive: true, force: true });
   });
 
-  it("resolves config from CWD file", async () => {
-    await writeFile(
-      join(testDir, ".qontoctl.yaml"),
-      "api-key:\n  organization-slug: my-org\n  secret-key: my-secret\n",
-    );
+  it("resolves config from explicit path", async () => {
+    const cfgPath = join(testDir, ".qontoctl.yaml");
+    await writeFile(cfgPath, "api-key:\n  organization-slug: my-org\n  secret-key: my-secret\n");
 
     const result = await resolveConfig({
-      cwd: testDir,
+      path: cfgPath,
       home: testHome,
       env: {},
     });
@@ -41,16 +39,16 @@ describe("resolveConfig", () => {
       secretKey: "my-secret",
     });
     expect(result.warnings).toEqual([]);
+    expect(result.path).toBe(cfgPath);
   });
 
-  it("resolves config from home fallback", async () => {
+  it("resolves config from home default when no path or profile is given", async () => {
     await writeFile(
       join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -58,6 +56,7 @@ describe("resolveConfig", () => {
       organizationSlug: "home-org",
       secretKey: "home-secret",
     });
+    expect(result.path).toBe(join(testHome, ".qontoctl.yaml"));
   });
 
   it("resolves config from named profile", async () => {
@@ -70,7 +69,6 @@ describe("resolveConfig", () => {
 
     const result = await resolveConfig({
       profile: "staging",
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -78,16 +76,121 @@ describe("resolveConfig", () => {
       organizationSlug: "staging-org",
       secretKey: "staging-secret",
     });
+    expect(result.path).toBe(join(profileDir, "staging.yaml"));
+  });
+
+  describe("path precedence (issue #479)", () => {
+    it("explicit path beats QONTOCTL_CONFIG_FILE env var", async () => {
+      const explicitPath = join(testDir, ".qontoctl.yaml");
+      const envPath = join(testHome, "env-config.yaml");
+      await writeFile(explicitPath, "api-key:\n  organization-slug: explicit\n  secret-key: x\n");
+      await writeFile(envPath, "api-key:\n  organization-slug: from-env\n  secret-key: x\n");
+
+      const result = await resolveConfig({
+        path: explicitPath,
+        home: testHome,
+        env: { QONTOCTL_CONFIG_FILE: envPath },
+      });
+      expect(result.config.apiKey?.organizationSlug).toBe("explicit");
+      expect(result.path).toBe(explicitPath);
+    });
+
+    it("QONTOCTL_CONFIG_FILE beats profile-derived path", async () => {
+      const envPath = join(testDir, "env-config.yaml");
+      const profileDir = join(testHome, ".qontoctl");
+      await mkdir(profileDir);
+      await writeFile(envPath, "api-key:\n  organization-slug: from-env\n  secret-key: x\n");
+      await writeFile(join(profileDir, "prod.yaml"), "api-key:\n  organization-slug: from-profile\n  secret-key: x\n");
+
+      const result = await resolveConfig({
+        profile: "prod",
+        home: testHome,
+        env: { QONTOCTL_CONFIG_FILE: envPath },
+      });
+      expect(result.config.apiKey?.organizationSlug).toBe("from-env");
+      expect(result.path).toBe(envPath);
+    });
+
+    it("profile beats home default", async () => {
+      const profileDir = join(testHome, ".qontoctl");
+      await mkdir(profileDir);
+      await writeFile(join(profileDir, "prod.yaml"), "api-key:\n  organization-slug: from-profile\n  secret-key: x\n");
+      await writeFile(join(testHome, ".qontoctl.yaml"), "api-key:\n  organization-slug: from-home\n  secret-key: x\n");
+
+      const result = await resolveConfig({
+        profile: "prod",
+        home: testHome,
+        env: {},
+      });
+      expect(result.config.apiKey?.organizationSlug).toBe("from-profile");
+    });
+
+    it("does NOT inspect process.cwd at any stage (no CWD discovery)", async () => {
+      // Even when a .qontoctl.yaml exists in process.cwd, the resolver
+      // ignores it. Only path/env/profile/home defaults are honored.
+      // This is the load/write divergence elimination from #479.
+      const result = await resolveConfig({
+        home: testHome,
+        env: {
+          QONTOCTL_ORGANIZATION_SLUG: "from-env",
+          QONTOCTL_SECRET_KEY: "x",
+        },
+      });
+      expect(result.config.apiKey?.organizationSlug).toBe("from-env");
+      // path is undefined when no file was loaded
+      expect(result.path).toBeUndefined();
+    });
+  });
+
+  describe("profile name validation (issue #479)", () => {
+    it.each([
+      ["../etc/passwd", "path traversal"],
+      ["..", "parent directory reference"],
+      ["a/b", "path separator"],
+      ["a\\b", "windows path separator"],
+      ["star*glob", "glob char *"],
+      ["q?mark", "glob char ?"],
+      ["bracket[ed]", "glob char ["],
+      ["", "empty"],
+      ["endpoint", "reserved suffix ENDPOINT"],
+      ["client-id", "reserved suffix CLIENT_ID (with - normalized)"],
+      ["access_token", "reserved suffix ACCESS_TOKEN"],
+      ["config-file", "reserved suffix CONFIG_FILE"],
+      ["sca-method", "reserved suffix SCA_METHOD"],
+    ])('rejects "%s" (%s)', async (profile) => {
+      await expect(
+        resolveConfig({
+          profile,
+          home: testHome,
+          env: {},
+        }),
+      ).rejects.toMatchObject({
+        name: "ConfigError",
+        code: "VALIDATION",
+      });
+    });
+
+    it("accepts ordinary profile names", async () => {
+      const profileDir = join(testHome, ".qontoctl");
+      await mkdir(profileDir);
+      await writeFile(join(profileDir, "production-eu.yaml"), "api-key:\n  organization-slug: org\n  secret-key: x\n");
+
+      const result = await resolveConfig({
+        profile: "production-eu",
+        home: testHome,
+        env: {},
+      });
+      expect(result.config.apiKey?.organizationSlug).toBe("org");
+    });
   });
 
   it("env vars overlay onto file values", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: file-org\n  secret-key: file-secret\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: { QONTOCTL_SECRET_KEY: "env-secret" },
     });
@@ -99,7 +202,6 @@ describe("resolveConfig", () => {
 
   it("resolves credentials from env vars only", async () => {
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {
         QONTOCTL_ORGANIZATION_SLUG: "env-org",
@@ -112,42 +214,44 @@ describe("resolveConfig", () => {
     });
   });
 
-  it("throws ConfigError when no credentials found", async () => {
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(ConfigError);
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(/No credentials found/);
+  it("throws ConfigError NO_CREDS when no credentials found", async () => {
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(ConfigError);
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toMatchObject({
+      code: "NO_CREDS",
+    });
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(/No credentials found/);
   });
 
-  it("throws ConfigError on schema validation errors", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key: not-a-mapping\n");
+  it("throws ConfigError VALIDATION on schema validation errors", async () => {
+    await writeFile(join(testHome, ".qontoctl.yaml"), "api-key: not-a-mapping\n");
 
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(ConfigError);
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(/Invalid configuration/);
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toMatchObject({
+      code: "VALIDATION",
+    });
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(/Invalid configuration/);
   });
 
   it("throws ConfigError when organization-slug is missing", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key:\n  secret-key: my-secret\n");
+    await writeFile(join(testHome, ".qontoctl.yaml"), "api-key:\n  secret-key: my-secret\n");
 
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(
       /Missing required field "organization-slug"/,
     );
   });
 
   it("throws ConfigError when secret-key is missing", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "api-key:\n  organization-slug: my-org\n");
+    await writeFile(join(testHome, ".qontoctl.yaml"), "api-key:\n  organization-slug: my-org\n");
 
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
-      /Missing required field "secret-key"/,
-    );
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(/Missing required field "secret-key"/);
   });
 
   it("returns warnings for unknown keys", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: my-org\n  secret-key: my-secret\n  extra: value\nfuture-feature: true\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -166,7 +270,6 @@ describe("resolveConfig", () => {
 
     const result = await resolveConfig({
       profile: "prod",
-      cwd: testDir,
       home: testHome,
       env: { QONTOCTL_PROD_SECRET_KEY: "env-secret" },
     });
@@ -180,7 +283,6 @@ describe("resolveConfig", () => {
     await expect(
       resolveConfig({
         profile: "nonexistent",
-        cwd: testDir,
         home: testHome,
         env: {},
       }),
@@ -188,16 +290,16 @@ describe("resolveConfig", () => {
   });
 
   it("describes config path in error when file exists but has no api-key", async () => {
-    await writeFile(join(testDir, ".qontoctl.yaml"), "endpoint: https://example.com\n");
+    const cfgPath = join(testHome, ".qontoctl.yaml");
+    await writeFile(cfgPath, "endpoint: https://example.com\n");
 
-    await expect(resolveConfig({ cwd: testDir, home: testHome, env: {} })).rejects.toThrow(
-      /Found config at .* but it contains no api-key credentials/,
+    await expect(resolveConfig({ home: testHome, env: {} })).rejects.toThrow(
+      /Found config at .* but it contains no credentials/,
     );
   });
 
   it("defaults endpoint to production URL", async () => {
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {
         QONTOCTL_ORGANIZATION_SLUG: "org",
@@ -209,12 +311,11 @@ describe("resolveConfig", () => {
 
   it("resolves endpoint from config file", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: org\n  secret-key: secret\nendpoint: https://custom.example.com\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -223,12 +324,11 @@ describe("resolveConfig", () => {
 
   it("resolves staging endpoint when staging-token is configured in oauth", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "oauth:\n  client-id: cid\n  client-secret: csecret\n  staging-token: tok_abc123\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -237,12 +337,11 @@ describe("resolveConfig", () => {
 
   it("explicit endpoint takes precedence over staging-token in oauth", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "oauth:\n  client-id: cid\n  client-secret: csecret\n  staging-token: tok_abc123\nendpoint: https://custom.example.com\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -251,12 +350,11 @@ describe("resolveConfig", () => {
 
   it("QONTOCTL_ENDPOINT env var takes precedence over staging-token in oauth", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "oauth:\n  client-id: cid\n  client-secret: csecret\n  staging-token: tok_abc123\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: { QONTOCTL_ENDPOINT: "https://env.example.com" },
     });
@@ -265,7 +363,6 @@ describe("resolveConfig", () => {
 
   it("QONTOCTL_STAGING_TOKEN env var resolves to staging endpoint", async () => {
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {
         QONTOCTL_CLIENT_ID: "cid",
@@ -278,7 +375,6 @@ describe("resolveConfig", () => {
 
   it("QONTOCTL_ENDPOINT takes precedence over QONTOCTL_STAGING_TOKEN", async () => {
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {
         QONTOCTL_CLIENT_ID: "cid",
@@ -292,12 +388,11 @@ describe("resolveConfig", () => {
 
   it("loads sca.method from config file", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: org\n  secret-key: secret\nsca:\n  method: passkey\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: {},
     });
@@ -306,12 +401,11 @@ describe("resolveConfig", () => {
 
   it("QONTOCTL_SCA_METHOD env var overlays sca.method", async () => {
     await writeFile(
-      join(testDir, ".qontoctl.yaml"),
+      join(testHome, ".qontoctl.yaml"),
       "api-key:\n  organization-slug: org\n  secret-key: secret\nsca:\n  method: passkey\n",
     );
 
     const result = await resolveConfig({
-      cwd: testDir,
       home: testHome,
       env: { QONTOCTL_SCA_METHOD: "sms-otp" },
     });
@@ -321,18 +415,17 @@ describe("resolveConfig", () => {
   describe("oauthAccessTokenFromEnv flag (issue #495)", () => {
     it("is false when no env access-token is set", async () => {
       await writeFile(
-        join(testDir, ".qontoctl.yaml"),
+        join(testHome, ".qontoctl.yaml"),
         "oauth:\n  client-id: cid\n  client-secret: csecret\n  access-token: file-at\n  refresh-token: file-rt\n",
       );
 
-      const result = await resolveConfig({ cwd: testDir, home: testHome, env: {} });
+      const result = await resolveConfig({ home: testHome, env: {} });
       expect(result.oauthAccessTokenFromEnv).toBe(false);
       expect(result.config.oauth?.accessToken).toBe("file-at");
     });
 
     it("is true when QONTOCTL_ACCESS_TOKEN is set in env", async () => {
       const result = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: {
           QONTOCTL_CLIENT_ID: "cid",
@@ -346,12 +439,11 @@ describe("resolveConfig", () => {
 
     it("is true and overrides file access-token when env has QONTOCTL_ACCESS_TOKEN", async () => {
       await writeFile(
-        join(testDir, ".qontoctl.yaml"),
+        join(testHome, ".qontoctl.yaml"),
         "oauth:\n  client-id: cid\n  client-secret: csecret\n  access-token: file-at\n  refresh-token: file-rt\n",
       );
 
       const result = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: { QONTOCTL_ACCESS_TOKEN: "env-at" },
       });
@@ -361,12 +453,26 @@ describe("resolveConfig", () => {
       // the source of truth for runtime-mutable fields)
       expect(result.config.oauth?.refreshToken).toBe("file-rt");
     });
+
+    it("env-only QONTOCTL_ACCESS_TOKEN without file or client creds surfaces NO_CREDS, not 'missing client-id' (issue #479)", async () => {
+      // Pre-#479: env access-token alone synthesized an oauth block with
+      // empty client-id, then resolve.ts threw "Missing required field
+      // 'client-id'" — misleading: the user never asked to set client-id.
+      // Post-#479: env access-token alone is insufficient (client creds
+      // cannot be resolved from any source) — NO_CREDS surfaces accurately.
+      await expect(
+        resolveConfig({
+          home: testHome,
+          env: { QONTOCTL_ACCESS_TOKEN: "env-at" },
+        }),
+      ).rejects.toMatchObject({ code: "NO_CREDS" });
+    });
   });
 
   describe("runtime-mutable OAuth fields preserved through env-overlay (issue #495)", () => {
     it("preserves refreshToken from file even when env supplies static OAuth fields", async () => {
       await writeFile(
-        join(testDir, ".qontoctl.yaml"),
+        join(testHome, ".qontoctl.yaml"),
         "oauth:\n" +
           "  client-id: file-cid\n" +
           "  client-secret: file-csecret\n" +
@@ -377,7 +483,6 @@ describe("resolveConfig", () => {
       );
 
       const result = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: {
           QONTOCTL_CLIENT_ID: "env-cid",
@@ -396,12 +501,11 @@ describe("resolveConfig", () => {
 
     it("ignores QONTOCTL_REFRESH_TOKEN env var entirely (issue #495)", async () => {
       await writeFile(
-        join(testDir, ".qontoctl.yaml"),
+        join(testHome, ".qontoctl.yaml"),
         "oauth:\n  client-id: cid\n  client-secret: csecret\n  refresh-token: file-rt\n",
       );
 
       const result = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: { QONTOCTL_REFRESH_TOKEN: "env-rt-should-be-ignored" },
       });
@@ -412,7 +516,6 @@ describe("resolveConfig", () => {
 
     it("does not surface a refreshToken when only QONTOCTL_REFRESH_TOKEN is set in env (no file)", async () => {
       const result = await resolveConfig({
-        cwd: testDir,
         home: testHome,
         env: {
           QONTOCTL_CLIENT_ID: "cid",
@@ -428,34 +531,71 @@ describe("resolveConfig", () => {
     });
   });
 
-  describe("loader hygiene: empty/comment-only CWD falls back to home (issue #495)", () => {
-    it("falls back to home when CWD .qontoctl.yaml is empty", async () => {
-      await writeFile(join(testDir, ".qontoctl.yaml"), "");
-      await writeFile(
-        join(testHome, ".qontoctl.yaml"),
-        "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n",
-      );
+  // Windows does not implement Unix file-permission bits the way POSIX
+  // does — `writeFile(..., { mode })` is best-effort and stat reports a
+  // synthesized 0o666/0o444 based on the read-only flag. Skip on Windows
+  // so the warning behavior stays exercised on Linux + macOS where the
+  // mask actually means something. The CI matrix (#477) includes a
+  // POSIX leg, so coverage is preserved.
+  describe.skipIf(process.platform === "win32")("permission warning (issue #479)", () => {
+    it("warns on group/world-readable file containing OAuth client-secret", async () => {
+      const cfgPath = join(testHome, ".qontoctl.yaml");
+      await writeFile(cfgPath, "oauth:\n  client-id: cid\n  client-secret: csec\n", { mode: 0o644 });
 
-      const result = await resolveConfig({ cwd: testDir, home: testHome, env: {} });
-      expect(result.config.apiKey).toEqual({
-        organizationSlug: "home-org",
-        secretKey: "home-secret",
-      });
+      const result = await resolveConfig({ home: testHome, env: {} });
+      expect(result.warnings.some((w) => /permissions 644/.test(w))).toBe(true);
     });
 
-    it("falls back to home when CWD .qontoctl.yaml is comment-only", async () => {
-      await writeFile(join(testDir, ".qontoctl.yaml"), "# only a comment\n");
-      await writeFile(
-        join(testHome, ".qontoctl.yaml"),
-        "api-key:\n  organization-slug: home-org\n  secret-key: home-secret\n",
-      );
+    it("does NOT warn on 0o600 file", async () => {
+      const cfgPath = join(testHome, ".qontoctl.yaml");
+      await writeFile(cfgPath, "oauth:\n  client-id: cid\n  client-secret: csec\n", { mode: 0o600 });
 
-      const result = await resolveConfig({ cwd: testDir, home: testHome, env: {} });
-      expect(result.config.apiKey).toEqual({
-        organizationSlug: "home-org",
-        secretKey: "home-secret",
-      });
+      const result = await resolveConfig({ home: testHome, env: {} });
+      expect(result.warnings.every((w) => !/permissions/.test(w))).toBe(true);
     });
+
+    it("does NOT warn on 0o644 file containing only api-key (no OAuth bearer)", async () => {
+      const cfgPath = join(testHome, ".qontoctl.yaml");
+      await writeFile(cfgPath, "api-key:\n  organization-slug: org\n  secret-key: x\n", { mode: 0o644 });
+
+      const result = await resolveConfig({ home: testHome, env: {} });
+      // Warning is only emitted when the loaded config contains OAuth
+      // credentials. api-key files are out of scope for this warning by
+      // design (the secret-key risk is conveyed via other channels).
+      expect(result.warnings.every((w) => !/permissions/.test(w))).toBe(true);
+    });
+  });
+});
+
+describe("resolveConfigPath", () => {
+  // Use platform-native path separators so the assertions hold on
+  // Windows (`\`) and POSIX (`/`) alike.
+  const HOME = join("home", "u");
+
+  it("returns explicit path when provided", () => {
+    expect(resolveConfigPath({ path: "/tmp/cfg.yaml" })).toBe("/tmp/cfg.yaml");
+  });
+
+  it("returns env-var value when set and no explicit path", () => {
+    expect(resolveConfigPath({ env: { QONTOCTL_CONFIG_FILE: "/etc/qonto.yaml" }, home: HOME })).toBe("/etc/qonto.yaml");
+  });
+
+  it("returns profile-derived path when profile is set", () => {
+    expect(resolveConfigPath({ profile: "staging", home: HOME })).toBe(join(HOME, ".qontoctl", "staging.yaml"));
+  });
+
+  it("returns home default when nothing else is set", () => {
+    expect(resolveConfigPath({ home: HOME })).toBe(join(HOME, ".qontoctl.yaml"));
+  });
+
+  it("explicit path beats env-var", () => {
+    expect(
+      resolveConfigPath({
+        path: "/from-arg.yaml",
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        home: HOME,
+      }),
+    ).toBe("/from-arg.yaml");
   });
 });
 

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -2,10 +2,11 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { ConfigResult, OAuthCredentials, QontoctlConfig, ResolveOptions } from "./types.js";
-import { loadConfigFile } from "./loader.js";
-import { validateConfig } from "./validate.js";
+import { loadConfigFile, resolveConfigFilePath } from "./loader.js";
+import { isValidProfileName, validateConfig } from "./validate.js";
 import { applyEnvOverlay, type EnvOverlayConfig } from "./env.js";
 import { API_BASE_URL, SANDBOX_BASE_URL } from "../constants.js";
+import { stat } from "node:fs/promises";
 
 /**
  * Sandbox-only SCA method that triggers a mock SCA challenge instead of
@@ -15,90 +16,151 @@ import { API_BASE_URL, SANDBOX_BASE_URL } from "../constants.js";
  */
 const SANDBOX_DEFAULT_SCA_METHOD = "mock";
 
+/**
+ * Discriminator for {@link ConfigError}, allowing callers (CLI/MCP error
+ * handlers) to switch on cause without parsing message strings.
+ *
+ * - `NO_CREDS` — no credentials found in any source (file, env, profile).
+ * - `PARSE` — YAML parse failure.
+ * - `VALIDATION` — schema validation failure or invalid profile name.
+ * - `PERMISSION` — file system permission denied (EACCES/EPERM) on read or write.
+ * - `CONFLICT` — concurrent write contention (lock could not be acquired
+ *   within the configured retry window).
+ */
+export type ConfigErrorCode = "NO_CREDS" | "PARSE" | "VALIDATION" | "PERMISSION" | "CONFLICT";
+
 export class ConfigError extends Error {
-  constructor(message: string) {
+  readonly code: ConfigErrorCode;
+
+  constructor(message: string, code: ConfigErrorCode) {
     super(message);
     this.name = "ConfigError";
+    this.code = code;
   }
 }
 
 /**
+ * File mode bits to check when warning about insecure permissions on a
+ * config file containing OAuth client-secret or access-token. We warn when
+ * group or world has any read access — the file should be 0o600 (or stricter)
+ * for OAuth credentials.
+ */
+const INSECURE_PERMS_MASK = 0o077;
+
+/**
  * Resolves the full configuration by:
- * 1. Loading the appropriate YAML config file (profile-aware)
- * 2. Validating the schema (producing warnings for unknown keys)
- * 3. Overlaying environment variables (static fields only)
- * 4. Re-attaching runtime-mutable file fields (refreshToken,
+ * 1. Validating the profile name (if any).
+ * 2. Loading the appropriate YAML config file (explicit path > env > profile > home).
+ * 3. Validating the schema (producing warnings for unknown keys).
+ * 4. Overlaying environment variables (static fields only).
+ * 5. Re-attaching runtime-mutable file fields (refreshToken,
  *    accessTokenExpiresAt, scopes) that env-overlay deliberately does not
  *    cover — see {@link applyEnvOverlay}.
- * 5. Verifying that credentials are present
- * 6. Resolving the API endpoint
+ * 6. Verifying that credentials are present.
+ * 7. Resolving the API endpoint.
+ * 8. Emitting a stderr warning if the loaded file has insecure permissions
+ *    on OAuth-bearing content.
  *
  * Endpoint precedence:
  *   QONTOCTL_ENDPOINT > staging-token presence > profile endpoint > default
  *
- * @throws {ConfigError} on validation errors or missing credentials
+ * @throws {ConfigError} on validation errors or missing credentials. Always
+ *   includes a {@link ConfigErrorCode} discriminator.
  */
 export async function resolveConfig(options?: ResolveOptions): Promise<ConfigResult> {
   const profile = options?.profile;
 
-  // 1. Load config file
+  // 1. Validate profile name (if any) before any I/O.
+  if (profile !== undefined && !isValidProfileName(profile)) {
+    throw new ConfigError(
+      `Invalid profile name "${profile}". Profile names must not contain path separators, parent-directory references, glob characters, or shadow reserved env-var suffixes.`,
+      "VALIDATION",
+    );
+  }
+
+  // 2. Load config file via deterministic precedence.
   const { raw, path } = await loadConfigFile({
+    path: options?.path,
     profile,
-    cwd: options?.cwd,
     home: options?.home,
+    env: options?.env,
   });
 
-  // 2. Validate
+  // 3. Validate schema.
   const { config: fileConfig, warnings, errors } = validateConfig(raw);
 
   if (errors.length > 0) {
     const location = path !== undefined ? ` (${path})` : "";
-    throw new ConfigError(`Invalid configuration${location}:\n  - ${errors.join("\n  - ")}`);
+    throw new ConfigError(`Invalid configuration${location}:\n  - ${errors.join("\n  - ")}`, "VALIDATION");
   }
 
-  // 3. Overlay env vars (static fields only — env never carries
-  //    refreshToken/accessTokenExpiresAt/scopes)
+  // 4. Overlay env vars (static fields only — env never carries
+  //    refreshToken/accessTokenExpiresAt/scopes).
   const fileStatic = pickStaticFields(fileConfig);
   const { config: overlaidStatic, accessTokenFromEnv } = applyEnvOverlay(fileStatic, {
     profile,
     env: options?.env,
   });
 
-  // 4. Re-attach runtime-mutable file fields (refreshToken,
+  // 5. Re-attach runtime-mutable file fields (refreshToken,
   //    accessTokenExpiresAt, scopes) — env never overrides these, but the
   //    file copy must be preserved through the env-overlay pipeline.
   const config = mergeRuntimeFields(overlaidStatic, fileConfig);
 
-  // 5. Verify credentials are present (at least one auth method)
+  // 6. Verify credentials are present (at least one auth method).
   if (config.apiKey === undefined && config.oauth === undefined) {
-    const searchedLocations = describeSearchLocations(profile, path);
-    throw new ConfigError(`No credentials found. ${searchedLocations}`);
+    const searchedLocations = describeSearchLocations(profile, path, options?.path, options?.env);
+    throw new ConfigError(`No credentials found. ${searchedLocations}`, "NO_CREDS");
   }
 
   if (config.apiKey !== undefined) {
     if (config.apiKey.organizationSlug === "") {
-      throw new ConfigError('Missing required field "organization-slug" in api-key credentials');
+      throw new ConfigError('Missing required field "organization-slug" in api-key credentials', "VALIDATION");
     }
 
     if (config.apiKey.secretKey === "") {
-      throw new ConfigError('Missing required field "secret-key" in api-key credentials');
+      throw new ConfigError('Missing required field "secret-key" in api-key credentials', "VALIDATION");
     }
   }
 
   if (config.oauth !== undefined) {
     if (config.oauth.clientId === "") {
-      throw new ConfigError('Missing required field "client-id" in oauth credentials');
+      throw new ConfigError('Missing required field "client-id" in oauth credentials', "VALIDATION");
     }
 
     if (config.oauth.clientSecret === "") {
-      throw new ConfigError('Missing required field "client-secret" in oauth credentials');
+      throw new ConfigError('Missing required field "client-secret" in oauth credentials', "VALIDATION");
     }
   }
 
-  // 6. Resolve endpoint
+  // 7. Resolve endpoint.
   const endpoint = resolveEndpoint(config);
 
-  return { config, endpoint, warnings, oauthAccessTokenFromEnv: accessTokenFromEnv };
+  // 8. Permission warning for OAuth-bearing files (best-effort, non-fatal).
+  if (path !== undefined && config.oauth !== undefined) {
+    await maybeWarnInsecurePermissions(path, warnings);
+  }
+
+  return { config, endpoint, warnings, path, oauthAccessTokenFromEnv: accessTokenFromEnv };
+}
+
+/**
+ * Resolves the absolute path that {@link resolveConfig} would load from,
+ * without performing any I/O on file content. Useful for callers that need
+ * to know the destination of a write before calling a writer entrypoint
+ * (e.g., `auth login` choosing where to persist new tokens when no file
+ * yet exists).
+ *
+ * Precedence mirrors {@link resolveConfig}:
+ *   path > QONTOCTL_CONFIG_FILE > profile-derived > home default
+ */
+export function resolveConfigPath(options?: ResolveOptions): string {
+  return resolveConfigFilePath({
+    path: options?.path,
+    profile: options?.profile,
+    home: options?.home,
+    env: options?.env,
+  });
 }
 
 /**
@@ -208,12 +270,48 @@ export function resolveScaMethod(config: QontoctlConfig, override?: string): str
   return undefined;
 }
 
-function describeSearchLocations(profile: string | undefined, loadedPath: string | undefined): string {
+/**
+ * Best-effort permission check on the loaded config file. Emits a stderr
+ * warning (and appends to the warnings array) when an OAuth-bearing file is
+ * group- or world-readable. Skipped silently on stat failure — permission
+ * hygiene is advisory, not a gate.
+ */
+async function maybeWarnInsecurePermissions(path: string, warnings: string[]): Promise<void> {
+  try {
+    const info = await stat(path);
+    // `mode` is 0o100755-style; mask off file-type bits.
+    const perms = info.mode & 0o777;
+    if ((perms & INSECURE_PERMS_MASK) !== 0) {
+      const message = `Config file ${path} contains OAuth credentials but has permissions ${perms.toString(8).padStart(3, "0")} (group/world readable). Tighten with: chmod 600 ${path}`;
+      warnings.push(message);
+      // Best-effort stderr emit; not all callers print warnings, so surface
+      // immediately for the security-relevant case.
+      process.stderr.write(`warning: ${message}\n`);
+    }
+  } catch {
+    // stat failed (e.g., race on file deletion); silently skip — permission
+    // checks are not a load gate.
+  }
+}
+
+function describeSearchLocations(
+  profile: string | undefined,
+  loadedPath: string | undefined,
+  explicitPath: string | undefined,
+  env: Record<string, string | undefined> | undefined,
+): string {
+  if (explicitPath !== undefined) {
+    return `Explicit path "${explicitPath}" was loaded but contains no credentials.`;
+  }
   if (profile !== undefined) {
     return `Checked ~/.qontoctl/${profile}.yaml and QONTOCTL_${profile.toUpperCase().replaceAll("-", "_")}_* env vars.`;
   }
-  if (loadedPath !== undefined) {
-    return `Found config at ${loadedPath} but it contains no api-key credentials. Also checked QONTOCTL_* env vars.`;
+  const envFile = (env ?? (process.env as Record<string, string | undefined>))["QONTOCTL_CONFIG_FILE"];
+  if (envFile !== undefined) {
+    return `Checked QONTOCTL_CONFIG_FILE="${envFile}" and QONTOCTL_* env vars.`;
   }
-  return "Checked .qontoctl.yaml (CWD), ~/.qontoctl.yaml (home), and QONTOCTL_* env vars.";
+  if (loadedPath !== undefined) {
+    return `Found config at ${loadedPath} but it contains no credentials. Also checked QONTOCTL_* env vars.`;
+  }
+  return "Checked ~/.qontoctl.yaml (home), QONTOCTL_CONFIG_FILE env var, and QONTOCTL_* env vars. Use --config <path>, set QONTOCTL_CONFIG_FILE, or pass --profile <name>.";
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -57,6 +57,17 @@ export interface ConfigResult {
   endpoint: string;
   warnings: string[];
   /**
+   * Absolute path of the config file that was loaded, or `undefined` when no
+   * file was found (env-only or no-config invocations).
+   *
+   * Callers performing follow-on writes (`saveOAuthTokens`, etc.) MUST round-
+   * trip this value via the writer's `path` option to guarantee load/write
+   * consistency — i.e. the writer cannot silently land on a different file
+   * than the loader read from. See #479 for the load/write divergence class
+   * this field eliminates.
+   */
+  path: string | undefined;
+  /**
    * `true` when `config.oauth.accessToken` came from `QONTOCTL_ACCESS_TOKEN`
    * (or its profile-scoped variant) — i.e. the env-supplied bearer overrode
    * any file value.
@@ -72,12 +83,28 @@ export interface ConfigResult {
 
 /**
  * Options for resolving configuration.
+ *
+ * Path resolution precedence (highest first):
+ *   1. `path` — explicit absolute or relative path
+ *   2. `QONTOCTL_CONFIG_FILE` env var
+ *   3. `profile` — derives `~/.qontoctl/{profile}.yaml`
+ *   4. `~/.qontoctl.yaml` (home default)
+ *
+ * No CWD inspection is performed at any stage. Local-config workflows must
+ * use `path`, the env var, or a direnv shim that exports the env var.
  */
 export interface ResolveOptions {
+  /**
+   * Explicit path to a config file. Highest-priority resolution input;
+   * overrides {@link profile} and the `QONTOCTL_CONFIG_FILE` env var.
+   *
+   * Mutually exclusive in spirit with {@link profile}: when both are passed
+   * and disagree, `path` wins (callers that want profile-derived paths
+   * should pass `profile` only).
+   */
+  path?: string | undefined;
   /** Named profile to load from `~/.qontoctl/{profile}.yaml`. */
   profile?: string | undefined;
-  /** Override CWD for file resolution (useful for testing). */
-  cwd?: string | undefined;
   /** Override home directory for file resolution (useful for testing). */
   home?: string | undefined;
   /** Override environment variables (useful for testing). */

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -333,6 +333,11 @@ describe("isValidProfileName", () => {
     expect(isValidProfileName("default")).toBe(true);
     expect(isValidProfileName("my-profile")).toBe(true);
     expect(isValidProfileName("profile_123")).toBe(true);
+    expect(isValidProfileName("production-eu")).toBe(true);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidProfileName("")).toBe(false);
   });
 
   it("rejects names with forward slashes", () => {
@@ -350,5 +355,36 @@ describe("isValidProfileName", () => {
 
   it("accepts names with single dots", () => {
     expect(isValidProfileName("my.profile")).toBe(true);
+  });
+
+  it("rejects glob characters (issue #479)", () => {
+    expect(isValidProfileName("star*")).toBe(false);
+    expect(isValidProfileName("question?")).toBe(false);
+    expect(isValidProfileName("bracket[")).toBe(false);
+    expect(isValidProfileName("bracket]")).toBe(false);
+  });
+
+  it("rejects names that shadow reserved env-var suffixes (issue #479)", () => {
+    expect(isValidProfileName("endpoint")).toBe(false);
+    expect(isValidProfileName("ENDPOINT")).toBe(false);
+    expect(isValidProfileName("client-id")).toBe(false);
+    expect(isValidProfileName("client-secret")).toBe(false);
+    expect(isValidProfileName("access-token")).toBe(false);
+    expect(isValidProfileName("refresh-token")).toBe(false);
+    expect(isValidProfileName("scopes")).toBe(false);
+    expect(isValidProfileName("staging-token")).toBe(false);
+    expect(isValidProfileName("organization-slug")).toBe(false);
+    expect(isValidProfileName("secret-key")).toBe(false);
+    expect(isValidProfileName("sca-method")).toBe(false);
+    expect(isValidProfileName("config-file")).toBe(false);
+    // Underscore form too (the post-normalization shape)
+    expect(isValidProfileName("client_id")).toBe(false);
+    expect(isValidProfileName("CONFIG_FILE")).toBe(false);
+  });
+
+  it("accepts names that contain reserved suffixes as substrings", () => {
+    // Reserved match is exact (post-normalization), not substring match.
+    expect(isValidProfileName("my-endpoint-prod")).toBe(true);
+    expect(isValidProfileName("client-id-team")).toBe(true);
   });
 });

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -4,13 +4,52 @@
 import type { QontoctlConfig } from "./types.js";
 
 /**
- * Check whether a profile name is safe to use as a filename.
+ * Profile names that would shadow no-profile env-var suffixes.
  *
- * Rejects names containing path separators (`/`, `\`) or parent-directory
- * references (`..`) to prevent path-traversal attacks.
+ * Env vars are derived by `QONTOCTL_<PROFILE_UPPERCASE>_<SUFFIX>`. A profile
+ * named `endpoint` would generate `QONTOCTL_ENDPOINT_*` patterns that collide
+ * with the no-profile `QONTOCTL_ENDPOINT` variable, producing an ambiguous
+ * resolution rule. Profiles matching any reserved suffix (case-insensitive,
+ * after `-` → `_` normalization) are rejected at resolution time.
+ *
+ * `REFRESH_TOKEN` is included even though `QONTOCTL_REFRESH_TOKEN` is not
+ * read at runtime (per #495) — it remains a reserved suffix to prevent
+ * future re-introduction from accidentally re-shadowing.
+ */
+const RESERVED_PROFILE_SUFFIXES = new Set([
+  "ORGANIZATION_SLUG",
+  "SECRET_KEY",
+  "ENDPOINT",
+  "CLIENT_ID",
+  "CLIENT_SECRET",
+  "ACCESS_TOKEN",
+  "REFRESH_TOKEN",
+  "SCOPES",
+  "STAGING_TOKEN",
+  "SCA_METHOD",
+  "CONFIG_FILE",
+]);
+
+/**
+ * Check whether a profile name is safe to use as a filename and as an
+ * env-var suffix.
+ *
+ * Rejects:
+ *   - Path separators (`/`, `\`) and parent-directory references (`..`) —
+ *     prevents path-traversal attacks via `--profile ../foo`.
+ *   - Glob characters (`*`, `?`, `[`, `]`) — these would silently pass
+ *     through to filesystem APIs and surprise users expecting glob expansion.
+ *   - Empty strings.
+ *   - Reserved env-var suffixes — see {@link RESERVED_PROFILE_SUFFIXES}.
  */
 export function isValidProfileName(name: string): boolean {
-  return !/[/\\]/.test(name) && !name.includes("..");
+  if (name === "") return false;
+  if (/[/\\]/.test(name)) return false;
+  if (name.includes("..")) return false;
+  if (/[*?[\]]/.test(name)) return false;
+  const normalized = name.toUpperCase().replaceAll("-", "_");
+  if (RESERVED_PROFILE_SUFFIXES.has(normalized)) return false;
+  return true;
 }
 
 const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key", "oauth", "endpoint", "sca"]);

--- a/packages/core/src/config/writer.test.ts
+++ b/packages/core/src/config/writer.test.ts
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { mkdtemp, readFile, writeFile, rm, mkdir } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile, rm, mkdir, stat, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { parse as parseYaml } from "yaml";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { saveOAuthTokens, saveOAuthClientCredentials, clearOAuthTokens, saveOAuthScopes } from "./writer.js";
+import { ConfigError } from "./resolve.js";
 
 describe("saveOAuthTokens", () => {
   let tempDir: string;
@@ -26,7 +27,7 @@ describe("saveOAuthTokens", () => {
         refreshToken: "refresh-456",
         accessTokenExpiresAt: "2026-02-28T16:00:00Z",
       },
-      { home: tempDir, cwd: tempDir },
+      { home: tempDir },
     );
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
@@ -46,7 +47,7 @@ describe("saveOAuthTokens", () => {
         accessToken: "access-123",
         accessTokenExpiresAt: "2026-02-28T16:00:00Z",
       },
-      { home: tempDir, cwd: tempDir },
+      { home: tempDir },
     );
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
@@ -65,7 +66,7 @@ describe("saveOAuthTokens", () => {
         accessToken: "access-123",
         accessTokenExpiresAt: "2026-02-28T16:00:00Z",
       },
-      { home: tempDir, cwd: tempDir },
+      { home: tempDir },
     );
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
@@ -99,7 +100,7 @@ describe("saveOAuthTokens", () => {
         accessToken: "access-123",
         accessTokenExpiresAt: "2026-02-28T16:00:00Z",
       },
-      { home: tempDir, cwd: tempDir },
+      { home: tempDir },
     );
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
@@ -107,45 +108,97 @@ describe("saveOAuthTokens", () => {
     const oauth = doc["oauth"] as Record<string, unknown>;
     expect(oauth["refresh-token"]).toBeUndefined();
   });
+
+  it("writes to explicit path option (issue #479)", async () => {
+    const explicitPath = join(tempDir, "custom.yaml");
+    await saveOAuthTokens(
+      {
+        accessToken: "access-via-path",
+        accessTokenExpiresAt: "2026-12-31T23:59:59Z",
+      },
+      { path: explicitPath },
+    );
+
+    const content = await readFile(explicitPath, "utf-8");
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect((doc["oauth"] as Record<string, unknown>)["access-token"]).toBe("access-via-path");
+    // The home default file MUST NOT be created when path is explicit
+    await expect(readFile(join(tempDir, ".qontoctl.yaml"), "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("explicit path beats profile (issue #479)", async () => {
+    const explicitPath = join(tempDir, "custom.yaml");
+    await saveOAuthTokens(
+      {
+        accessToken: "via-path",
+        accessTokenExpiresAt: "2026-12-31T23:59:59Z",
+      },
+      { path: explicitPath, profile: "acme", home: tempDir },
+    );
+
+    expect(await readFile(explicitPath, "utf-8")).toMatch(/access-token: via-path/);
+    // Profile-derived path MUST NOT have been created.
+    await expect(readFile(join(tempDir, ".qontoctl", "acme.yaml"), "utf-8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.skipIf(process.platform === "win32")("creates file with 0o600 permissions", async () => {
+    // Windows reports synthesized POSIX modes from the read-only flag, so
+    // 0o600 doesn't roundtrip — skip on Windows. Linux + macOS exercise
+    // the real permission bits.
+    await saveOAuthTokens(
+      {
+        accessToken: "secret-bearer",
+        accessTokenExpiresAt: "2026-12-31T23:59:59Z",
+      },
+      { home: tempDir },
+    );
+
+    const info = await stat(join(tempDir, ".qontoctl.yaml"));
+    // Mask off file-type bits; on POSIX 0o600 is owner-rw only.
+    expect(info.mode & 0o777).toBe(0o600);
+  });
 });
 
 describe("saveOAuthClientCredentials", () => {
-  let cwdDir: string;
-  let homeDir: string;
+  let tempDir: string;
 
   beforeEach(async () => {
-    cwdDir = await mkdtemp(join(tmpdir(), "qontoctl-writer-cwd-"));
-    homeDir = await mkdtemp(join(tmpdir(), "qontoctl-writer-home-"));
+    tempDir = await mkdtemp(join(tmpdir(), "qontoctl-writer-test-"));
   });
 
   afterEach(async () => {
-    await rm(cwdDir, { recursive: true, force: true });
-    await rm(homeDir, { recursive: true, force: true });
+    await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("writes to CWD config when it exists", async () => {
-    // CWD has a config file already
-    await writeFile(join(cwdDir, ".qontoctl.yaml"), "api-key:\n  organization-slug: test\n  secret-key: key\n");
+  it("writes to home default when no path/profile is given", async () => {
+    await saveOAuthClientCredentials({ clientId: "cid", clientSecret: "csecret" }, { home: tempDir });
 
-    await saveOAuthClientCredentials({ clientId: "cid", clientSecret: "csecret" }, { home: homeDir, cwd: cwdDir });
-
-    const content = await readFile(join(cwdDir, ".qontoctl.yaml"), "utf-8");
+    const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(content) as Record<string, unknown>;
     const oauth = doc["oauth"] as Record<string, unknown>;
     expect(oauth["client-id"]).toBe("cid");
     expect(oauth["client-secret"]).toBe("csecret");
-    // Home config should NOT have been created
-    await expect(readFile(join(homeDir, ".qontoctl.yaml"), "utf-8")).rejects.toThrow();
   });
 
-  it("falls back to home config when CWD has no config", async () => {
-    await saveOAuthClientCredentials({ clientId: "cid", clientSecret: "csecret" }, { home: homeDir, cwd: cwdDir });
+  it("preserves existing fields when adding client credentials", async () => {
+    await writeFile(join(tempDir, ".qontoctl.yaml"), "api-key:\n  organization-slug: test\n  secret-key: key\n");
 
-    const content = await readFile(join(homeDir, ".qontoctl.yaml"), "utf-8");
+    await saveOAuthClientCredentials({ clientId: "cid", clientSecret: "csecret" }, { home: tempDir });
+
+    const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(content) as Record<string, unknown>;
     const oauth = doc["oauth"] as Record<string, unknown>;
     expect(oauth["client-id"]).toBe("cid");
-    expect(oauth["client-secret"]).toBe("csecret");
+    expect((doc["api-key"] as Record<string, unknown>)["organization-slug"]).toBe("test");
+  });
+
+  it("respects explicit path", async () => {
+    const explicitPath = join(tempDir, "explicit.yaml");
+    await saveOAuthClientCredentials({ clientId: "cid", clientSecret: "csecret" }, { path: explicitPath });
+
+    const content = await readFile(explicitPath, "utf-8");
+    const doc = parseYaml(content) as Record<string, unknown>;
+    expect((doc["oauth"] as Record<string, unknown>)["client-id"]).toBe("cid");
   });
 });
 
@@ -165,7 +218,7 @@ describe("clearOAuthTokens", () => {
       'oauth:\n  client-id: my-client\n  client-secret: my-secret\n  access-token: old-token\n  refresh-token: old-refresh\n  access-token-expires-at: "2026-02-28T15:00:00Z"\n';
     await writeFile(join(tempDir, ".qontoctl.yaml"), content);
 
-    await clearOAuthTokens({ home: tempDir, cwd: tempDir });
+    await clearOAuthTokens({ home: tempDir });
 
     const result = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(result) as Record<string, unknown>;
@@ -182,7 +235,7 @@ describe("clearOAuthTokens", () => {
       'oauth:\n  client-id: my-client\n  client-secret: my-secret\n  access-token: old-token\n  token-expires-at: "2026-02-28T15:00:00Z"\n';
     await writeFile(join(tempDir, ".qontoctl.yaml"), content);
 
-    await clearOAuthTokens({ home: tempDir, cwd: tempDir });
+    await clearOAuthTokens({ home: tempDir });
 
     const result = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(result) as Record<string, unknown>;
@@ -193,14 +246,14 @@ describe("clearOAuthTokens", () => {
   });
 
   it("does nothing when config file does not exist", async () => {
-    await expect(clearOAuthTokens({ home: tempDir, cwd: tempDir })).resolves.toBeUndefined();
+    await expect(clearOAuthTokens({ home: tempDir })).resolves.toBeUndefined();
   });
 
   it("does nothing when no oauth section exists", async () => {
     const content = "api-key:\n  organization-slug: my-org\n";
     await writeFile(join(tempDir, ".qontoctl.yaml"), content);
 
-    await clearOAuthTokens({ home: tempDir, cwd: tempDir });
+    await clearOAuthTokens({ home: tempDir });
 
     const result = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(result) as Record<string, unknown>;
@@ -223,7 +276,7 @@ describe("saveOAuthScopes", () => {
     const existingContent = "oauth:\n  client-id: my-client\n  client-secret: my-secret\n";
     await writeFile(join(tempDir, ".qontoctl.yaml"), existingContent);
 
-    await saveOAuthScopes(["offline_access", "payment.write"], { home: tempDir, cwd: tempDir });
+    await saveOAuthScopes(["offline_access", "payment.write"], { home: tempDir });
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(content) as Record<string, unknown>;
@@ -234,11 +287,85 @@ describe("saveOAuthScopes", () => {
   });
 
   it("creates config file when it does not exist", async () => {
-    await saveOAuthScopes(["offline_access"], { home: tempDir, cwd: tempDir });
+    await saveOAuthScopes(["offline_access"], { home: tempDir });
 
     const content = await readFile(join(tempDir, ".qontoctl.yaml"), "utf-8");
     const doc = parseYaml(content) as Record<string, unknown>;
     const oauth = doc["oauth"] as Record<string, unknown>;
     expect(oauth["scopes"]).toEqual(["offline_access"]);
+  });
+});
+
+describe("atomicity and locking (issue #479)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "qontoctl-writer-atomic-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not leave a temp file alongside the destination on success", async () => {
+    await saveOAuthTokens(
+      {
+        accessToken: "a",
+        accessTokenExpiresAt: "2026-12-31T23:59:59Z",
+      },
+      { home: tempDir },
+    );
+
+    const fs = await import("node:fs/promises");
+    const entries = await fs.readdir(tempDir);
+    const tmpFiles = entries.filter((e) => /\.qontoctl\.yaml\.tmp\./.test(e));
+    expect(tmpFiles).toEqual([]);
+  });
+
+  it("permission error during write surfaces as ConfigError PERMISSION", async () => {
+    // Make the home directory non-writable so the writer's mkdir + open
+    // fail with EACCES. Skip on root (ignores perms) and Windows (different
+    // perm model — chmod is best-effort).
+    if (process.platform === "win32") {
+      return;
+    }
+    if (process.getuid && process.getuid() === 0) {
+      return;
+    }
+
+    await chmod(tempDir, 0o500);
+    try {
+      await expect(
+        saveOAuthTokens(
+          {
+            accessToken: "a",
+            accessTokenExpiresAt: "2026-12-31T23:59:59Z",
+          },
+          { home: tempDir },
+        ),
+      ).rejects.toBeInstanceOf(ConfigError);
+    } finally {
+      // Restore so afterEach can clean up
+      await chmod(tempDir, 0o700);
+    }
+  });
+
+  it("concurrent writes serialize correctly (no lost updates)", async () => {
+    // Fire two saves at slightly different access tokens; lock should
+    // serialize them. Final file must contain ONE of the two tokens
+    // verbatim — partial writes / interleaved YAML would fail to parse.
+    const explicitPath = join(tempDir, ".qontoctl.yaml");
+
+    const expiresAt = "2026-12-31T23:59:59Z";
+    const writeA = saveOAuthTokens({ accessToken: "AAA", accessTokenExpiresAt: expiresAt }, { path: explicitPath });
+    const writeB = saveOAuthTokens({ accessToken: "BBB", accessTokenExpiresAt: expiresAt }, { path: explicitPath });
+
+    await Promise.all([writeA, writeB]);
+
+    const content = await readFile(explicitPath, "utf-8");
+    const doc = parseYaml(content) as Record<string, unknown>;
+    const oauth = doc["oauth"] as Record<string, unknown>;
+    // Whichever ran second wins; both tokens are valid landings.
+    expect(["AAA", "BBB"]).toContain(oauth["access-token"]);
   });
 });

--- a/packages/core/src/config/writer.ts
+++ b/packages/core/src/config/writer.ts
@@ -1,14 +1,33 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { readFile, writeFile, mkdir, access } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { homedir } from "node:os";
+import { mkdir, open, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import { CONFIG_DIR } from "../constants.js";
+import lockfile from "proper-lockfile";
+import { resolveConfigFilePath, type LoadOptions } from "./loader.js";
+import { ConfigError } from "./resolve.js";
 
-const CONFIG_FILENAME = ".qontoctl.yaml";
 const FILE_MODE = 0o600;
+
+/**
+ * Lock retry policy. Bounded — failure surfaces as `CONFLICT` rather than
+ * deadlocking. Total wait ~3s in the worst case.
+ */
+const LOCK_RETRY_OPTIONS = {
+  retries: 5,
+  factor: 1.5,
+  minTimeout: 100,
+  maxTimeout: 1000,
+} as const;
+
+/**
+ * Stale-lock threshold (ms). proper-lockfile considers a lock stale (and
+ * eligible for steal) when it hasn't been updated within this window.
+ * 10s gives slow disks/snapshots room while preventing crashed processes
+ * from holding the lock forever.
+ */
+const LOCK_STALE_MS = 10_000;
 
 /**
  * OAuth token fields to persist in the config file.
@@ -20,211 +39,253 @@ export interface TokenUpdate {
 }
 
 /**
+ * Options accepted by all writer entrypoints.
+ *
+ * - `path` — explicit absolute or relative path. When provided, no
+ *   resolution occurs and `profile`/`home` are ignored. Callers performing
+ *   write-after-load (e.g., `auth refresh`) should round-trip the `path`
+ *   field returned by {@link import("./resolve.js").resolveConfig} to
+ *   guarantee the writer lands on the exact file the loader read from.
+ * - `profile` — derives `~/.qontoctl/{profile}.yaml`.
+ * - `home` — overrides `homedir()` for resolution (testing).
+ * - `env` — overrides env-var lookup for `QONTOCTL_CONFIG_FILE` (testing).
+ *
+ * No `cwd` option — CWD is never inspected by writers. See #479.
+ */
+export type WriteOptions = LoadOptions;
+
+/**
  * Saves OAuth tokens to the user's config file.
  *
  * Reads the existing YAML file, updates the `oauth` section with new token
- * values, and writes it back. Creates the file and directory if they don't exist.
+ * values, and writes it back atomically (temp-file + rename) under an
+ * advisory lock. Creates the file and directory if they don't exist.
  * File permissions are set to 0o600 (owner read/write only).
  *
  * @param tokens - The token values to save
- * @param options - Optional profile name and home directory override
+ * @param options - Optional path/profile/home — see {@link WriteOptions}
+ *
+ * @throws {ConfigError} `CONFLICT` on lock contention, `PERMISSION` on
+ *   filesystem permission errors. Other errors propagate as-is.
  */
-export async function saveOAuthTokens(
-  tokens: TokenUpdate,
-  options?: {
-    readonly profile?: string;
-    readonly home?: string;
-    readonly cwd?: string;
-  },
-): Promise<void> {
-  const path = await resolveConfigPath(options?.profile, options?.home, options?.cwd);
+export async function saveOAuthTokens(tokens: TokenUpdate, options?: WriteOptions): Promise<void> {
+  const path = resolveConfigFilePath(options);
+  await withLockedFile(path, async () => {
+    const doc = await readDoc(path);
+    const existingOAuth = getOAuthSection(doc) ?? {};
 
-  // Ensure directory exists
-  await mkdir(dirname(path), { recursive: true });
+    // Remove legacy key if present
+    delete existingOAuth["token-expires-at"];
 
-  // Read existing content
-  let doc: Record<string, unknown> = {};
-  try {
-    const content = await readFile(path, "utf-8");
-    const parsed: unknown = parseYaml(content);
-    if (parsed !== null && parsed !== undefined && typeof parsed === "object" && !Array.isArray(parsed)) {
-      doc = parsed as Record<string, unknown>;
-    }
-  } catch (error: unknown) {
-    if (!isNodeError(error) || error.code !== "ENOENT") {
-      throw error;
-    }
-    // File doesn't exist yet, start with empty doc
-  }
+    doc["oauth"] = {
+      ...existingOAuth,
+      "access-token": tokens.accessToken,
+      "access-token-expires-at": tokens.accessTokenExpiresAt,
+      ...(tokens.refreshToken !== undefined ? { "refresh-token": tokens.refreshToken } : {}),
+    };
 
-  // Update oauth section
-  const existingOAuth =
-    typeof doc["oauth"] === "object" && doc["oauth"] !== null && !Array.isArray(doc["oauth"])
-      ? (doc["oauth"] as Record<string, unknown>)
-      : {};
-
-  // Remove legacy key if present
-  delete existingOAuth["token-expires-at"];
-
-  doc["oauth"] = {
-    ...existingOAuth,
-    "access-token": tokens.accessToken,
-    "access-token-expires-at": tokens.accessTokenExpiresAt,
-    ...(tokens.refreshToken !== undefined ? { "refresh-token": tokens.refreshToken } : {}),
-  };
-
-  // Write back
-  const yaml = stringifyYaml(doc);
-  await writeFile(path, yaml, { mode: FILE_MODE });
+    await atomicWriteDoc(path, doc);
+  });
 }
 
 /**
  * Saves OAuth client credentials (client-id and client-secret) to the config file.
  *
  * Reads the existing YAML file, updates the `oauth` section with client
- * credentials, and writes it back. Creates the file and directory if needed.
+ * credentials, and writes it back atomically under an advisory lock.
+ * Creates the file and directory if needed.
  */
 export async function saveOAuthClientCredentials(
   credentials: { readonly clientId: string; readonly clientSecret: string },
-  options?: { readonly profile?: string; readonly home?: string; readonly cwd?: string },
+  options?: WriteOptions,
 ): Promise<void> {
-  const path = await resolveConfigPath(options?.profile, options?.home, options?.cwd);
+  const path = resolveConfigFilePath(options);
+  await withLockedFile(path, async () => {
+    const doc = await readDoc(path);
+    const existingOAuth = getOAuthSection(doc) ?? {};
 
-  await mkdir(dirname(path), { recursive: true });
+    doc["oauth"] = {
+      ...existingOAuth,
+      "client-id": credentials.clientId,
+      "client-secret": credentials.clientSecret,
+    };
 
-  let doc: Record<string, unknown> = {};
-  try {
-    const content = await readFile(path, "utf-8");
-    const parsed: unknown = parseYaml(content);
-    if (parsed !== null && parsed !== undefined && typeof parsed === "object" && !Array.isArray(parsed)) {
-      doc = parsed as Record<string, unknown>;
-    }
-  } catch (error: unknown) {
-    if (!isNodeError(error) || error.code !== "ENOENT") {
-      throw error;
-    }
-  }
-
-  const existingOAuth =
-    typeof doc["oauth"] === "object" && doc["oauth"] !== null && !Array.isArray(doc["oauth"])
-      ? (doc["oauth"] as Record<string, unknown>)
-      : {};
-
-  doc["oauth"] = {
-    ...existingOAuth,
-    "client-id": credentials.clientId,
-    "client-secret": credentials.clientSecret,
-  };
-
-  const yaml = stringifyYaml(doc);
-  await writeFile(path, yaml, { mode: FILE_MODE });
+    await atomicWriteDoc(path, doc);
+  });
 }
 
 /**
  * Clears OAuth tokens from the user's config file.
  *
  * Removes `access-token`, `refresh-token`, and `token-expires-at` from the
- * `oauth` section, preserving `client-id` and `client-secret`.
+ * `oauth` section, preserving `client-id` and `client-secret`. No-op when
+ * the file or `oauth` section does not exist.
  */
-export async function clearOAuthTokens(options?: {
-  readonly profile?: string;
-  readonly home?: string;
-  readonly cwd?: string;
-}): Promise<void> {
-  const path = await resolveConfigPath(options?.profile, options?.home, options?.cwd);
+export async function clearOAuthTokens(options?: WriteOptions): Promise<void> {
+  const path = resolveConfigFilePath(options);
 
-  let doc: Record<string, unknown>;
+  // Fast path: if the file doesn't exist, nothing to clear and no need to
+  // create one just to lock on. Probe via readFile and short-circuit.
+  let exists = true;
   try {
-    const content = await readFile(path, "utf-8");
-    const parsed: unknown = parseYaml(content);
-    if (parsed === null || parsed === undefined || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return; // Nothing to clear
-    }
-    doc = parsed as Record<string, unknown>;
+    await readFile(path, "utf-8");
   } catch (error: unknown) {
     if (isNodeError(error) && error.code === "ENOENT") {
-      return; // Nothing to clear
+      exists = false;
     }
-    throw error;
+  }
+  if (!exists) {
+    return;
   }
 
-  if (typeof doc["oauth"] !== "object" || doc["oauth"] === null || Array.isArray(doc["oauth"])) {
-    return; // No oauth section to clear
-  }
+  await withLockedFile(path, async () => {
+    const doc = await readDoc(path);
+    const oauth = getOAuthSection(doc);
+    if (oauth === undefined) return;
 
-  const oauth = doc["oauth"] as Record<string, unknown>;
-  delete oauth["access-token"];
-  delete oauth["refresh-token"];
-  delete oauth["token-expires-at"];
-  delete oauth["access-token-expires-at"];
+    delete oauth["access-token"];
+    delete oauth["refresh-token"];
+    delete oauth["token-expires-at"];
+    delete oauth["access-token-expires-at"];
 
-  const yaml = stringifyYaml(doc);
-  await writeFile(path, yaml, { mode: FILE_MODE });
+    await atomicWriteDoc(path, doc);
+  });
 }
 
 /**
  * Saves OAuth scopes to the user's config file.
  *
- * Reads the existing YAML file, updates the `oauth.scopes` field,
- * and writes it back. Creates the file and directory if they don't exist.
+ * Reads the existing YAML file, updates the `oauth.scopes` field, and
+ * writes it back atomically under an advisory lock. Creates the file and
+ * directory if they don't exist.
  */
-export async function saveOAuthScopes(
-  scopes: readonly string[],
-  options?: { readonly profile?: string; readonly home?: string; readonly cwd?: string },
-): Promise<void> {
-  const path = await resolveConfigPath(options?.profile, options?.home, options?.cwd);
+export async function saveOAuthScopes(scopes: readonly string[], options?: WriteOptions): Promise<void> {
+  const path = resolveConfigFilePath(options);
+  await withLockedFile(path, async () => {
+    const doc = await readDoc(path);
+    const existingOAuth = getOAuthSection(doc) ?? {};
 
-  await mkdir(dirname(path), { recursive: true });
+    doc["oauth"] = {
+      ...existingOAuth,
+      scopes: [...scopes],
+    };
 
-  let doc: Record<string, unknown> = {};
+    await atomicWriteDoc(path, doc);
+  });
+}
+
+/**
+ * Returns the `oauth` subsection of `doc` if it is a plain object, else
+ * `undefined`. Centralizes the type-guard the writers all need before
+ * mutating or extending the section.
+ */
+function getOAuthSection(doc: Record<string, unknown>): Record<string, unknown> | undefined {
+  const oauth = doc["oauth"];
+  if (typeof oauth === "object" && oauth !== null && !Array.isArray(oauth)) {
+    return oauth as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+/**
+ * Reads and parses the YAML doc at `path`, returning an empty doc if the
+ * file does not exist. Throws on parse errors and on permission errors.
+ */
+async function readDoc(path: string): Promise<Record<string, unknown>> {
   try {
     const content = await readFile(path, "utf-8");
     const parsed: unknown = parseYaml(content);
     if (parsed !== null && parsed !== undefined && typeof parsed === "object" && !Array.isArray(parsed)) {
-      doc = parsed as Record<string, unknown>;
+      return parsed as Record<string, unknown>;
     }
+    return {};
   } catch (error: unknown) {
-    if (!isNodeError(error) || error.code !== "ENOENT") {
-      throw error;
+    if (isNodeError(error)) {
+      if (error.code === "ENOENT") {
+        return {};
+      }
+      if (error.code === "EACCES" || error.code === "EPERM") {
+        throw new ConfigError(`Permission denied reading config file "${path}".`, "PERMISSION");
+      }
     }
+    throw error;
   }
-
-  const existingOAuth =
-    typeof doc["oauth"] === "object" && doc["oauth"] !== null && !Array.isArray(doc["oauth"])
-      ? (doc["oauth"] as Record<string, unknown>)
-      : {};
-
-  doc["oauth"] = {
-    ...existingOAuth,
-    scopes: [...scopes],
-  };
-
-  const yaml = stringifyYaml(doc);
-  await writeFile(path, yaml, { mode: FILE_MODE });
 }
 
 /**
- * Resolves the config file path for writing, mirroring the loader's resolution:
- *   - With `profile`: `~/.qontoctl/{profile}.yaml`
- *   - Without `profile`: CWD `.qontoctl.yaml` if it exists, otherwise `~/.qontoctl.yaml`
+ * Atomically writes the YAML serialization of `doc` to `path` via a
+ * temp-file + rename pattern. The temp file inherits 0o600 mode; rename is
+ * atomic on POSIX (and best-effort on Windows via `node:fs/promises`).
+ *
+ * On any failure mid-write, the temp file is best-effort removed so the
+ * destination remains in its prior state — never truncated, never left as
+ * a 0-byte file the user is locked out of.
  */
-async function resolveConfigPath(
-  profile: string | undefined,
-  home: string | undefined,
-  cwd: string | undefined,
-): Promise<string> {
-  const homeDir = home ?? homedir();
-  if (profile !== undefined) {
-    return join(homeDir, CONFIG_DIR, `${profile}.yaml`);
+async function atomicWriteDoc(path: string, doc: Record<string, unknown>): Promise<void> {
+  const yaml = stringifyYaml(doc);
+  // Temp file lives next to the target so `rename` is intra-filesystem
+  // (cross-fs rename is non-atomic on most platforms). PID + monotonic
+  // suffix avoids collision when the same process performs back-to-back
+  // writes within the lock.
+  const tmpPath = `${path}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    await writeFile(tmpPath, yaml, { mode: FILE_MODE });
+    await rename(tmpPath, path);
+  } catch (error: unknown) {
+    await unlink(tmpPath).catch(() => {
+      /* best-effort */
+    });
+    if (isNodeError(error) && (error.code === "EACCES" || error.code === "EPERM")) {
+      throw new ConfigError(`Permission denied writing config file "${path}".`, "PERMISSION");
+    }
+    throw error;
+  }
+}
+
+/**
+ * Acquires an advisory lock on `path` (creating the file if needed),
+ * runs `fn`, then releases. Concurrent callers wait per
+ * {@link LOCK_RETRY_OPTIONS} or surface a `CONFLICT` ConfigError.
+ */
+async function withLockedFile<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  // Ensure parent directory exists.
+  await mkdir(dirname(path), { recursive: true });
+
+  // Touch the file (idempotent) so proper-lockfile has a stable target.
+  // 'a' opens for append + creates if missing; we don't write anything,
+  // just close. Mode is applied only on creation.
+  try {
+    const handle = await open(path, "a", FILE_MODE);
+    await handle.close();
+  } catch (error: unknown) {
+    if (isNodeError(error) && (error.code === "EACCES" || error.code === "EPERM")) {
+      throw new ConfigError(`Permission denied creating config file "${path}".`, "PERMISSION");
+    }
+    throw error;
   }
 
-  // Mirror the loader: prefer CWD config if it exists
-  const cwdPath = join(cwd ?? process.cwd(), CONFIG_FILENAME);
+  let release: () => Promise<void>;
   try {
-    await access(cwdPath);
-    return cwdPath;
-  } catch {
-    return join(homeDir, CONFIG_FILENAME);
+    release = await lockfile.lock(path, {
+      retries: LOCK_RETRY_OPTIONS,
+      stale: LOCK_STALE_MS,
+    });
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ConfigError(
+      `Could not acquire lock on "${path}" (another process may be writing). ${detail}`,
+      "CONFLICT",
+    );
+  }
+
+  try {
+    return await fn();
+  } finally {
+    try {
+      await release();
+    } catch {
+      /* best-effort release; lock will be reaped by stale timeout */
+    }
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,10 +19,12 @@ export {
 
 export {
   resolveConfig,
+  resolveConfigPath,
   resolveScaMethod,
   ConfigError,
   isValidProfileName,
   loadConfigFile,
+  resolveConfigFilePath,
   validateConfig,
   applyEnvOverlay,
   saveOAuthTokens,
@@ -33,14 +35,17 @@ export {
 
 export type {
   ApiKeyCredentials,
+  ConfigErrorCode,
   OAuthCredentials,
   QontoctlConfig,
   ConfigResult,
   ResolveOptions,
   ScaConfig,
+  LoadOptions,
   LoadResult,
   ValidationResult,
   TokenUpdate,
+  WriteOptions,
   EnvOverlayConfig,
   EnvOverlayResult,
   StaticOAuthFields,

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -2,8 +2,23 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+
+/**
+ * Absolute path to the repo-root `.qontoctl.yaml`, computed once from this
+ * module's own location. Used to inject `QONTOCTL_CONFIG_FILE` into spawned
+ * CLI subprocesses so they hit the repo's config file without relying on
+ * CWD inspection (which the resolver no longer does, post #479).
+ *
+ * The walk-up helpers below (`findConfigDir`, `cliCwd`, the loop in
+ * `readConfigFileCredentials`) remain in place for in-process credential
+ * detection used by `hasApiKeyCredentials()`/`hasOAuthCredentials()`/
+ * `hasStagingToken()` — those parse YAML directly and don't go through the
+ * resolver. The full walk-up removal is scoped to #481.
+ */
+const REPO_ROOT_CONFIG_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", ".qontoctl.yaml");
 
 interface ConfigCredentials {
   readonly organizationSlug?: string;
@@ -201,10 +216,22 @@ function findConfigDir(): string | undefined {
 /**
  * Build an environment for spawning CLI child processes.
  *
- * Passes through the current process environment as-is.
+ * Injects `QONTOCTL_CONFIG_FILE=<repo-root>/.qontoctl.yaml` so the CLI
+ * loads the repo's config file without relying on CWD inspection (which
+ * the resolver no longer performs, post #479). Existing env values for
+ * the variable are preserved — tests that explicitly set
+ * `QONTOCTL_CONFIG_FILE` keep their override.
+ *
+ * Existing api-key / oauth env vars (`QONTOCTL_ORGANIZATION_SLUG`, etc.)
+ * also continue to take precedence over file values via the env-overlay,
+ * so suites that rely on env-only credentials are unaffected.
  */
 export function cliEnv(): Record<string, string> {
-  return { ...(process.env as Record<string, string>) };
+  const env = { ...(process.env as Record<string, string>) };
+  if (env["QONTOCTL_CONFIG_FILE"] === undefined || env["QONTOCTL_CONFIG_FILE"] === "") {
+    env["QONTOCTL_CONFIG_FILE"] = REPO_ROOT_CONFIG_PATH;
+  }
+  return env;
 }
 
 /**

--- a/packages/mcp/src/errors.test.ts
+++ b/packages/mcp/src/errors.test.ts
@@ -39,7 +39,7 @@ describe("withClient", () => {
 
   describe("ConfigError", () => {
     it("formats configuration error with setup guidance", async () => {
-      const factory = () => Promise.reject(new ConfigError("No credentials found"));
+      const factory = () => Promise.reject(new ConfigError("No credentials found", "NO_CREDS"));
       const result = await withClient(factory, async () => ({
         content: [{ type: "text" as const, text: "unreachable" }],
       }));

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -23,21 +23,52 @@ function textError(message: string): CallToolResult {
 }
 
 function formatConfigError(error: ConfigError): CallToolResult {
-  return textError(
-    [
-      `Configuration error: ${error.message}`,
-      "",
-      "To configure credentials, create ~/.qontoctl.yaml:",
-      "",
-      "api-key:",
-      "  organization-slug: <your-org-slug>",
-      "  secret-key: <your-secret-key>",
-      "",
-      "Or set environment variables:",
-      "  QONTOCTL_ORGANIZATION_SLUG=<your-org-slug>",
-      "  QONTOCTL_SECRET_KEY=<your-secret-key>",
-    ].join("\n"),
-  );
+  switch (error.code) {
+    case "NO_CREDS":
+      return textError(
+        [
+          `Configuration error: ${error.message}`,
+          "",
+          "Set credentials via one of:",
+          "  • A config file at ~/.qontoctl.yaml",
+          "  • The QONTOCTL_CONFIG_FILE env var pointing at an absolute path",
+          "  • Env vars QONTOCTL_ORGANIZATION_SLUG + QONTOCTL_SECRET_KEY (api-key)",
+          "  • Env vars QONTOCTL_CLIENT_ID + QONTOCTL_CLIENT_SECRET (oauth)",
+        ].join("\n"),
+      );
+    case "PARSE":
+      return textError(
+        [
+          `Configuration error: ${error.message}`,
+          "",
+          "The YAML file could not be parsed. Check indentation, quoting, and special characters.",
+        ].join("\n"),
+      );
+    case "VALIDATION":
+      return textError([`Configuration error: ${error.message}`, "", "Fix the offending field and retry."].join("\n"));
+    case "PERMISSION":
+      return textError(
+        [
+          `Configuration error: ${error.message}`,
+          "",
+          "Check file ownership and permissions. OAuth-bearing files should be 0600 (chmod 600 <path>).",
+        ].join("\n"),
+      );
+    case "CONFLICT":
+      return textError(
+        [
+          `Configuration error: ${error.message}`,
+          "",
+          "Another qontoctl process is writing to the same config file.",
+          "Wait for it to finish, or kill it if it's stuck (a stale lock is reaped after 10 seconds).",
+        ].join("\n"),
+      );
+    default:
+      // Future-proof: any unrecognized code (e.g., a new ConfigErrorCode
+      // variant added without updating this switch) still produces a
+      // legible message rather than returning undefined.
+      return textError(`Configuration error: ${error.message}`);
+  }
 }
 
 function formatAuthError(error: AuthError): CallToolResult {
@@ -45,7 +76,7 @@ function formatAuthError(error: AuthError): CallToolResult {
     [
       `Authentication error: ${error.message}`,
       "",
-      "Verify your API key credentials in ~/.qontoctl.yaml or environment variables.",
+      "Verify your API key credentials in ~/.qontoctl.yaml, via QONTOCTL_CONFIG_FILE, or via environment variables.",
     ].join("\n"),
   );
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -16,7 +16,7 @@ import { runStdioServer } from "./stdio.js";
 
 await runStdioServer({
   getClient: async () => {
-    const { config, endpoint, oauthAccessTokenFromEnv } = await resolveConfig();
+    const { config, endpoint, path, oauthAccessTokenFromEnv } = await resolveConfig();
 
     let authorization: Authorization;
     let fallbackAuthorization: Authorization | undefined;
@@ -25,6 +25,7 @@ await runStdioServer({
       authorization = createOAuthAuthorization({
         oauth: config.oauth,
         tokenUrl: config.oauth.stagingToken !== undefined ? OAUTH_TOKEN_SANDBOX_URL : OAUTH_TOKEN_URL,
+        ...(path !== undefined ? { path } : {}),
         readOnly: oauthAccessTokenFromEnv,
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
 
   packages/core:
     dependencies:
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       yaml:
         specifier: 'catalog:'
         version: 2.8.3
@@ -133,6 +136,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.15
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -694,6 +700,12 @@ packages:
   '@types/node@25.3.2':
     resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1134,6 +1146,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1394,6 +1409,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1425,6 +1443,10 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
@@ -1480,6 +1502,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -2038,6 +2063,12 @@ snapshots:
       undici-types: 7.18.2
     optional: true
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/retry@0.12.5': {}
+
   '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3)(typescript@5.9.3)':
@@ -2577,6 +2608,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -2794,6 +2827,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -2819,6 +2858,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
+
+  retry@0.12.0: {}
 
   rollup@4.60.0:
     dependencies:
@@ -2927,6 +2968,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   sisteransi@1.0.5: {}
 


### PR DESCRIPTION
Closes #479.

## Summary

Replaces the implicit CWD-first config-discovery model with a single deterministic resolution chain shared by loader and writer:

```
explicit `path` arg  >  QONTOCTL_CONFIG_FILE env  >  ~/.qontoctl/{profile}.yaml  >  ~/.qontoctl.yaml
```

No CWD inspection at any stage. `ConfigResult.path` round-trips to writers so `auth refresh` (and runtime OAuth refresh in `createOAuthAuthorization`) write back to the exact file the loader read from — eliminating the ghost-credentials class.

## What changed

**Resolution model**
- `loader.ts`: drops CWD-first fallback; new `LoadOptions` accepts `path`/`profile`/`home`/`env`; exposes `resolveConfigFilePath()` for I/O-free path resolution.
- `writer.ts`: drops `access(cwdPath)` check; all four entrypoints accept `WriteOptions = LoadOptions`.
- `resolve.ts`: returns `path: string | undefined` in `ConfigResult`; new `describeSearchLocations` reflects no-CWD rules.
- `env.ts`: reads `QONTOCTL_CONFIG_FILE` (via loader's resolver — semantic placement; functionally equivalent).

**Atomicity + concurrency**
- Writers use temp-file + atomic `rename` (intra-fs). Mid-write SIGKILL no longer truncates the file.
- Advisory lock around RMW window via `proper-lockfile` (bounded retries: ~3s worst case; 10s stale timeout).
- Lock-budget exhaustion surfaces `ConfigError` `code: 'CONFLICT'` (no deadlock).

**ConfigError discriminator**
- New union: `'NO_CREDS' | 'PARSE' | 'VALIDATION' | 'PERMISSION' | 'CONFLICT'`.
- CLI/MCP error handlers switch on `code` with tailored guidance per cause; `default:` branch future-proofs new codes.

**Hardening**
- Permission warning (stderr) for OAuth-bearing config files that are group/world readable (mask `0o077`).
- Profile name validation: rejects path separators, `..`, glob chars (`*?[]`), empty, and reserved env-var suffixes (ENDPOINT, CLIENT_ID, CLIENT_SECRET, ACCESS_TOKEN, REFRESH_TOKEN, SCOPES, STAGING_TOKEN, ORGANIZATION_SLUG, SECRET_KEY, SCA_METHOD, CONFIG_FILE).
- Env-overlay bug fix: env-only `QONTOCTL_ACCESS_TOKEN` (or `QONTOCTL_STAGING_TOKEN`) without resolvable client creds no longer fabricates an oauth block with empty `client-id`. Downstream now surfaces `NO_CREDS` accurately instead of misleading `Missing required field "client-id"`.

**Caller round-trip**
- `oauth-authorization-factory.ts`: accepts `path?`, prefers it over profile when persisting refreshed tokens.
- `cli/client.ts` + `mcp/index.ts`: extract `path` from `resolveConfig` and pass to `createOAuthAuthorization`.
- `cli/commands/auth.ts`: new `buildWriteOptions(path, profile)` helper used by login/setup/refresh/revoke — writes hit the exact loaded file.

**E2E gap mitigation (until #481)**
- `packages/e2e/src/sandbox.ts`: `cliEnv()` injects `QONTOCTL_CONFIG_FILE=<repo-root>/.qontoctl.yaml` so e2e suites stay green during the gap before #481 finishes the sandbox.ts rewrite. Path computed deterministically via `import.meta.url` (no walk-up needed for the injection itself).

## Migration / breaking change

`./.qontoctl.yaml` is no longer auto-discovered from CWD. Local-config workflows have three paths:

1. **Recommended**: copy `.envrc.example` → `.envrc` (gitignored), run `direnv allow`. Exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` automatically when you `cd` into the repo.
2. Per-shell: `export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`.
3. After #480: `qontoctl --config ./.qontoctl.yaml ...`.

CLAUDE.md and a new `.envrc.example` document the workflow.

## Test plan

- [x] All unit tests pass: 2002 tests across 5 packages (core 953 + cli 685 + mcp 346 + qontoctl 18).
  - 23 net new tests covering: path precedence (path > env > profile > home), profile name validation (13 input rejection cases + accept cases), env-overlay partial-overlay fix (access-token-only and staging-token-only surface NO_CREDS, not phantom missing-client-id), permission warning (0o644 + OAuth warns; 0o600 doesn't; 0o644 + api-key-only doesn't), atomicity (no temp file leak on success; 0o600 mode), lock serialization (concurrent writes don't lose data), CWD non-inspection invariant, ConfigError code discriminator coverage.
- [x] Lint clean across 5 packages (`pnpm -r lint`).
- [x] License check clean (`pnpm license-check` — `proper-lockfile` is MIT, allow-listed).
- [x] Full build clean (`pnpm -r build`).
- [x] E2E run locally — auth/profile/transactions/transfers/clients pass; the 25 unrelated failures match known issues #488 (intl Zod schema), #489 (cards/insurance HTTP 400), #490 (sandbox data assumptions), #491 (SCA token capture). None are config/credential regressions.

## Verification by reviewer

```sh
# Quick verification commands
pnpm -r build && pnpm -r test && pnpm -r lint && pnpm license-check

# Walk the resolution chain
git diff main...HEAD -- packages/core/src/config/loader.ts
git diff main...HEAD -- packages/core/src/config/resolve.ts
git diff main...HEAD -- packages/core/src/config/writer.ts

# Confirm no CWD inspection
grep -rn "process.cwd\|options?.cwd\|cwd:" packages/core/src/config/ | grep -v node_modules
# (Should show only doc comments, no live calls.)
```

## Out of scope

Per #479's "Out of scope" section, deferred to follow-ups:
- CLI `--config` flag and path-threading through commands → #480
- E2E sandbox.ts walk-up removal (rest of harness rewrite) → #481
- MCP env var support already lands here; remaining MCP/docs work → #482
- YAML `Document` API for comment preservation, `auth whoami` source-reporting — separate refactors

## Council

Designed via 3-agent council (technical-architect, security-architect, typescript-architect). See issue #479 for the full evaluation and rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)