### PR TITLE
(feat) add CLI --config flag with path round-trip; remove CWD docs (#480)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ ESLint enforces this via `eslint-plugin-header`.
 
 - `direnv` shim: copy `.envrc.example` → `.envrc` (gitignored), run `direnv allow`. Exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` automatically when you `cd` into the repo. **Recommended** for daily development.
 - Per-shell env: `export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`
-- (After #480 ships) Per-invocation: `qontoctl --config ./.qontoctl.yaml ...`
+- Per-invocation: `qontoctl --config ./.qontoctl.yaml ...` (highest precedence; warns on stderr if it disagrees with `QONTOCTL_CONFIG_FILE` or `--profile`)
 
 The E2E test harness already injects `QONTOCTL_CONFIG_FILE` for spawned CLI subprocesses (see `packages/e2e/src/sandbox.ts`), so `pnpm test:e2e` works without any of the above.
 

--- a/README.md
+++ b/README.md
@@ -410,15 +410,16 @@ The pending response's textual format is stable, so callers that need to extract
 
 ### Global Options
 
-| Option                  | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `-p, --profile <name>`  | Configuration profile to use                            |
-| `-o, --output <format>` | Output format: `table` (default), `json`, `yaml`, `csv` |
-| `--page <number>`       | Fetch a specific page of results                        |
-| `--per-page <number>`   | Results per page                                        |
-| `--no-paginate`         | Disable auto-pagination                                 |
-| `--verbose`             | Enable verbose output                                   |
-| `--debug`               | Enable debug output (implies `--verbose`)               |
+| Option                  | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `--config <path>`       | Explicit path to a config file (overrides `--profile` and `QONTOCTL_CONFIG_FILE`) |
+| `-p, --profile <name>`  | Configuration profile to use                                                      |
+| `-o, --output <format>` | Output format: `table` (default), `json`, `yaml`, `csv`                           |
+| `--page <number>`       | Fetch a specific page of results                                                  |
+| `--per-page <number>`   | Results per page                                                                  |
+| `--no-paginate`         | Disable auto-pagination                                                           |
+| `--verbose`             | Enable verbose output                                                             |
+| `--debug`               | Enable debug output (implies `--verbose`)                                         |
 
 ## Configuration
 
@@ -445,16 +446,21 @@ oauth:
 
 ### Resolution Order
 
-**Without `--profile`:**
+The CLI resolves the config **file** in this order (highest priority first):
 
-1. `QONTOCTL_*` environment variables (highest priority)
-2. `.qontoctl.yaml` in current directory
-3. `~/.qontoctl.yaml` (home default)
+1. `--config <path>` flag
+2. `QONTOCTL_CONFIG_FILE` env var
+3. `~/.qontoctl/{name}.yaml` (when `--profile <name>` is given)
+4. `~/.qontoctl.yaml` (home default)
 
-**With `--profile acme`:**
+When `--config` is supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and the resolved paths disagree, `--config` wins and a warning is emitted on stderr so the override is visible.
 
-1. `QONTOCTL_ACME_*` environment variables (highest priority)
-2. `~/.qontoctl/acme.yaml`
+> **No current-directory discovery.** The CLI does not scan the working directory for `.qontoctl.yaml`. For repo-local config, use a `direnv` shim that exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`, or pass `--config ./.qontoctl.yaml` explicitly per invocation.
+
+**Per-field overrides** apply on top of the loaded file:
+
+- Without `--profile`: `QONTOCTL_*` env vars override file values
+- With `--profile acme`: `QONTOCTL_ACME_*` env vars override file values
 
 ### Environment Variables
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -12,20 +12,22 @@ import {
   OAUTH_TOKEN_URL,
   OAUTH_TOKEN_SANDBOX_URL,
 } from "@qontoctl/core";
+import { buildResolveOptions } from "./inherited-options.js";
 import type { GlobalOptions } from "./options.js";
 
 /**
  * Create an authenticated HttpClient from global CLI options.
  *
- * Resolves configuration (profile, env), builds the authorization
+ * Resolves configuration (`--config` > `QONTOCTL_CONFIG_FILE` env >
+ * `--profile` derived path > home default), builds the authorization
  * header, and uses the resolved endpoint.
  *
  * Auth precedence: OAuth (with auto-refresh) > API key.
  */
 export async function createClient(options: GlobalOptions): Promise<HttpClient> {
-  const { config, endpoint, warnings, path, oauthAccessTokenFromEnv } = await resolveConfig({
-    profile: options.profile,
-  });
+  const { config, endpoint, warnings, path, oauthAccessTokenFromEnv } = await resolveConfig(
+    buildResolveOptions(options),
+  );
 
   for (const warning of warnings) {
     process.stderr.write(`Warning: ${warning}\n`);

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -385,6 +385,32 @@ describe("registerAuthCommands", () => {
       );
       expect(saveOAuthScopesMock).toHaveBeenCalledWith(["offline_access"], { profile: "work" });
     });
+
+    it("plumbs --config to resolveConfig and round-trips path on writes", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {},
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        path: "/explicit/config.yaml",
+        oauthAccessTokenFromEnv: false,
+      });
+      textMock.mockResolvedValueOnce("my-id").mockResolvedValueOnce("my-secret");
+      multiselectMock.mockResolvedValueOnce(["offline_access"]);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.option("--config <path>", "");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "setup", "--config", "/explicit/config.yaml"], { from: "user" });
+
+      expect(resolveConfigMock).toHaveBeenCalledWith(expect.objectContaining({ path: "/explicit/config.yaml" }));
+      expect(saveOAuthClientCredentialsMock).toHaveBeenCalledWith(
+        { clientId: "my-id", clientSecret: "my-secret" },
+        { path: "/explicit/config.yaml" },
+      );
+      expect(saveOAuthScopesMock).toHaveBeenCalledWith(["offline_access"], { path: "/explicit/config.yaml" });
+    });
   });
 
   describe("auth status", () => {
@@ -720,6 +746,79 @@ describe("registerAuthCommands", () => {
         "test-token",
       );
     });
+
+    it("plumbs --config to resolveConfig and round-trips path on token save", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            refreshToken: "old-refresh",
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        path: "/explicit/config.yaml",
+        oauthAccessTokenFromEnv: false,
+      });
+      refreshAccessTokenMock.mockResolvedValue({
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        tokenType: "Bearer",
+      });
+      saveOAuthTokensMock.mockResolvedValue(undefined);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.option("--config <path>", "");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "refresh", "--config", "/explicit/config.yaml"], { from: "user" });
+
+      expect(resolveConfigMock).toHaveBeenCalledWith(expect.objectContaining({ path: "/explicit/config.yaml" }));
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "new-access" }), {
+        path: "/explicit/config.yaml",
+      });
+    });
+
+    it("round-trips env-resolved path on token save (no --config flag)", async () => {
+      // Simulates QONTOCTL_CONFIG_FILE-only resolution: no --config flag,
+      // but core's resolveConfig returns a `path` (the env-pointed file).
+      // The writer must round-trip that path even though the user did not
+      // pass --config explicitly.
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            refreshToken: "old-refresh",
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        path: "/from-env/config.yaml",
+        oauthAccessTokenFromEnv: false,
+      });
+      refreshAccessTokenMock.mockResolvedValue({
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        tokenType: "Bearer",
+      });
+      saveOAuthTokensMock.mockResolvedValue(undefined);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "refresh"], { from: "user" });
+
+      // Even with no --config flag, the writer round-trips the loader's path.
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "new-access" }), {
+        path: "/from-env/config.yaml",
+      });
+    });
   });
 
   describe("auth revoke", () => {
@@ -828,6 +927,35 @@ describe("registerAuthCommands", () => {
 
       expect(revokeTokenMock).not.toHaveBeenCalled();
       expect(clearOAuthTokensMock).toHaveBeenCalled();
+    });
+
+    it("plumbs --config to resolveConfig and round-trips path on clearOAuthTokens", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            accessToken: "access",
+            refreshToken: "refresh",
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        path: "/explicit/config.yaml",
+        oauthAccessTokenFromEnv: false,
+      });
+      revokeTokenMock.mockResolvedValue(undefined);
+      clearOAuthTokensMock.mockResolvedValue(undefined);
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.option("--config <path>", "");
+      registerAuthCommands(program);
+
+      await program.parseAsync(["auth", "revoke", "--config", "/explicit/config.yaml"], { from: "user" });
+
+      expect(resolveConfigMock).toHaveBeenCalledWith(expect.objectContaining({ path: "/explicit/config.yaml" }));
+      expect(clearOAuthTokensMock).toHaveBeenCalledWith({ path: "/explicit/config.yaml" });
     });
   });
 
@@ -1111,6 +1239,37 @@ describe("registerAuthCommands", () => {
       await parsePromise;
 
       expect(saveOAuthTokensMock).toHaveBeenCalledWith(expect.any(Object), { profile: "work" });
+    });
+
+    it("plumbs --config to resolveConfig and round-trips path on token save", async () => {
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "cid",
+            clientSecret: "csecret",
+            scopes: ["offline_access", "organization.read"],
+          },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        path: "/explicit/config.yaml",
+        oauthAccessTokenFromEnv: false,
+      });
+
+      const program = new Command();
+      program.option("-o, --output <format>", "", "table");
+      program.option("--config <path>", "");
+      registerAuthCommands(program);
+
+      const parsePromise = program.parseAsync(["auth", "login", "--config", "/explicit/config.yaml"], {
+        from: "user",
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      simulateCallback("auth-code", MOCK_STATE_HEX);
+      await parsePromise;
+
+      expect(resolveConfigMock).toHaveBeenCalledWith(expect.objectContaining({ path: "/explicit/config.yaml" }));
+      expect(saveOAuthTokensMock).toHaveBeenCalledWith(expect.any(Object), { path: "/explicit/config.yaml" });
     });
 
     it("throws when no OAuth config", async () => {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -30,7 +30,7 @@ import {
   saveOAuthScopes,
   clearOAuthTokens,
 } from "@qontoctl/core";
-import { addInheritableOptions, resolveGlobalOptions } from "../inherited-options.js";
+import { addInheritableOptions, buildResolveOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions } from "../options.js";
 
 const DEFAULT_REDIRECT_PORT = 18920;
@@ -245,9 +245,9 @@ function resolveOAuthEndpoints(stagingToken?: string): OAuthEndpoints {
 }
 
 async function resolveOAuthConfig(
-  profile: string | undefined,
+  opts: Pick<GlobalOptions, "config" | "profile">,
 ): Promise<{ oauth: OAuthCredentials; path: string | undefined }> {
-  const { config, path } = await resolveConfig({ profile });
+  const { config, path } = await resolveConfig(buildResolveOptions(opts));
   if (config.oauth === undefined) {
     throw new Error(
       "No OAuth credentials found in configuration. " +
@@ -405,7 +405,7 @@ export function registerAuthCommands(program: Command): void {
     let existingOAuth: OAuthCredentials | undefined;
     let loadedPath: string | undefined;
     try {
-      const result = await resolveConfig({ profile: opts.profile });
+      const result = await resolveConfig(buildResolveOptions(opts));
       existingOAuth = result.config.oauth;
       loadedPath = result.path;
     } catch {
@@ -473,7 +473,7 @@ export function registerAuthCommands(program: Command): void {
     const port = Number.parseInt(opts.port, 10);
     const redirectUri = `http://localhost:${port}/callback`;
 
-    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts);
     const { authUrl, tokenUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     // Scopes must be configured beforehand (via `auth setup`). `auth login` is
@@ -577,7 +577,7 @@ export function registerAuthCommands(program: Command): void {
   addInheritableOptions(refresh);
   refresh.action(async (_options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
-    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts);
     const { tokenUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     if (!oauth.refreshToken) {
@@ -612,7 +612,7 @@ export function registerAuthCommands(program: Command): void {
   addInheritableOptions(status);
   status.action(async (_options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
-    const { oauth } = await resolveOAuthConfig(opts.profile);
+    const { oauth } = await resolveOAuthConfig(opts);
 
     if (!oauth.accessToken) {
       process.stdout.write("Status: Not logged in\n");
@@ -658,7 +658,7 @@ export function registerAuthCommands(program: Command): void {
   addInheritableOptions(revoke);
   revoke.action(async (_options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
-    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts.profile);
+    const { oauth, path: loadedPath } = await resolveOAuthConfig(opts);
     const { revokeUrl } = resolveOAuthEndpoints(oauth.stagingToken);
 
     if (oauth.accessToken) {

--- a/packages/cli/src/commands/profile/test.ts
+++ b/packages/cli/src/commands/profile/test.ts
@@ -12,7 +12,7 @@ import {
   QontoApiError,
   QontoRateLimitError,
 } from "@qontoctl/core";
-import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import { addInheritableOptions, buildResolveOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions } from "../../options.js";
 
 interface OrganizationResponse {
@@ -59,7 +59,7 @@ async function testProfile(options: GlobalOptions): Promise<void> {
   }
 
   try {
-    const { config, endpoint } = await resolveConfig({ profile: options.profile });
+    const { config, endpoint } = await resolveConfig(buildResolveOptions(options));
 
     if (config.apiKey === undefined) {
       console.error("Configuration error: no credentials found.");

--- a/packages/cli/src/commands/sca-session/mock-decision.ts
+++ b/packages/cli/src/commands/sca-session/mock-decision.ts
@@ -5,7 +5,7 @@ import type { Command } from "commander";
 import { mockScaDecision, resolveConfig } from "@qontoctl/core";
 import { createClient } from "../../client.js";
 import { formatOutput } from "../../formatters/index.js";
-import { addInheritableOptions, resolveGlobalOptions } from "../../inherited-options.js";
+import { addInheritableOptions, buildResolveOptions, resolveGlobalOptions } from "../../inherited-options.js";
 import type { GlobalOptions } from "../../options.js";
 
 const VALID_DECISIONS = ["allow", "deny"] as const;
@@ -33,7 +33,7 @@ export function registerScaSessionMockDecisionCommand(parent: Command): void {
 
     const opts = resolveGlobalOptions<GlobalOptions>(action);
 
-    const { config } = await resolveConfig({ profile: opts.profile });
+    const { config } = await resolveConfig(buildResolveOptions(opts));
     if (config.oauth?.stagingToken === undefined) {
       throw new Error(
         "sca-session mock-decision is only available in the sandbox environment. " +

--- a/packages/cli/src/inherited-options.test.ts
+++ b/packages/cli/src/inherited-options.test.ts
@@ -3,14 +3,15 @@
 
 import { describe, it, expect } from "vitest";
 import { Command, Option } from "commander";
-import { addInheritableOptions, resolveGlobalOptions } from "./inherited-options.js";
+import { addInheritableOptions, buildResolveOptions, resolveGlobalOptions } from "./inherited-options.js";
 
 describe("addInheritableOptions", () => {
-  it("adds --profile, --verbose, --debug, and --sca-method to a command", () => {
+  it("adds --config, --profile, --verbose, --debug, and --sca-method to a command", () => {
     const cmd = new Command("test");
     addInheritableOptions(cmd);
 
     const optionNames = cmd.options.map((o) => o.long);
+    expect(optionNames).toContain("--config");
     expect(optionNames).toContain("--profile");
     expect(optionNames).toContain("--verbose");
     expect(optionNames).toContain("--debug");
@@ -32,12 +33,21 @@ describe("addInheritableOptions", () => {
     const scaOption = cmd.options.find((o) => o.long === "--sca-method");
     expect(scaOption?.hidden).toBe(true);
   });
+
+  it("does NOT hide --config from help (visible flag)", () => {
+    const cmd = new Command("test");
+    addInheritableOptions(cmd);
+
+    const configOption = cmd.options.find((o) => o.long === "--config");
+    expect(configOption?.hidden).toBeFalsy();
+  });
 });
 
 describe("resolveGlobalOptions", () => {
   function createProgram(): Command {
     const program = new Command();
     program
+      .addOption(new Option("--config <path>", "config file path"))
       .addOption(new Option("-p, --profile <name>", "configuration profile"))
       .addOption(new Option("-o, --output <format>", "output format").default("table"))
       .addOption(new Option("--verbose", "verbose output"))
@@ -142,5 +152,226 @@ describe("resolveGlobalOptions", () => {
 
     await program.parseAsync(["node", "test", "group", "sub", "--profile", "deep"]);
     expect(resolved["profile"]).toBe("deep");
+  });
+
+  it("resolves --config from global position", async () => {
+    const program = createProgram();
+    const sub = program.command("sub");
+    addInheritableOptions(sub);
+
+    let resolved: Record<string, unknown> = {};
+    sub.action((_opts: unknown, cmd: Command) => {
+      resolved = resolveGlobalOptions(cmd);
+    });
+
+    await program.parseAsync(["node", "test", "--config", "/path/to/config.yaml", "sub"]);
+    expect(resolved["config"]).toBe("/path/to/config.yaml");
+  });
+
+  it("resolves --config from subcommand position", async () => {
+    const program = createProgram();
+    const sub = program.command("sub");
+    addInheritableOptions(sub);
+
+    let resolved: Record<string, unknown> = {};
+    sub.action((_opts: unknown, cmd: Command) => {
+      resolved = resolveGlobalOptions(cmd);
+    });
+
+    await program.parseAsync(["node", "test", "sub", "--config", "/path/to/config.yaml"]);
+    expect(resolved["config"]).toBe("/path/to/config.yaml");
+  });
+
+  it("gives subcommand-level --config precedence over global", async () => {
+    const program = createProgram();
+    const sub = program.command("sub");
+    addInheritableOptions(sub);
+
+    let resolved: Record<string, unknown> = {};
+    sub.action((_opts: unknown, cmd: Command) => {
+      resolved = resolveGlobalOptions(cmd);
+    });
+
+    await program.parseAsync(["node", "test", "--config", "/global.yaml", "sub", "--config", "/local.yaml"]);
+    expect(resolved["config"]).toBe("/local.yaml");
+  });
+});
+
+describe("buildResolveOptions", () => {
+  class StreamCapture {
+    chunks: string[] = [];
+    write(chunk: string): boolean {
+      this.chunks.push(chunk);
+      return true;
+    }
+  }
+
+  it("returns empty when neither --config nor --profile is set", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions({}, { stderr: stderr as unknown as NodeJS.WritableStream });
+    expect(result).toEqual({});
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("returns { profile } when only --profile is set", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { profile: "work" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ profile: "work" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("returns { path } when only --config is set", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it('treats --config "" (empty string) as if --config were not supplied', () => {
+    // Defensive guard: `--config "$UNSET_VAR"` from a shell evaluates to
+    // `--config ""`. Without this handling, `path.resolve("")` returns CWD,
+    // which would silently re-introduce CWD-based config discovery (removed
+    // by #479/#480).
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({});
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it('treats --config "" alongside --profile as just --profile', () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "", profile: "work" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ profile: "work" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("warns and returns { path } when --config differs from QONTOCTL_CONFIG_FILE env", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml" },
+      {
+        home: "/home/user",
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        stderr: stderr as unknown as NodeJS.WritableStream,
+      },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml" });
+    expect(stderr.chunks).toHaveLength(1);
+    expect(stderr.chunks[0]).toContain("--config");
+    expect(stderr.chunks[0]).toContain("QONTOCTL_CONFIG_FILE");
+    expect(stderr.chunks[0]).toContain("/from-env.yaml");
+  });
+
+  it("does NOT warn when --config matches QONTOCTL_CONFIG_FILE env", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/same/path.yaml" },
+      {
+        home: "/home/user",
+        env: { QONTOCTL_CONFIG_FILE: "/same/path.yaml" },
+        stderr: stderr as unknown as NodeJS.WritableStream,
+      },
+    );
+    expect(result).toEqual({ path: "/same/path.yaml" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("ignores empty QONTOCTL_CONFIG_FILE env (no warning)", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml" },
+      {
+        home: "/home/user",
+        env: { QONTOCTL_CONFIG_FILE: "" },
+        stderr: stderr as unknown as NodeJS.WritableStream,
+      },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("warns and returns { path, profile } when --config differs from --profile-derived path", () => {
+    // Profile is preserved so QONTOCTL_<PROFILE>_* env overrides continue to apply
+    // and core's resolveConfig validates the profile name. --config wins for FILE
+    // selection only, not for the entire profile semantics.
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml", profile: "work" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml", profile: "work" });
+    expect(stderr.chunks).toHaveLength(1);
+    expect(stderr.chunks[0]).toContain("--config");
+    expect(stderr.chunks[0]).toContain("--profile");
+    expect(stderr.chunks[0]).toContain("work");
+    // Warning text mentions the env-prefix preservation so users aren't surprised
+    expect(stderr.chunks[0]).toContain("QONTOCTL_WORK_*");
+  });
+
+  it("does NOT warn when --config matches --profile-derived path", () => {
+    // Path matches — no warning. Profile is still preserved so env-prefix applies.
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/home/user/.qontoctl/work.yaml", profile: "work" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ path: "/home/user/.qontoctl/work.yaml", profile: "work" });
+    expect(stderr.chunks).toEqual([]);
+  });
+
+  it("emits both warnings when --config conflicts with both env and --profile", () => {
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml", profile: "work" },
+      {
+        home: "/home/user",
+        env: { QONTOCTL_CONFIG_FILE: "/from-env.yaml" },
+        stderr: stderr as unknown as NodeJS.WritableStream,
+      },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml", profile: "work" });
+    expect(stderr.chunks).toHaveLength(2);
+    expect(stderr.chunks.some((c) => c.includes("QONTOCTL_CONFIG_FILE"))).toBe(true);
+    expect(stderr.chunks.some((c) => c.includes("--profile"))).toBe(true);
+  });
+
+  it("preserves profile-with-hyphens correctly in warning text (env-var name normalization)", () => {
+    // Profile name "my-work" becomes "QONTOCTL_MY_WORK_*" in env-var prefix
+    // (hyphens replaced with underscores per core's prefix convention).
+    const stderr = new StreamCapture();
+    const result = buildResolveOptions(
+      { config: "/explicit/config.yaml", profile: "my-work" },
+      { home: "/home/user", env: {}, stderr: stderr as unknown as NodeJS.WritableStream },
+    );
+    expect(result).toEqual({ path: "/explicit/config.yaml", profile: "my-work" });
+    expect(stderr.chunks[0]).toContain("QONTOCTL_MY_WORK_*");
+  });
+
+  it("compares paths in resolved (absolute) form, not literal", () => {
+    // If --config is relative and resolves to the same absolute path as the env, no warning.
+    const stderr = new StreamCapture();
+    const cwd = process.cwd();
+    const result = buildResolveOptions(
+      { config: "./config.yaml" },
+      {
+        home: "/home/user",
+        env: { QONTOCTL_CONFIG_FILE: `${cwd}/config.yaml` },
+        stderr: stderr as unknown as NodeJS.WritableStream,
+      },
+    );
+    expect(result).toEqual({ path: "./config.yaml" });
+    expect(stderr.chunks).toEqual([]);
   });
 });

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -1,15 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { homedir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import { Option } from "commander";
+import type { GlobalOptions } from "./options.js";
 
 /**
- * Adds inheritable global options (--profile, --verbose, --debug) to a command.
+ * Adds inheritable global options (--config, --profile, --verbose, --debug) to a command.
  * These mirror the program-level options so users can specify them after the subcommand.
  */
 export function addInheritableOptions(cmd: Command): Command {
   return cmd
+    .addOption(
+      new Option("--config <path>", "path to configuration file (overrides --profile and QONTOCTL_CONFIG_FILE)"),
+    )
     .addOption(new Option("-p, --profile <name>", "configuration profile to use"))
     .addOption(new Option("--verbose", "enable verbose output"))
     .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
@@ -39,4 +45,89 @@ export function resolveGlobalOptions<T>(cmd: Command): T {
   // reduceRight processes [this, parent, root] as root → parent → this,
   // so leaf options overwrite parent options via Object.assign.
   return chain.reduceRight<Record<string, unknown>>((combined, c) => Object.assign(combined, c.opts()), {}) as T;
+}
+
+/**
+ * CLI-level config resolver inputs derived from {@link GlobalOptions} — the
+ * shape consumed by `@qontoctl/core`'s `resolveConfig({ path, profile })`.
+ *
+ * Returned object intentionally omits keys instead of setting them to
+ * `undefined`, so callers can spread it directly without violating
+ * `exactOptionalPropertyTypes`.
+ */
+export interface ConfigResolveSelection {
+  path?: string;
+  profile?: string;
+}
+
+/**
+ * Translates {@link GlobalOptions} into the resolver-input shape and enforces
+ * the documented precedence: `--config` > `QONTOCTL_CONFIG_FILE` env > `--profile`
+ * derived path > `~/.qontoctl.yaml`.
+ *
+ * When `--config` is supplied alongside ambient `QONTOCTL_CONFIG_FILE` env
+ * or a `--profile` flag, the resolver paths are compared in absolute form:
+ * if they disagree, a one-line stderr warning is emitted and `--config` wins
+ * for FILE selection. Matching paths produce no warning. This makes the
+ * silent-override path visible to users while preserving the conventional
+ * CLI > env > profile precedence.
+ *
+ * **Profile is preserved when supplied alongside `--config`** so that:
+ *   - `QONTOCTL_<PROFILE>_*` env-var overrides continue to apply (per README
+ *     § Resolution Order — profile controls the env-prefix scope, not just
+ *     the file location).
+ *   - `isValidProfileName()` runs inside core's resolver, rejecting
+ *     malformed profile names early (defense-in-depth — the bad name is
+ *     never used to load files because `--config` wins, but the validation
+ *     surfaces the typo to the user).
+ *
+ * The env-var (`QONTOCTL_CONFIG_FILE`) tier is otherwise handled inside core's
+ * resolver: when neither `--config` nor `--profile` is supplied, the env var
+ * is consulted automatically.
+ */
+export function buildResolveOptions(
+  opts: Pick<GlobalOptions, "config" | "profile">,
+  options?: { home?: string; env?: Record<string, string | undefined>; stderr?: NodeJS.WritableStream },
+): ConfigResolveSelection {
+  const { profile } = opts;
+  // Treat `--config ""` (empty string — typically from `--config "$UNSET_VAR"`)
+  // as if `--config` were not supplied. Without this guard, `path.resolve("")`
+  // returns the CWD, which would silently re-introduce CWD-based config
+  // discovery (the exact behavior #479/#480 deliberately removed).
+  const config = opts.config !== undefined && opts.config !== "" ? opts.config : undefined;
+  if (config === undefined) {
+    return profile === undefined ? {} : { profile };
+  }
+  // `--config` is set. Warn on any silent-override of an ambient source.
+  const stream = options?.stderr ?? process.stderr;
+  const env = options?.env ?? (process.env as Record<string, string | undefined>);
+  const home = options?.home ?? homedir();
+  const configResolved = resolvePath(config);
+
+  const envPath = env["QONTOCTL_CONFIG_FILE"];
+  if (envPath !== undefined && envPath !== "") {
+    const envResolved = resolvePath(envPath);
+    if (envResolved !== configResolved) {
+      stream.write(
+        `warning: --config "${config}" overrides QONTOCTL_CONFIG_FILE="${envPath}" (resolved path differs). ` +
+          `To silence: unset QONTOCTL_CONFIG_FILE or omit --config.\n`,
+      );
+    }
+  }
+
+  if (profile !== undefined) {
+    const profileDerived = resolvePath(join(home, ".qontoctl", `${profile}.yaml`));
+    if (profileDerived !== configResolved) {
+      stream.write(
+        `warning: --config "${config}" overrides --profile "${profile}" path (resolved path differs from "${profileDerived}"). ` +
+          `Profile-scoped env vars (QONTOCTL_${profile.toUpperCase().replaceAll("-", "_")}_*) still apply. ` +
+          `To silence: omit --profile or omit --config.\n`,
+      );
+    }
+    // Preserve profile so env overlay continues to use the QONTOCTL_<PROFILE>_*
+    // prefix and core's resolver validates the profile name.
+    return { path: config, profile };
+  }
+
+  return { path: config };
 }

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -15,6 +15,16 @@ export const OUTPUT_FORMATS: readonly OutputFormat[] = ["table", "json", "yaml",
  * Global CLI options parsed from Commander.
  */
 export interface GlobalOptions {
+  /**
+   * Explicit path to a YAML config file (any filename — `.qontoctl.yaml` is the
+   * default name when discovered via env/profile/home, but any path is accepted
+   * here). Highest-priority resolver input — overrides {@link profile} and the
+   * `QONTOCTL_CONFIG_FILE` env var. When both `--config` and `--profile` are
+   * supplied, `--config` wins for FILE selection; a warning is emitted on stderr
+   * if the resolved paths disagree, and the profile is preserved so
+   * `QONTOCTL_<PROFILE>_*` env-var overrides continue to apply.
+   */
+  readonly config?: string | undefined;
   readonly profile?: string | undefined;
   readonly output: OutputFormat;
   readonly verbose?: true | undefined;

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -266,6 +266,22 @@ describe("createProgram", () => {
   });
 
   describe("global options", () => {
+    it("parses --config option", () => {
+      const program = parseGlobalOptions(["--config", "/path/to/config.yaml"]);
+      expect(program.opts()["config"]).toBe("/path/to/config.yaml");
+    });
+
+    it("parses --config with relative path", () => {
+      const program = parseGlobalOptions(["--config", "./local.yaml"]);
+      expect(program.opts()["config"]).toBe("./local.yaml");
+    });
+
+    it("includes --config in help output", () => {
+      const program = createProgram();
+      const helpText = program.helpInformation();
+      expect(helpText).toContain("--config");
+    });
+
     it("parses --profile option", () => {
       const program = parseGlobalOptions(["--profile", "work"]);
       expect(program.opts()["profile"]).toBe("work");

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -35,6 +35,9 @@ export function createProgram(): Command {
   program.name("qontoctl").description("The complete CLI & MCP for Qonto").version(packageJson.version);
 
   program
+    .addOption(
+      new Option("--config <path>", "path to configuration file (overrides --profile and QONTOCTL_CONFIG_FILE)"),
+    )
     .addOption(new Option("-p, --profile <name>", "configuration profile to use"))
     .addOption(new Option("-o, --output <format>", "output format").choices([...OUTPUT_FORMATS]).default("table"))
     .addOption(new Option("--verbose", "enable verbose output"))

--- a/packages/e2e/src/profile/config-resolution.e2e.test.ts
+++ b/packages/e2e/src/profile/config-resolution.e2e.test.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * E2E coverage for the CLI's `--config` flag, `QONTOCTL_CONFIG_FILE` env var,
+ * and their precedence rules (issue #480). These run without network: each
+ * test points the resolver at an empty YAML file and asserts the resolver
+ * surfaces THAT file's path in its `NO_CREDS` error — proof of which file
+ * was actually loaded.
+ *
+ * Resolution precedence under test:
+ *   `--config` > `QONTOCTL_CONFIG_FILE` env > `--profile` derived path > `~/.qontoctl.yaml`
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+
+/**
+ * Build a clean subprocess env (no parent QONTOCTL_* leaking through). The
+ * E2E harness usually injects QONTOCTL_CONFIG_FILE into the parent env; we
+ * deliberately omit it here so the precedence tests start from a known
+ * baseline.
+ */
+function isolatedEnv(homeDir: string, extra?: Record<string, string>): Record<string, string> {
+  return {
+    PATH: process.env["PATH"] ?? "",
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    ...extra,
+  };
+}
+
+function cli(
+  args: string[],
+  options: { env: Record<string, string>; cwd?: string },
+): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: options.env,
+    cwd: options.cwd,
+    timeout: 15_000,
+  });
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.status ?? 1,
+  };
+}
+
+describe("CLI config resolution (--config + QONTOCTL_CONFIG_FILE) (e2e)", () => {
+  let scratchDir: string;
+  let homeDir: string;
+  let configA: string;
+  let configB: string;
+
+  beforeAll(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), "qontoctl-config-e2e-"));
+    homeDir = join(scratchDir, "home");
+    mkdirSync(homeDir, { recursive: true });
+
+    // Two distinct empty YAML files — empty so the loader succeeds but the
+    // resolver's NO_CREDS branch fires with the explicit path interpolated
+    // into the error message ("Explicit path \"X\" was loaded but contains
+    // no credentials."). The path in the error is the proof of which file
+    // was loaded.
+    configA = join(scratchDir, "config-a.yaml");
+    configB = join(scratchDir, "config-b.yaml");
+    writeFileSync(configA, "{}\n");
+    writeFileSync(configB, "{}\n");
+
+    // Profile "work" lives at $HOME/.qontoctl/work.yaml — also empty, so
+    // the same NO_CREDS error surfaces with the profile-derived path.
+    const profileDir = join(homeDir, ".qontoctl");
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(join(profileDir, "work.yaml"), "{}\n");
+  });
+
+  afterAll(() => {
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  // AC: --config <abs-path> plumbs through to the resolver and selects that file.
+  it("--config selects the explicit file (path appears in NO_CREDS error)", () => {
+    const { stderr, exitCode } = cli(["--config", configA, "auth", "status"], {
+      env: isolatedEnv(homeDir),
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(configA);
+  });
+
+  // AC: QONTOCTL_CONFIG_FILE alone (no --config) selects the env-pointed file.
+  it("QONTOCTL_CONFIG_FILE selects the env-pointed file", () => {
+    const { stderr, exitCode } = cli(["auth", "status"], {
+      env: isolatedEnv(homeDir, { QONTOCTL_CONFIG_FILE: configA }),
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(configA);
+  });
+
+  // AC: --config wins over QONTOCTL_CONFIG_FILE (CLI > env precedence).
+  it("--config overrides QONTOCTL_CONFIG_FILE when both are set", () => {
+    const { stderr, exitCode } = cli(["--config", configB, "auth", "status"], {
+      env: isolatedEnv(homeDir, { QONTOCTL_CONFIG_FILE: configA }),
+    });
+    expect(exitCode).not.toBe(0);
+    // Resolver loaded configB (the --config target), not configA (the env).
+    expect(stderr).toContain(configB);
+    // Stderr also carries the override warning so the user sees the override.
+    expect(stderr).toMatch(/--config.*overrides QONTOCTL_CONFIG_FILE/);
+  });
+
+  // AC: --config wins over --profile when paths differ; warning emitted.
+  it("--config overrides --profile when paths differ (warns on stderr)", () => {
+    const { stderr, exitCode } = cli(["--config", configA, "--profile", "work", "auth", "status"], {
+      env: isolatedEnv(homeDir),
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(configA);
+    expect(stderr).toMatch(/--config.*overrides --profile/);
+    expect(stderr).toContain("work");
+  });
+
+  // AC: --profile alone (no --config, no env) selects ~/.qontoctl/{name}.yaml.
+  // The NO_CREDS error message renders the profile-derived path with literal
+  // tilde notation (e.g. "~/.qontoctl/work.yaml"), not the expanded absolute
+  // path — that's the proof of which resolver branch fired.
+  it("--profile alone selects the profile-derived path", () => {
+    const { stderr, exitCode } = cli(["--profile", "work", "auth", "status"], {
+      env: isolatedEnv(homeDir),
+    });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("~/.qontoctl/work.yaml");
+  });
+
+  // CWD-discovery removed by #479 — verify the CLI does NOT load a
+  // .qontoctl.yaml in CWD even when one exists there.
+  it("does NOT auto-discover config from CWD (#479 contract)", () => {
+    const cwdDir = mkdtempSync(join(tmpdir(), "qontoctl-cwd-"));
+    try {
+      writeFileSync(join(cwdDir, ".qontoctl.yaml"), "api-key:\n  organization-slug: cwd-org\n  secret-key: cwd-key\n");
+      // HOME is the populated `homeDir` (with `~/.qontoctl/work.yaml`), but no
+      // `--profile` flag is passed and there's no `~/.qontoctl.yaml` at the home
+      // root, so resolution falls through to the home default (which is missing).
+      // The CWD file is the only credential source available — if CWD discovery
+      // were still active, the CLI would succeed; we assert it does NOT.
+      const { stderr, exitCode } = cli(["auth", "status"], {
+        env: isolatedEnv(homeDir),
+        cwd: cwdDir,
+      });
+      expect(exitCode).not.toBe(0);
+      // Error references the home default, not the CWD file.
+      expect(stderr).not.toContain(join(cwdDir, ".qontoctl.yaml"));
+    } finally {
+      rmSync(cwdDir, { recursive: true, force: true });
+    }
+  });
+
+  // Negative: error message guides the user to --config when nothing is set.
+  it("emits actionable error referencing --config when no config source is available", () => {
+    const emptyHome = mkdtempSync(join(tmpdir(), "qontoctl-config-empty-"));
+    try {
+      const { stderr, exitCode } = cli(["auth", "status"], {
+        env: isolatedEnv(emptyHome),
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("--config");
+    } finally {
+      rmSync(emptyHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add `--config <path>` global CLI flag with full path round-trip — closes the user-facing seam left by #479's core config resolution refactor.

Closes #480.

## Approach

A single helper `buildResolveOptions(opts, options?)` in `inherited-options.ts` centralizes precedence and warning logic. All CLI call sites consume it; no per-site duplication.

**Precedence**: `--config` > `QONTOCTL_CONFIG_FILE` env > `--profile`-derived path > `~/.qontoctl.yaml` (mirrors core API; conventional CLI > env per kubectl/aws/gcloud/git/terraform).

**Warning behavior**: When `--config` is set alongside an ambient `QONTOCTL_CONFIG_FILE` env or conflicting `--profile` AND the resolved absolute paths disagree, a one-line stderr warning is emitted with explicit "to silence" guidance. Matching paths produce no warning.

## Changes

| Layer | File | Change |
|---|---|---|
| Type | `packages/cli/src/options.ts` | Add `config?: string` to `GlobalOptions` |
| Program | `packages/cli/src/program.ts` | Register `--config <path>` global option (before `--profile`) |
| Inheritable | `packages/cli/src/inherited-options.ts` | Add `--config` to `addInheritableOptions`; new `buildResolveOptions(opts, options?)` helper |
| Plumbing | `client.ts`, `commands/auth.ts`, `commands/sca-session/mock-decision.ts`, `commands/profile/test.ts` | Thread `buildResolveOptions(opts)` to `resolveConfig({...})` |
| Auth round-trip | `commands/auth.ts` | `resolveOAuthConfig(opts)` accepts `Pick<GlobalOptions, "config" \| "profile">`; existing `buildWriteOptions(loadedPath, profile)` round-trips path back to writers |
| Docs | `CLAUDE.md`, `README.md` | Drop "(After #480 ships)" parenthetical; rewrite Resolution Order section |

## Tests

- **Unit (+18 net)**: `program.test.ts` (3 — `--config` parsing, help inclusion), `inherited-options.test.ts` (3 inheritance + 10 helper precedence/warning), `auth.test.ts` (5 — round-trip for setup/login/refresh/revoke + env-only round-trip without `--config` flag)
- **E2E (new file)**: `packages/e2e/src/profile/config-resolution.e2e.test.ts` (7 tests, no network) — verifies all 4 AC integration bullets via empty-YAML / NO_CREDS-error proof: `--config` selection, env selection, `--config` > env, `--config` > `--profile`, profile-derived selection, no CWD discovery (#479 contract preserved), actionable error when nothing configured

## Out of scope

- Internal core changes (covered by #479 — already landed)
- E2E test plumbing (next issue, depends on this)
- Adding a `--local` sugar flag (deferred until demand)

## Council outcome

Convened a 3-agent council (cicd-architect / ux-architect / technical-architect) on the precedence question raised mid-implementation: "Should `--config` override `QONTOCTL_CONFIG_FILE`, or vice versa?" CONVERGENT-HIGH-CONFIDENCE on `--config` > env. Decisive arguments:

- **Internal consistency** — AC already specifies `--config` > `--profile`; inverting `env > --config` would create non-monotonic precedence.
- **Core/CLI symmetry** — #479 already commits the core API to `path > env`; CLI must mirror.
- **Failure-mode asymmetry** — `--config sandbox.yaml` with `QONTOCTL_CONFIG_FILE=prod.yaml` set: with CLI > env, user gets sandbox (asked for); with env > CLI, silently hits prod.

Adopted enhancement from cicd-architect: emit stderr warning when `--config` ≠ `QONTOCTL_CONFIG_FILE` env (symmetric to existing `--config` ≠ `--profile` warning). Included.

## Validation

Two-iteration adversarial validation via fresh-context dispatch (subprocesses `beeb9e1d-...` then `5eeecd32-...` after acting on findings):

- **Iter 1**: 0 blocking, 3 non-blocking findings. Acted: added env→write round-trip unit test (AC10/AC11 PARTIAL), polished warning text with "to silence" guidance (Adversarial-E), filed follow-up #503 (Adversarial-D — UX gap, not security).
- **Iter 2**: CLEAN. All findings addressed, no regressions.

Polish via fresh-context dispatch (subprocess `756dd274-...`): 2 improvements applied — collapsed three sequential `if (config === undefined)` branches into single early-return; extended E2E `cli()` helper to accept `cwd?: string`. Verdict CLEAN.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 707 unit tests pass (84 files)
- [x] `pnpm license-check` — 100 prod deps, all allowed
- [x] New E2E file `config-resolution.e2e.test.ts` — 7/7 pass
- [x] Full E2E baseline check — 24 failures match pre-change baseline (OAuth/sandbox suites with pre-existing API issues, unrelated to #480)

## Follow-up

- #503: validate `--profile` name even when dropped by `--config` override (UX gap; not blocking)