### PR TITLE
(feat) MCP QONTOCTL_CONFIG_FILE support; configuration docs (#482)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,21 @@ pnpm license-check    # Verify dependency licenses
 pnpm dev              # Watch mode
 ```
 
+## Configuration
+
+QontoCtl resolves its config file via a deterministic precedence chain (highest first):
+
+1. `--config <path>` CLI flag (CLI only)
+2. `QONTOCTL_CONFIG_FILE` env var (CLI **and** MCP server)
+3. `~/.qontoctl/{profile}.yaml` (when `--profile <name>` is passed)
+4. `~/.qontoctl.yaml` (home default)
+
+**No CWD discovery** — the resolver does not scan or walk up the working directory (removed in #479). For repo-local configs, use the `direnv` shim (`.envrc.example` → `.envrc`) that exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`, or pass `--config ./.qontoctl.yaml` per CLI invocation.
+
+The MCP server has no CLI flags, so `QONTOCTL_CONFIG_FILE` is its only mechanism for pointing at a non-default file. The path is captured at MCP startup.
+
+Full reference (per-field env overlay, profile semantics, migration guidance for users coming from pre-#479 builds): [`docs/configuration.md`](docs/configuration.md).
+
 ## Conventions
 
 ### Source Files

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 </details>
 
+#### Pointing MCP at a non-default config file
+
+The MCP server has no CLI flags. To load credentials from a config file other than `~/.qontoctl.yaml`, set `QONTOCTL_CONFIG_FILE` in the host's `env` block:
+
+```jsonc
+{
+    "mcpServers": {
+        "qontoctl": {
+            "command": "npx",
+            "args": ["qontoctl", "mcp"],
+            "env": {
+                "QONTOCTL_CONFIG_FILE": "/abs/path/to/qontoctl.yaml",
+            },
+        },
+    },
+}
+```
+
+The path is captured at server startup. See [`docs/configuration.md`](docs/configuration.md) for the full resolution chain.
+
 ### Available MCP Tools
 
 | Tool                            | Description                                                           |
@@ -461,6 +481,8 @@ When `--config` is supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and 
 
 - Without `--profile`: `QONTOCTL_*` env vars override file values
 - With `--profile acme`: `QONTOCTL_ACME_*` env vars override file values
+
+For the full reference (precedence rules per entry point, profile semantics, migration from CWD discovery), see [`docs/configuration.md`](docs/configuration.md).
 
 ### Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,184 @@
+# Configuration
+
+QontoCtl reads its configuration from a YAML file plus a fixed set of
+environment variables. This document is the canonical reference for the
+**file-resolution chain** (which file gets loaded), the **per-field overlay**
+(env vars that override file values), and the **migration story** for users
+coming from pre-`0.x` builds that walked the current directory.
+
+For credential format and authentication-method choice, see [`README.md`](../README.md#configuration)
+(API key vs. OAuth) and [`oauth-setup.md`](./oauth-setup.md). For sandbox-specific
+SCA setup, see [`sandbox-testing.md`](./sandbox-testing.md).
+
+## File resolution
+
+The resolver picks **exactly one** file (or no file, if env-only) using the
+following precedence — highest wins, no further inputs are consulted once a
+match is selected:
+
+| Priority | Source                         | Selected when                                     |
+| -------- | ------------------------------ | ------------------------------------------------- |
+| 1        | `--config <path>` CLI flag     | Flag is supplied (any non-empty string)           |
+| 2        | `QONTOCTL_CONFIG_FILE` env var | Env var is set to a non-empty string              |
+| 3        | `~/.qontoctl/{profile}.yaml`   | `--profile <name>` is supplied (and 1, 2 are not) |
+| 4        | `~/.qontoctl.yaml`             | Default — no flag, no env var, no profile         |
+
+> **No current-directory discovery.** The resolver does **not** scan the working
+> directory for `.qontoctl.yaml` and does not walk up the directory tree. This
+> behavior was removed in
+> [#479](https://github.com/alexey-pelykh/qontoctl/pull/502) to make the
+> load destination deterministic regardless of where you invoke `qontoctl` from.
+> See [Migration from CWD discovery](#migration-from-cwd-discovery) below.
+
+### How each entry point resolves the path
+
+- **CLI** (`qontoctl <command>`): walks priorities 1 → 4. When `--config` is
+  supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and the resolved
+  paths disagree, `--config` wins and a one-line stderr warning surfaces the
+  override.
+- **MCP server** (`qontoctl mcp`): no CLI flags exist. The server captures
+  `QONTOCTL_CONFIG_FILE` at **startup** and passes it to the resolver as the
+  `path` option (priority 1 in the table). Subsequent `process.env` mutations
+  cannot redirect later loads. With no env var set, the resolver falls through
+  to the home default at priority 4.
+- **E2E test harness** (`pnpm test:e2e`): the harness in
+  `packages/e2e/src/sandbox.ts` injects `QONTOCTL_CONFIG_FILE` into spawned
+  CLI subprocesses, pointing at the repo's `.qontoctl.yaml` (gitignored).
+  See [`e2e-testing.md`](./e2e-testing.md).
+
+## Profile semantics
+
+A **profile** is a named credential set. `--profile acme` controls two things:
+
+1. **The default file location** when neither `--config` nor
+   `QONTOCTL_CONFIG_FILE` is supplied: `~/.qontoctl/acme.yaml`.
+2. **The env-var prefix scope** for per-field overrides:
+   `QONTOCTL_ACME_*` instead of `QONTOCTL_*`. This still applies even when
+   `--config` overrides the file location, so `--profile acme --config /foo.yaml`
+   loads `/foo.yaml` but reads `QONTOCTL_ACME_ORGANIZATION_SLUG` for env overlay.
+
+Profile names must not contain path separators, parent-directory references
+(`..`), glob characters, or shadow reserved env-var suffixes. Invalid names
+are rejected with a `VALIDATION` error before any I/O.
+
+## Per-field environment variable overlay
+
+After a file is loaded (or skipped), the resolver overlays per-field env vars.
+Env vars carry **inputs** (static configuration the tool reads but never
+writes back); runtime-mutable state (refresh tokens, token expiry, granted
+scopes) lives in the file only.
+
+Without `--profile`:
+
+| Variable                     | Field                       | Notes                                            |
+| ---------------------------- | --------------------------- | ------------------------------------------------ |
+| `QONTOCTL_ORGANIZATION_SLUG` | `api-key.organization-slug` |                                                  |
+| `QONTOCTL_SECRET_KEY`        | `api-key.secret-key`        |                                                  |
+| `QONTOCTL_CLIENT_ID`         | `oauth.client-id`           |                                                  |
+| `QONTOCTL_CLIENT_SECRET`     | `oauth.client-secret`       |                                                  |
+| `QONTOCTL_ACCESS_TOKEN`      | `oauth.access-token`        | Read-only — see semantics note below             |
+| `QONTOCTL_ENDPOINT`          | `endpoint`                  | Custom API endpoint                              |
+| `QONTOCTL_STAGING_TOKEN`     | `oauth.staging-token`       | Activates sandbox URLs                           |
+| `QONTOCTL_SCA_METHOD`        | `sca.method`                | See [`sandbox-testing.md`](./sandbox-testing.md) |
+
+With `--profile <name>`, the prefix becomes `QONTOCTL_{NAME}_` (uppercased,
+hyphens replaced with underscores). For example, `--profile acme` reads
+`QONTOCTL_ACME_ORGANIZATION_SLUG`.
+
+> **`QONTOCTL_ACCESS_TOKEN` semantics**: when set, the env-supplied bearer is
+> used for the current invocation only. Proactive token refresh is not
+> attempted, and refreshed tokens are not persisted to disk (mirrors
+> `AWS_SESSION_TOKEN`). If the token has expired, the API surfaces a `401`;
+> re-issue the token externally.
+>
+> **`QONTOCTL_REFRESH_TOKEN` is intentionally not supported.** Refresh tokens
+> are runtime-mutable state — every refresh produces a new value the tool
+> must write back somewhere — and env vars carry inputs, not state. Use
+> file-based credentials (`~/.qontoctl.yaml` or a profile) for OAuth flows
+> that need refresh, or stick with API-key env vars in CI. See
+> [#495](https://github.com/alexey-pelykh/qontoctl/pull/497).
+
+## `QONTOCTL_CONFIG_FILE` — quick reference
+
+The env var accepts an **absolute** or **relative** path. Relative paths are
+passed through to the resolver verbatim — there is no implicit normalization
+against CWD or the home directory beyond Node's own `path.resolve` semantics.
+For predictable behavior in scripts and `direnv` shims, prefer absolute paths.
+
+Empty string (e.g., from `QONTOCTL_CONFIG_FILE="$UNSET_VAR"` shell expansion)
+is treated as "not set" — the resolver falls through to the next priority.
+
+### CI usage
+
+```sh
+# CI (api-key only, points at a repo-checked-out config or env-only)
+export QONTOCTL_ORGANIZATION_SLUG="$ORG"
+export QONTOCTL_SECRET_KEY="$KEY"
+qontoctl account list
+```
+
+### Repo-local development with `direnv`
+
+[direnv](https://direnv.net/) auto-exports env vars when you `cd` into a
+project. Recommended for daily development:
+
+```sh
+# .envrc (gitignored)
+export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"
+```
+
+Then `direnv allow` once. Now any `qontoctl` invocation from the repo loads
+the local file without a `--config` flag, and any other directory loads the
+home default.
+
+A starter template is in [`.envrc.example`](../.envrc.example) at the repo root.
+
+### MCP client wiring
+
+Most MCP host configs accept an `env` field. Point QontoCtl at a non-default
+config without a wrapper script:
+
+```jsonc
+{
+    "mcpServers": {
+        "qontoctl": {
+            "command": "npx",
+            "args": ["qontoctl", "mcp"],
+            "env": {
+                "QONTOCTL_CONFIG_FILE": "/abs/path/to/qontoctl.yaml",
+            },
+        },
+    },
+}
+```
+
+The MCP server captures the env var at startup, so the path is frozen for
+the lifetime of the server process.
+
+## Migration from CWD discovery
+
+Pre-`0.x` builds discovered `.qontoctl.yaml` by walking up from the current
+working directory. That heuristic was removed in
+[#479](https://github.com/alexey-pelykh/qontoctl/pull/502) because it made
+the load destination depend on **where** you invoked `qontoctl` from, not
+**which** project you intended to operate on — leading to silent
+mis-targeting in scripts, CI matrix jobs, and editor-spawned subprocesses.
+
+If you previously relied on CWD discovery, pick one of these replacements:
+
+| Before                                        | After                                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------- |
+| `cd ~/projects/acme && qontoctl account list` | `qontoctl --config ~/projects/acme/.qontoctl.yaml account list`             |
+| Repo-local `.qontoctl.yaml` auto-discovered   | `direnv` shim (see above) — auto-exports `QONTOCTL_CONFIG_FILE`             |
+| CI script `cd repo && qontoctl ...`           | `QONTOCTL_CONFIG_FILE="$GITHUB_WORKSPACE/repo/.qontoctl.yaml" qontoctl ...` |
+| Single-tenant home install                    | No change needed — `~/.qontoctl.yaml` still works at priority 4             |
+
+The CLI emits no warning when the previously-discovered `./.qontoctl.yaml`
+exists but is now ignored — adopt one of the explicit mechanisms above.
+
+## See also
+
+- [`oauth-setup.md`](./oauth-setup.md) — OAuth app registration and `auth login`/`auth refresh` flows.
+- [`sandbox-testing.md`](./sandbox-testing.md) — sandbox setup including `mock` SCA flow.
+- [`e2e-testing.md`](./e2e-testing.md) — E2E test taxonomy and credential gating.
+- [`release-runbook.md`](./release-runbook.md) — release procedure.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -100,8 +100,15 @@ CI workflow and can be removed from repository settings.
 ## Running locally
 
 `pnpm test:e2e` runs the full suite. Suites gate themselves based on what's
-configured in `.qontoctl.yaml` (auto-discovered by walking up from CWD) or
+configured in `.qontoctl.yaml` (located via `QONTOCTL_CONFIG_FILE`,
+`--config`, `--profile`, or the home default — see
+[`docs/configuration.md`](./configuration.md) for the full chain) or
 `QONTOCTL_*` environment variables.
+
+The harness in `packages/e2e/src/sandbox.ts` injects `QONTOCTL_CONFIG_FILE`
+into spawned CLI subprocesses, pointing at the repo's `.qontoctl.yaml`
+(gitignored), so you can keep credentials in the repo without exporting the
+env var in your shell.
 
 To run **api-key-compatible suites only** (mirroring CI behavior):
 

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -76,14 +76,27 @@ Highest wins:
 
 The MCP server resolves the SCA method from **environment / config only** — there is no MCP tool input parameter for it. This is deliberate: letting an LLM client choose the SCA method on a write is a threat-model risk in production. Operators control the SCA method by setting env vars or config; the LLM cannot.
 
-Sandbox MCP testing therefore looks like:
+Sandbox MCP testing has two equivalent setups:
+
+**Env-only** (no config file):
 
 ```sh
 QONTOCTL_STAGING_TOKEN="..." \
   QONTOCTL_CLIENT_ID="..." \
   QONTOCTL_CLIENT_SECRET="..." \
-  qontoctl mcp serve  # auto-defaults sca.method to "mock"
+  qontoctl mcp  # auto-defaults sca.method to "mock"
 ```
+
+**Config-file pointer** (when credentials live in a YAML file):
+
+```sh
+QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml" qontoctl mcp
+```
+
+In MCP host configs, the same env var goes in the `env` block — see
+[`docs/configuration.md`](./configuration.md#mcp-client-wiring) for the
+full pattern. The MCP server has no CLI flags, so `QONTOCTL_CONFIG_FILE`
+is the only way to point it at a non-default file.
 
 ## Approving sandbox SCA challenges
 

--- a/packages/mcp/src/config.test.ts
+++ b/packages/mcp/src/config.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, afterEach } from "vitest";
+import { buildMcpResolveOptions } from "./config.js";
+
+describe("buildMcpResolveOptions", () => {
+  describe("with explicit env argument", () => {
+    it("returns undefined when QONTOCTL_CONFIG_FILE is absent", () => {
+      expect(buildMcpResolveOptions({})).toBeUndefined();
+    });
+
+    it("returns undefined when QONTOCTL_CONFIG_FILE is empty string", () => {
+      // Defensive guard: `QONTOCTL_CONFIG_FILE="$UNSET_VAR"` from a shell
+      // evaluates to an empty string. Without this handling, callers would
+      // silently treat "" as a valid path.
+      expect(buildMcpResolveOptions({ QONTOCTL_CONFIG_FILE: "" })).toBeUndefined();
+    });
+
+    it("returns { path } when QONTOCTL_CONFIG_FILE is set to an absolute path", () => {
+      expect(buildMcpResolveOptions({ QONTOCTL_CONFIG_FILE: "/etc/qontoctl.yaml" })).toEqual({
+        path: "/etc/qontoctl.yaml",
+      });
+    });
+
+    it("returns { path } when QONTOCTL_CONFIG_FILE is set to a relative path", () => {
+      // Relative paths are passed through verbatim — core's resolver
+      // handles normalization.
+      expect(buildMcpResolveOptions({ QONTOCTL_CONFIG_FILE: "./local.yaml" })).toEqual({ path: "./local.yaml" });
+    });
+
+    it("ignores other QONTOCTL_* env vars", () => {
+      // Only QONTOCTL_CONFIG_FILE is consulted by this helper. Other
+      // QONTOCTL_* vars are processed downstream by core's env overlay.
+      expect(
+        buildMcpResolveOptions({
+          QONTOCTL_ORGANIZATION_SLUG: "acme",
+          QONTOCTL_SECRET_KEY: "secret",
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("falling back to process.env", () => {
+    const ORIGINAL = process.env["QONTOCTL_CONFIG_FILE"];
+
+    afterEach(() => {
+      if (ORIGINAL === undefined) {
+        delete process.env["QONTOCTL_CONFIG_FILE"];
+      } else {
+        process.env["QONTOCTL_CONFIG_FILE"] = ORIGINAL;
+      }
+    });
+
+    it("reads from process.env when env argument is omitted", () => {
+      process.env["QONTOCTL_CONFIG_FILE"] = "/from/process/env.yaml";
+      expect(buildMcpResolveOptions()).toEqual({ path: "/from/process/env.yaml" });
+    });
+
+    it("returns undefined when process.env QONTOCTL_CONFIG_FILE is unset", () => {
+      delete process.env["QONTOCTL_CONFIG_FILE"];
+      expect(buildMcpResolveOptions()).toBeUndefined();
+    });
+  });
+});

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { ResolveOptions } from "@qontoctl/core";
+
+const CONFIG_FILE_ENV = "QONTOCTL_CONFIG_FILE";
+
+/**
+ * Build the `path` portion of {@link ResolveOptions} for the MCP server's
+ * config load, sourced from the `QONTOCTL_CONFIG_FILE` env var.
+ *
+ * The MCP server has no CLI flags, so the env var is its only mechanism for
+ * pointing at a non-default config file (CI, multi-config dev workflows,
+ * agent-driven setups). Reading the env explicitly at the MCP layer — and
+ * passing it through as `path` — makes three properties true:
+ *
+ *  1. **Symmetry with the CLI**: `qontoctl --config <path>` and
+ *     `QONTOCTL_CONFIG_FILE=<path> qontoctl mcp` route through the same
+ *     `path`-option codepath in core's resolver.
+ *  2. **Startup capture**: the config path is frozen at MCP startup; later
+ *     mutations to `process.env.QONTOCTL_CONFIG_FILE` cannot redirect
+ *     subsequent loads inside the running server.
+ *  3. **Self-evident intent**: the MCP bootstrap reads as
+ *     `resolveConfig(buildMcpResolveOptions())` rather than relying on
+ *     core's implicit `process.env` fallback.
+ *
+ * Empty string is treated as "not set" — typically arises from
+ * `QONTOCTL_CONFIG_FILE="$UNSET_VAR"` shell expansion, where the variable
+ * is technically present but carries no path. Without this guard, callers
+ * could silently load the wrong file.
+ *
+ * @param env - Override the env source (testing). Defaults to `process.env`.
+ * @returns `{ path }` when the env var is set to a non-empty string;
+ *   `undefined` otherwise. Pass directly to `resolveConfig` — the resolver
+ *   accepts `undefined` and falls back to its home/profile defaults.
+ */
+export function buildMcpResolveOptions(
+  env?: Record<string, string | undefined>,
+): Pick<ResolveOptions, "path"> | undefined {
+  const source = env ?? (process.env as Record<string, string | undefined>);
+  const configPath = source[CONFIG_FILE_ENV];
+  if (configPath === undefined || configPath === "") {
+    return undefined;
+  }
+  return { path: configPath };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,11 +12,19 @@ import {
   OAUTH_TOKEN_SANDBOX_URL,
   type Authorization,
 } from "@qontoctl/core";
+import { buildMcpResolveOptions } from "./config.js";
 import { runStdioServer } from "./stdio.js";
+
+// Capture QONTOCTL_CONFIG_FILE at MCP startup. The env var is the only way
+// to point the MCP server at a non-default config path (no CLI flags exist),
+// so reading it explicitly here mirrors the CLI's `--config` codepath
+// (`resolveConfig({ path })`) and freezes the resolution destination — later
+// `process.env` mutations cannot redirect subsequent loads.
+const mcpResolveOptions = buildMcpResolveOptions();
 
 await runStdioServer({
   getClient: async () => {
-    const { config, endpoint, path, oauthAccessTokenFromEnv } = await resolveConfig();
+    const { config, endpoint, path, oauthAccessTokenFromEnv } = await resolveConfig(mcpResolveOptions);
 
     let authorization: Authorization;
     let fallbackAuthorization: Authorization | undefined;

--- a/packages/qontoctl/README.md
+++ b/packages/qontoctl/README.md
@@ -143,6 +143,26 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 </details>
 
+#### Pointing MCP at a non-default config file
+
+The MCP server has no CLI flags. To load credentials from a config file other than `~/.qontoctl.yaml`, set `QONTOCTL_CONFIG_FILE` in the host's `env` block:
+
+```jsonc
+{
+    "mcpServers": {
+        "qontoctl": {
+            "command": "npx",
+            "args": ["qontoctl", "mcp"],
+            "env": {
+                "QONTOCTL_CONFIG_FILE": "/abs/path/to/qontoctl.yaml",
+            },
+        },
+    },
+}
+```
+
+The path is captured at server startup. See [`docs/configuration.md`](https://github.com/alexey-pelykh/qontoctl/blob/main/docs/configuration.md) for the full resolution chain.
+
 ### Available MCP Tools
 
 | Tool                            | Description                                                       |
@@ -340,15 +360,16 @@ Once configured, you can ask your AI assistant things like:
 
 ### Global Options
 
-| Option                  | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `-p, --profile <name>`  | Configuration profile to use                            |
-| `-o, --output <format>` | Output format: `table` (default), `json`, `yaml`, `csv` |
-| `--page <number>`       | Fetch a specific page of results                        |
-| `--per-page <number>`   | Results per page                                        |
-| `--no-paginate`         | Disable auto-pagination                                 |
-| `--verbose`             | Enable verbose output                                   |
-| `--debug`               | Enable debug output (implies `--verbose`)               |
+| Option                  | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `--config <path>`       | Explicit path to a config file (overrides `--profile` and `QONTOCTL_CONFIG_FILE`) |
+| `-p, --profile <name>`  | Configuration profile to use                                                      |
+| `-o, --output <format>` | Output format: `table` (default), `json`, `yaml`, `csv`                           |
+| `--page <number>`       | Fetch a specific page of results                                                  |
+| `--per-page <number>`   | Results per page                                                                  |
+| `--no-paginate`         | Disable auto-pagination                                                           |
+| `--verbose`             | Enable verbose output                                                             |
+| `--debug`               | Enable debug output (implies `--verbose`)                                         |
 
 ## Configuration
 
@@ -383,16 +404,23 @@ When both API key and OAuth credentials are configured, OAuth is used when an ac
 
 ### Resolution Order
 
-**Without `--profile`:**
+The CLI resolves the config **file** in this order (highest priority first):
 
-1. `QONTOCTL_*` environment variables (highest priority)
-2. `.qontoctl.yaml` in current directory
-3. `~/.qontoctl.yaml` (home default)
+1. `--config <path>` flag
+2. `QONTOCTL_CONFIG_FILE` env var
+3. `~/.qontoctl/{name}.yaml` (when `--profile <name>` is given)
+4. `~/.qontoctl.yaml` (home default)
 
-**With `--profile acme`:**
+When `--config` is supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and the resolved paths disagree, `--config` wins and a warning is emitted on stderr so the override is visible.
 
-1. `QONTOCTL_ACME_*` environment variables (highest priority)
-2. `~/.qontoctl/acme.yaml`
+> **No current-directory discovery.** The CLI does not scan the working directory for `.qontoctl.yaml`. For repo-local config, use a `direnv` shim that exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`, or pass `--config ./.qontoctl.yaml` explicitly per invocation.
+
+**Per-field overrides** apply on top of the loaded file:
+
+- Without `--profile`: `QONTOCTL_*` env vars override file values
+- With `--profile acme`: `QONTOCTL_ACME_*` env vars override file values
+
+For the full reference (including the migration story for users coming from pre-`0.x` builds that walked CWD), see [`docs/configuration.md`](https://github.com/alexey-pelykh/qontoctl/blob/main/docs/configuration.md).
 
 ### Environment Variables
 


### PR DESCRIPTION
Closes #482. Final issue in the config-resolution refactor series (#479, #480, #481).

## Summary

- **MCP server** now reads `QONTOCTL_CONFIG_FILE` at startup via a testable helper (`buildMcpResolveOptions`) and passes it to `resolveConfig` as the `path` option — symmetric with the CLI's `--config` codepath, freezes the resolution destination for the server's lifetime, and makes intent self-evident vs relying on core's implicit `process.env` fallback.
- **New canonical `docs/configuration.md`** covers the precedence chain per entry point (CLI / MCP / E2E harness), profile semantics, the per-field env-var overlay, MCP host wiring, and a migration section for users coming from pre-#479 builds that walked CWD.
- **CLAUDE.md, README.md, packages/qontoctl/README.md, docs/sandbox-testing.md, docs/e2e-testing.md** updated to point at the canonical reference and surface the env-block / direnv patterns. `packages/qontoctl/README.md`'s Resolution Order section was stale (still listed CWD discovery, missing `--config` and `QONTOCTL_CONFIG_FILE`); now matches root README.

## Why

Issue #482 surfaced two gaps left after #479 (resolution refactor), #480 (CLI `--config` flag), and #481 (E2E harness path injection):
1. The MCP server has no CLI flags, so `QONTOCTL_CONFIG_FILE` is its only mechanism for pointing at a non-default config — but the codepath relied on core's implicit `process.env` fallback rather than reading + passing the env var explicitly.
2. Docs across CLAUDE.md, READMEs, and sandbox/e2e guides hadn't been consolidated; users had no canonical reference for the resolution chain or migration story.

## Test plan

- [x] Unit tests: `pnpm test` — 10/10 tasks pass (710 CLI + 353 MCP + others)
- [x] New `packages/mcp/src/config.test.ts` — 7/7 tests pass (env unset, empty string, abs path, rel path, ignores other QONTOCTL_*, process.env fallback, process.env unset)
- [x] Lint: `pnpm lint` — 8/8 pass
- [x] License-check: `pnpm license-check` — 100 deps clean (MIT, BSD, ISC)
- [x] Build: `pnpm build` — all packages
- [x] E2E: `pnpm test:e2e` — MCP server E2E and all `src/*/mcp.e2e.test.ts` pass; pre-existing OAuth-required & sandbox-only suite failures (cards CLI, intl currencies API contract drift, intl-beneficiary CLI parsing, payment-link OAuth, sca-continuation sandbox) are unrelated and don't run in CI (CI is api-key-only)

## Out of scope

- Changes to the resolution model (#479) — already landed
- CLI `--config` flag (#480) — already landed
- E2E sandbox config injection (#481) — already landed
- Sandbox/production explicitness — separate refactor (council P0 #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)