### PR TITLE
(refactor) E2E sandbox: explicit config path injection (#481)

### DIFF
--- a/packages/e2e/src/attachments/cli.e2e.test.ts
+++ b/packages/e2e/src/attachments/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { AttachmentSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 

--- a/packages/e2e/src/attachments/mcp.e2e.test.ts
+++ b/packages/e2e/src/attachments/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { AttachmentSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -46,7 +46,6 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -8,7 +8,7 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -25,7 +25,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 
@@ -111,7 +110,7 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () =
             "--debit-account",
             accountId,
           ],
-          { env: cliEnv(), cwd: cliCwd(), stdio: ["ignore", "pipe", "pipe"] },
+          { env: cliEnv(), stdio: ["ignore", "pipe", "pipe"] },
         );
 
         let stdout = "";
@@ -140,7 +139,6 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () =
               scaToken = match[1];
               approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
                 env: cliEnv(),
-                cwd: cliCwd(),
                 timeout: 25_000,
               });
               approvePromise.catch(() => {});

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -52,7 +52,6 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
       // stderr — the create test extracts the SCA token from there.
       args: [CLI_PATH, "--verbose", "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { CardSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { CardListResponseSchema, CardSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -42,7 +42,6 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { ClientInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientInvoiceListResponseSchema, ClientInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/clients/cli.e2e.test.ts
+++ b/packages/e2e/src/clients/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { ClientSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/clients/mcp.e2e.test.ts
+++ b/packages/e2e/src/clients/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientListResponseSchema, ClientSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/beneficiary.e2e.test.ts
+++ b/packages/e2e/src/commands/beneficiary.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { BeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/credit-note.e2e.test.ts
+++ b/packages/e2e/src/commands/credit-note.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { CreditNoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { LabelSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-beneficiaries.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BeneficiaryListResponseSchema, BeneficiarySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -30,7 +30,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP beneficiary tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-labels-memberships.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { LabelListResponseSchema, LabelSchema, MembershipListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -30,7 +30,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP label & membership tools (e2e)", (
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PaymentLinkListResponseSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/mcp-requests.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-requests.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RequestListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP request tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { MembershipSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -17,7 +17,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/payment-link.e2e.test.ts
+++ b/packages/e2e/src/commands/payment-link.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { PaymentLinkSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/request.e2e.test.ts
+++ b/packages/e2e/src/commands/request.e2e.test.ts
@@ -5,14 +5,13 @@ import { type ExecFileSyncOptionsWithStringEncoding, execFileSync } from "node:c
 import { resolve } from "node:path";
 import { RequestSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 const execOpts: ExecFileSyncOptionsWithStringEncoding = {
   encoding: "utf-8",
   env: cliEnv(),
-  cwd: cliCwd(),
   timeout: 15_000,
 };
 

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 

--- a/packages/e2e/src/einvoicing/mcp.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,6 @@ describe.skipIf(!hasOAuthCredentials())("e-invoicing MCP (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -12,7 +12,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,7 +18,6 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", ()
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlEligibilityResponseSchema, IntlCurrencySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlBeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -12,7 +12,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -7,7 +7,7 @@ import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -147,7 +147,6 @@ describe("MCP server via stdio (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
     client = new Client({ name: "e2e-test", version: "0.0.0" });

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -15,7 +15,6 @@ function cli(args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,6 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/quotes/cli.e2e.test.ts
+++ b/packages/e2e/src/quotes/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { QuoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { QuoteListResponseSchema, QuoteSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -23,7 +23,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 
@@ -49,7 +48,6 @@ interface SpawnWithScaResult {
 async function spawnWithScaApproval(...args: string[]): Promise<SpawnWithScaResult> {
   const child = spawn("node", [CLI_PATH, "--verbose", "--output", "json", ...args], {
     env: cliEnv(),
-    cwd: cliCwd(),
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -79,7 +77,6 @@ async function spawnWithScaApproval(...args: string[]): Promise<SpawnWithScaResu
         scaToken = match[1];
         approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
           env: cliEnv(),
-          cwd: cliCwd(),
           timeout: 25_000,
         });
         approvePromise.catch(() => {});

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -52,7 +52,6 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       // stderr — sandbox SCA tests extract the token from there.
       args: [CLI_PATH, "--verbose", "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -2,23 +2,25 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { readFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
 
-/**
- * Absolute path to the repo-root `.qontoctl.yaml`, computed once from this
- * module's own location. Used to inject `QONTOCTL_CONFIG_FILE` into spawned
- * CLI subprocesses so they hit the repo's config file without relying on
- * CWD inspection (which the resolver no longer does, post #479).
- *
- * The walk-up helpers below (`findConfigDir`, `cliCwd`, the loop in
- * `readConfigFileCredentials`) remain in place for in-process credential
- * detection used by `hasApiKeyCredentials()`/`hasOAuthCredentials()`/
- * `hasStagingToken()` — those parse YAML directly and don't go through the
- * resolver. The full walk-up removal is scoped to #481.
- */
 const REPO_ROOT_CONFIG_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", ".qontoctl.yaml");
+
+/**
+ * Return the absolute path to the repo-root `.qontoctl.yaml`. Computed once
+ * at module load via `import.meta.url`, so it is independent of process CWD.
+ *
+ * Used both for in-process credential detection (`hasApiKeyCredentials()` /
+ * `hasOAuthCredentials()` / `hasStagingToken()` / `getCredentials()`) and for
+ * `cliEnv()` to inject `QONTOCTL_CONFIG_FILE` into spawned CLI subprocesses,
+ * so the harness no longer relies on CWD-walking heuristics (the resolver
+ * dropped CWD discovery in #479).
+ */
+export function cliConfigPath(): string {
+  return REPO_ROOT_CONFIG_PATH;
+}
 
 interface ConfigCredentials {
   readonly organizationSlug?: string;
@@ -29,27 +31,12 @@ interface ConfigCredentials {
 }
 
 /**
- * Read credentials from `.qontoctl.yaml`, searching from the
- * working directory up to the filesystem root. Returns `undefined` if
- * no config file with credentials is found.
+ * Read credentials from the repo-root `.qontoctl.yaml`. Returns `undefined`
+ * if the file is absent, unreadable, or contains no recognized credentials.
  */
 function readConfigFileCredentials(): ConfigCredentials | undefined {
-  let dir = process.cwd();
-  for (;;) {
-    const result = tryReadConfigFile(join(dir, ".qontoctl.yaml"));
-    if (result !== undefined) {
-      return result;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return undefined;
-}
-
-function tryReadConfigFile(path: string): ConfigCredentials | undefined {
   try {
-    const content = readFileSync(path, "utf-8");
+    const content = readFileSync(REPO_ROOT_CONFIG_PATH, "utf-8");
     const parsed: unknown = parseYaml(content);
     if (typeof parsed !== "object" || parsed === null) {
       return undefined;
@@ -98,9 +85,8 @@ function tryReadConfigFile(path: string): ConfigCredentials | undefined {
 
     return hasAnyCreds ? result : undefined;
   } catch {
-    // File not found or unreadable
+    return undefined;
   }
-  return undefined;
 }
 
 /**
@@ -195,25 +181,6 @@ export function getCredentials(): ConfigCredentials {
 }
 
 /**
- * Find the directory containing `.qontoctl.yaml` by walking upward
- * from CWD. Returns `undefined` if no config file is found.
- */
-function findConfigDir(): string | undefined {
-  let dir = process.cwd();
-  for (;;) {
-    try {
-      readFileSync(join(dir, ".qontoctl.yaml"), "utf-8");
-      return dir;
-    } catch {
-      // not found, try parent
-    }
-    const parent = dirname(dir);
-    if (parent === dir) return undefined;
-    dir = parent;
-  }
-}
-
-/**
  * Build an environment for spawning CLI child processes.
  *
  * Injects `QONTOCTL_CONFIG_FILE=<repo-root>/.qontoctl.yaml` so the CLI
@@ -229,16 +196,7 @@ function findConfigDir(): string | undefined {
 export function cliEnv(): Record<string, string> {
   const env = { ...(process.env as Record<string, string>) };
   if (env["QONTOCTL_CONFIG_FILE"] === undefined || env["QONTOCTL_CONFIG_FILE"] === "") {
-    env["QONTOCTL_CONFIG_FILE"] = REPO_ROOT_CONFIG_PATH;
+    env["QONTOCTL_CONFIG_FILE"] = cliConfigPath();
   }
   return env;
-}
-
-/**
- * Return the CWD to use for CLI child processes so they can
- * discover `.qontoctl.yaml` via the config loader. Falls back
- * to the current CWD when no config file is found in parent dirs.
- */
-export function cliCwd(): string {
-  return findConfigDir() ?? process.cwd();
 }

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -44,7 +44,6 @@ function cliSync(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 25_000,
   });
 }
@@ -111,7 +110,6 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       ],
       {
         env: cliEnv(),
-        cwd: cliCwd(),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
@@ -146,7 +144,6 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
           // primary child (filling the OS pipe buffer would deadlock it).
           approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
             env: cliEnv(),
-            cwd: cliCwd(),
             timeout: 25_000,
           });
           // Attach a no-op error handler to avoid an "unhandled rejection"

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -8,7 +8,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -76,7 +76,6 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       command: "node",
       args: [CLI_PATH, "--verbose", "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -14,7 +14,6 @@ function listStatements(): Record<string, unknown>[] {
   const output = execFileSync("node", [CLI_PATH, "statement", "list", "--no-paginate", "-o", "json"], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
   return JSON.parse(output) as Record<string, unknown>[];
 }
@@ -48,7 +47,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const filteredOutput = execFileSync(
         "node",
         [CLI_PATH, "statement", "list", "--bank-account", bankAccountId, "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv(), cwd: cliCwd() },
+        { encoding: "utf-8", env: cliEnv() },
       );
       const filteredRows = JSON.parse(filteredOutput) as Record<string, unknown>[];
 
@@ -61,7 +60,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const output = execFileSync(
         "node",
         [CLI_PATH, "statement", "list", "--from", "01-2025", "--to", "12-2025", "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv(), cwd: cliCwd() },
+        { encoding: "utf-8", env: cliEnv() },
       );
 
       // The command should succeed; results may be empty if no statements in range
@@ -82,7 +81,6 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const showOutput = execFileSync("node", [CLI_PATH, "statement", "show", statementId, "-o", "json"], {
         encoding: "utf-8",
         env: cliEnv(),
-        cwd: cliCwd(),
       });
       const showRows = JSON.parse(showOutput) as Record<string, unknown>[];
       expect(showRows).toHaveLength(1);
@@ -141,7 +139,6 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       execFileSync("node", [CLI_PATH, "statement", "download", statementId, "--output-dir", outputDir], {
         encoding: "utf-8",
         env: cliEnv(),
-        cwd: cliCwd(),
       });
 
       const downloadedFile = join(outputDir, expectedFileName);

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StatementListResponseSchema, StatementSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,7 +19,6 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { SupplierInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SupplierInvoiceListResponseSchema, SupplierInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -27,7 +27,6 @@ describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () 
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/teams/cli.e2e.test.ts
+++ b/packages/e2e/src/teams/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TeamSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/teams/mcp.e2e.test.ts
+++ b/packages/e2e/src/teams/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TeamListResponseSchema, TeamSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -41,7 +41,6 @@ describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TransactionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransactionListResponseSchema, TransactionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -39,7 +39,6 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
   });
 }
 

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -38,7 +38,6 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { WebhookSubscriptionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -13,7 +13,6 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
-    cwd: cliCwd(),
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliCwd, cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -42,7 +42,6 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       command: "node",
       args: [CLI_PATH, "mcp"],
       env: cliEnv(),
-      cwd: cliCwd(),
       stderr: "pipe",
     });
 


### PR DESCRIPTION
## Summary

Companion to #479 + #480 — completes removal of CWD-walking heuristics from the E2E test harness. Closes #481.

- **`packages/e2e/src/sandbox.ts`**: drop `findConfigDir()` / `cliCwd()` / the upward-walking loop in `readConfigFileCredentials()`; add `cliConfigPath()` returning the absolute repo-root `.qontoctl.yaml` path computed via `import.meta.url`; preserve all credential-detection helpers' semantics.
- **53 `*.e2e.test.ts` files**: strip `cwd: cliCwd()` from `spawnSync` / `execFileSync` / `StdioClientTransport` call sites — subprocesses inherit `QONTOCTL_CONFIG_FILE` via `cliEnv()` (plumbed in #480).

Net diff: **54 files, +74 / -176**.

## Why this matters

- Removes the only remaining CWD-walking magic in the codebase.
- E2E tests become hermetic: no CWD dependency, no filesystem race.
- Aligns test config-discovery with the new CLI resolution rules (single source of truth for users + tests).

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` (unit) passes — 710 tests across 84 files
- [x] `pnpm test:e2e` produces an **identical pass/fail signature to `main`**: 8 failed test files | 24 passed | 27 skipped (Test Files), 24 failed | 110 passed | 121 skipped (Tests). The 24 failures are pre-existing and confined to OAuth + sandbox suites (cards, intl-beneficiaries, international, payment-link, insurance, sca-continuation), unrelated to config discovery. API-key-compatible suites (the CI scope) all pass.
- [x] No source-tree references to `findConfigDir` or `cliCwd` remain
- [x] `auth.e2e.test.ts` HOME-override pattern unaffected (it builds its own subprocess env via `homeEnv()` and never used `cliCwd`/`cliEnv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)