### PR TITLE
(fix) ClientSchema accepts individual clients without `name` field

### DIFF
--- a/packages/cli/src/commands/client.ts
+++ b/packages/cli/src/commands/client.ts
@@ -41,10 +41,10 @@ interface ClientUpdateOptions extends GlobalOptions, WriteOptions {
 }
 
 function clientDisplayName(c: Client): string {
-  if (c.name !== null) {
+  if (c.name != null) {
     return c.name;
   }
-  const parts = [c.first_name, c.last_name].filter((p) => p !== null);
+  const parts = [c.first_name, c.last_name].filter((p) => p != null);
   return parts.length > 0 ? parts.join(" ") : "";
 }
 

--- a/packages/core/src/types/client.schema.test.ts
+++ b/packages/core/src/types/client.schema.test.ts
@@ -142,6 +142,28 @@ describe("ClientSchema", () => {
     expect(result.currency).toBeUndefined();
   });
 
+  it("accepts individual clients without `name` field (regression: #496)", () => {
+    // Individual clients (kind: "individual") return first_name / last_name and
+    // OMIT the `name` field entirely. The schema must accept the field as
+    // optional, not just nullable.
+    const individualClient = {
+      id: "client-individual",
+      type: "individual",
+      kind: "individual" as const,
+      first_name: "Jean",
+      last_name: "Dupont",
+      email: "jean.dupont@example.com",
+      billing_address: null,
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-06-15T12:00:00.000Z",
+    };
+    const result = ClientSchema.parse(individualClient);
+    expect(result.name).toBeUndefined();
+    expect(result.first_name).toBe("Jean");
+    expect(result.last_name).toBe("Dupont");
+    expect(result.kind).toBe("individual");
+  });
+
   it("rejects missing required fields", () => {
     expect(() => ClientSchema.parse({ id: "client-1" })).toThrow();
   });

--- a/packages/core/src/types/client.schema.ts
+++ b/packages/core/src/types/client.schema.ts
@@ -20,7 +20,9 @@ export const ClientSchema = z
   .object({
     id: z.string(),
     type: z.string().optional(),
-    name: z.string().nullable(),
+    // Individual clients (kind: "individual") may omit `name` entirely; Qonto returns
+    // `first_name` / `last_name` instead. See #496.
+    name: z.string().nullable().optional(),
     first_name: z.string().nullable().optional(),
     last_name: z.string().nullable().optional(),
     kind: z.enum(["company", "individual", "freelancer"]),

--- a/packages/core/src/types/client.ts
+++ b/packages/core/src/types/client.ts
@@ -18,7 +18,7 @@ export interface ClientAddress {
 export interface Client {
   readonly id: string;
   readonly type?: string | undefined;
-  readonly name: string | null;
+  readonly name?: string | null | undefined;
   readonly first_name?: string | null | undefined;
   readonly last_name?: string | null | undefined;
   readonly kind: "company" | "individual" | "freelancer";


### PR DESCRIPTION
## Summary

Fixes Issue 1 of #496 — MCP `client_list` validation failure on accounts with individual clients.

Qonto's `/v2/clients` endpoint uses a discriminated `oneOf: ClientCompany | ClientIndividual` schema [per Qonto API docs](https://docs.qonto.com/api-reference/business-api/clients/list-clients). The `ClientIndividual` shape **omits** `name` entirely — only `first_name` / `last_name` are returned. The unified `ClientSchema` previously required `name` to be present (`z.string().nullable()`), causing:

```
Invalid API response from /v2/clients: clients.0.name: Invalid input: expected string, received undefined
```

against any account with individual clients.

## Changes

- `packages/core/src/types/client.schema.ts`: `name` is `.optional()` in addition to `.nullable()`.
- `packages/core/src/types/client.ts`: `name` typed as `?: string | null | undefined`.
- `packages/cli/src/commands/client.ts`: `clientDisplayName` switches `!== null` to `!= null` to also handle `undefined` (consistent with `first_name` / `last_name` which were already `string | null | undefined`).
- `packages/core/src/types/client.schema.test.ts`: regression test for the individual-client-without-`name` shape.

## Verification

- Unit tests: 1665 passed, 0 failed.
- E2E (api-key suites): all client + quote tests pass against production.
- Manual smoke test: built MCP `client_list` against my live account — previously failed with the issue's exact error, now returns individual clients with `first_name` / `last_name` and no `name` key, parsed correctly.
- Documentation cross-check: [Qonto API docs](https://docs.qonto.com/api-reference/business-api/clients/list-clients) confirm `ClientIndividual` schema does not include `name`.

## Issue 2 (quote `discount.type`) — deferred

Issue #496 reports a second bug: `quote_list` validation rejects `discount.type` values outside `"percentage" | "amount"`. The [Qonto API docs](https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/quotes/list-quotes) state the enum strictly contains those two values, contradicting the reporter's observation. Posted a question on #496 asking for the actual value and market context before relaxing the schema. #496 stays open; this PR partially addresses it.

## Test plan

- [x] Unit tests pass (`pnpm test`).
- [x] Lint passes (`pnpm lint`).
- [x] License check passes (`pnpm license-check`).
- [x] Build passes (`pnpm build`).
- [x] E2E client + quote suites pass (`pnpm test:e2e`, `clients/` and `quotes/` directories).
- [x] Manual smoke test: MCP `client_list` against live account succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)