### PR TITLE
(fix) cards CLI pagination loop terminates on omitted next_page (#489)

### DIFF
--- a/packages/cli/src/pagination.test.ts
+++ b/packages/cli/src/pagination.test.ts
@@ -123,6 +123,28 @@ describe("pagination", () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("treats omitted next_page (e.g. /v2/cards) as terminal", async () => {
+      // Some Qonto endpoints (notably /v2/cards) omit `next_page` entirely
+      // on the final page rather than returning `null`. Regression test
+      // for #489 — previously the loop sent `?page=undefined` and got 400.
+      const items = [{ id: "1" }, { id: "2" }, { id: "3" }];
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({
+          items,
+          meta: {
+            current_page: 1,
+            total_pages: 1,
+            total_count: 3,
+            per_page: 100,
+          },
+        }),
+      );
+
+      const result = await fetchAllPages(client, "/v2/cards", "items", 100);
+      expect(result.items).toEqual(items);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("stops at MAX_PAGES safety limit", async () => {
       // Always return a next_page to simulate infinite pagination
       fetchSpy.mockImplementation(() => {

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -75,7 +75,9 @@ export async function fetchAllPages<T>(
 
   let currentMeta = firstPage.meta;
   let pagesFetched = 1;
-  while (currentMeta.next_page !== null) {
+  // Some Qonto endpoints (e.g. `/v2/cards`) omit `next_page` entirely on
+  // the final page rather than returning `null`; treat both as terminal.
+  while (typeof currentMeta.next_page === "number") {
     if (pagesFetched >= MAX_PAGES) {
       break;
     }

--- a/packages/core/src/api-types.schema.test.ts
+++ b/packages/core/src/api-types.schema.test.ts
@@ -145,6 +145,13 @@ describe("PaginationMetaSchema", () => {
     expect(result.prev_page).toBeUndefined();
   });
 
+  it("accepts missing next_page (e.g. /v2/cards omits it on the final page)", () => {
+    const input = { ...validMeta };
+    delete (input as Record<string, unknown>).next_page;
+    const result = PaginationMetaSchema.parse(input);
+    expect(result.next_page).toBeUndefined();
+  });
+
   it("strips unknown fields", () => {
     const result = PaginationMetaSchema.parse({ ...validMeta, extra: true });
     expect(result).not.toHaveProperty("extra");

--- a/packages/core/src/api-types.schema.ts
+++ b/packages/core/src/api-types.schema.ts
@@ -40,7 +40,7 @@ export const OrganizationSchema = z
 export const PaginationMetaSchema = z
   .object({
     current_page: z.number(),
-    next_page: z.number().nullable(),
+    next_page: z.number().nullable().optional(),
     prev_page: z.number().nullable().optional(),
     total_pages: z.number(),
     total_count: z.number(),

--- a/packages/core/src/api-types.ts
+++ b/packages/core/src/api-types.ts
@@ -34,10 +34,13 @@ export interface Organization {
 
 /**
  * Pagination metadata returned by the Qonto API.
+ *
+ * `next_page` is optional because some endpoints (notably `/v2/cards`) omit
+ * the field entirely on the final page rather than returning `null`.
  */
 export interface PaginationMeta {
   readonly current_page: number;
-  readonly next_page: number | null;
+  readonly next_page?: number | null | undefined;
   readonly prev_page?: number | null | undefined;
   readonly total_pages: number;
   readonly total_count: number;

--- a/packages/core/src/cards/schemas.test.ts
+++ b/packages/core/src/cards/schemas.test.ts
@@ -92,6 +92,14 @@ describe("CardAppearanceSchema", () => {
   it("rejects missing assets", () => {
     expect(() => CardAppearanceSchema.parse({ theme: "light", gradient_hex_color: "#000" })).toThrow();
   });
+
+  it("accepts appearance without gradient_hex_color (Qonto omits it for some designs)", () => {
+    const appearance = makeAppearance();
+    delete (appearance as { gradient_hex_color?: string }).gradient_hex_color;
+    const result = CardAppearanceSchema.parse(appearance);
+    expect(result.gradient_hex_color).toBeUndefined();
+    expect(result.theme).toBe("dark");
+  });
 });
 
 describe("ParentCardSummarySchema", () => {
@@ -124,10 +132,19 @@ describe("CardSchema", () => {
         shipped_at: null,
         type_of_print: null,
         discard_on: null,
+        payment_lifespan_limit: null,
       }),
     );
     expect(result.embossed_name).toBeNull();
     expect(result.type_of_print).toBeNull();
+    expect(result.payment_lifespan_limit).toBeNull();
+  });
+
+  it("accepts card without initiator_id (Qonto omits it for some endpoints)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { initiator_id: _initiator_id, ...cardWithoutInitiator } = makeCard();
+    const result = CardSchema.parse(cardWithoutInitiator);
+    expect(result.initiator_id).toBeUndefined();
   });
 
   it("accepts card with parent_card_summary", () => {

--- a/packages/core/src/cards/schemas.ts
+++ b/packages/core/src/cards/schemas.ts
@@ -7,6 +7,9 @@ import { PaginationMetaSchema } from "../api-types.schema.js";
 
 /**
  * Visual appearance details for a card.
+ *
+ * `gradient_hex_color` is optional — the Qonto API omits it for some card
+ * designs (verified empirically against `/v2/cards`).
  */
 export const CardAppearanceSchema = z
   .object({
@@ -16,7 +19,7 @@ export const CardAppearanceSchema = z
       front_small_wallet: z.string(),
     }),
     theme: z.enum(["dark", "light"]),
-    gradient_hex_color: z.string(),
+    gradient_hex_color: z.string().optional(),
   })
   .strip();
 
@@ -78,7 +81,7 @@ export const CardSchema = z
     payment_transaction_limit_option: z.boolean(),
     active_days: z.array(z.number()),
     holder_id: z.string(),
-    initiator_id: z.string(),
+    initiator_id: z.string().optional(),
     bank_account_id: z.string(),
     organization_id: z.string(),
     updated_at: z.string(),
@@ -86,7 +89,7 @@ export const CardSchema = z
     shipped_at: z.string().nullable(),
     card_type: z.enum(["debit", "prepaid"]),
     card_level: z.enum(["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"]),
-    payment_lifespan_limit: z.number(),
+    payment_lifespan_limit: z.number().nullable(),
     payment_lifespan_spent: z.number(),
     pre_expires_at: z.string().nullable(),
     categories: z.array(z.string()),

--- a/packages/core/src/types/card.ts
+++ b/packages/core/src/types/card.ts
@@ -3,6 +3,9 @@
 
 /**
  * Visual appearance details for a card.
+ *
+ * `gradient_hex_color` is optional — the Qonto API omits it for some card
+ * designs (verified empirically against `/v2/cards`).
  */
 export interface CardAppearance {
   readonly assets: {
@@ -11,7 +14,7 @@ export interface CardAppearance {
     readonly front_small_wallet: string;
   };
   readonly theme: "dark" | "light";
-  readonly gradient_hex_color: string;
+  readonly gradient_hex_color?: string | undefined;
 }
 
 /**
@@ -68,7 +71,7 @@ export interface Card {
   readonly payment_transaction_limit_option: boolean;
   readonly active_days: readonly number[];
   readonly holder_id: string;
-  readonly initiator_id: string;
+  readonly initiator_id?: string | undefined;
   readonly bank_account_id: string;
   readonly organization_id: string;
   readonly updated_at: string;
@@ -76,7 +79,7 @@ export interface Card {
   readonly shipped_at: string | null;
   readonly card_type: "debit" | "prepaid";
   readonly card_level: "standard" | "plus" | "metal" | "virtual" | "virtual_partner" | "flash" | "advertising";
-  readonly payment_lifespan_limit: number;
+  readonly payment_lifespan_limit: number | null;
   readonly payment_lifespan_spent: number;
   readonly pre_expires_at: string | null;
   readonly categories: readonly string[];


### PR DESCRIPTION
## Summary

Fixes the cards-CLI E2E HTTP 400 failures (cards subgroup of #489).

The `/v2/cards` endpoint omits `next_page` entirely on the final page rather than returning `null`. Our `fetchAllPages` loop checked `next_page !== null`, so `undefined !== null` (true) caused a second request with `?page=undefined` and a HTTP 400 `unknown: Unknown error`.

## Changes

- **`packages/cli/src/pagination.ts`** — terminate the page-fetch loop when `currentMeta.next_page` is not a number; covers both `null` and `undefined`.
- **`packages/core/src/api-types.{ts,schema.ts}`** — `PaginationMeta.next_page` is now optional, matching observed Qonto API behavior (single-page responses omit the field).
- **`packages/core/src/cards/{schemas.ts,types/card.ts}`** — relax three `Card` fields the API also omits or returns null for, surfaced once the pagination bug stopped masking them:
  - `appearance.gradient_hex_color` → optional (omitted for some card designs)
  - `initiator_id` → optional (omitted on `/v2/cards`)
  - `payment_lifespan_limit` → nullable (returned as `null` when no lifetime cap set)
- New regression unit tests in `pagination.test.ts`, `api-types.schema.test.ts`, `cards/schemas.test.ts`.

## Verification

- All 7 cards-CLI E2E tests now pass (previously 7/7 failed with HTTP 400).
- All 5 cards-MCP E2E tests pass.
- 711 CLI unit tests, 957 core unit tests, 353 MCP unit tests, 18 qontoctl unit tests — all pass.
- Sampled regression on transactions / recurring-transfers / transfers E2E suites — no regressions (pagination change is loosening only).
- Lint clean, license-check clean.

## Scope discipline

#489 lists four failing subgroups: **cards (7 tests, prioritized)**, insurance create, iban-certificate (CLI + MCP), and a 422 in transactions. Per #489's explicit guidance and caller context, this PR addresses **cards only**. The other three failure modes have distinct root causes (test fixture insufficiency, sandbox KYB limitation, stderr from skipped SCA tests) and are tracked as follow-up issues.

Closes the cards subgroup of #489.

## Test plan

- [x] `pnpm test` — all unit tests pass
- [x] `pnpm lint`, `pnpm license-check` — clean
- [x] Cards E2E (CLI + MCP) — 12/12 pass against Qonto sandbox
- [x] Smoke E2E on transactions / recurring-transfers / transfers — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)