### PR TITLE
(test) E2E: shared helpers + skip-on-404 pattern; pagination next_page:0 guard (#490)

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -148,3 +148,90 @@ pnpm test:e2e
 See [`docs/oauth-setup.md`](./oauth-setup.md) for OAuth app registration and
 [`docs/sandbox-testing.md`](./sandbox-testing.md) for sandbox setup including
 the `mock` SCA flow.
+
+## Sandbox-data-dependent tests
+
+Some Qonto endpoints behave differently per organization (subscription tier,
+account configuration, prior data). E2E tests must not assume specific
+resources exist, or that opt-in features are enabled. Three strategies cover
+the spectrum, applied per-test in
+[`packages/e2e/src/commands/payment-link.e2e.test.ts`](../packages/e2e/src/commands/payment-link.e2e.test.ts)
+as the canonical reference:
+
+### 1. Skip-if-empty
+
+When a test needs a resource (e.g. payment link, invoice, beneficiary) to
+exercise a `show`/`update`/`delete` flow, list first and skip when empty.
+This is the dominant pattern for `show`-style tests:
+
+```ts
+const items = cliJson<{ id: string }[]>("payment-link", "list");
+if (items.length === 0) return; // Skip: nothing to show
+const first = items[0] as { id: string };
+const detail = cliJson<unknown>("payment-link", "show", first.id);
+```
+
+### 2. Skip-if-feature-unavailable
+
+When an endpoint returns HTTP 404 because a feature is not enabled (Qonto
+Payment Links subscription, OAuth-only Embed scopes, …), wrap the CLI call
+in [`skipIfNotFound`](../packages/e2e/src/helpers.ts) and bail on the
+sentinel:
+
+```ts
+import { cliJson, SKIP, skipIfNotFound } from "../helpers.js";
+
+const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
+if (stdout === SKIP) return; // Feature unavailable in this sandbox
+const items = JSON.parse(stdout) as { id: string }[];
+```
+
+`skipIfNotFound` is a special case of
+[`skipIfQontoStatus`](../packages/e2e/src/helpers.ts), which accepts an
+arbitrary set of "OK to skip" HTTP statuses (e.g. `[403, 404]` for tools
+gated by both subscription and OAuth scope). Both helpers re-throw on any
+other failure, so genuine bugs surface as test failures.
+
+### 3. Looser assertion
+
+When a test validates structural properties (e.g. "list returns an array",
+"each item has an `id`"), assert at the field level rather than calling
+`Schema.parse(item)` for every element. The strict parse is brittle when
+the sandbox returns slightly different shapes than production (or when the
+schema is not yet aligned with the actual API response — see
+[`docs/e2e-testing.md` § E2E in CI](#ci-behavior) for the production-only CI
+caveat).
+
+Use `Schema.parse` only on `show`-style tests where a single, fully-formed
+resource is fetched.
+
+### MCP analogue
+
+MCP tools surface the same Qonto error payloads via the
+`isError: true, content: [{ text: ... }]` wrapper. Tests detect feature
+unavailability by inspecting the error text — see the
+`isFeatureUnavailable` helper in
+[`packages/e2e/src/commands/mcp-payment-links.e2e.test.ts`](../packages/e2e/src/commands/mcp-payment-links.e2e.test.ts)
+for the canonical implementation. (The shared helpers module exposes
+`firstTextFromMcpResult` to centralize the content-extraction
+boilerplate.)
+
+### Helpers reference
+
+[`packages/e2e/src/helpers.ts`](../packages/e2e/src/helpers.ts) exports the
+shared helpers used across E2E suites:
+
+| Helper                   | Purpose                                                                   |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `cli(...args)`           | Spawn the bundled CLI; throws on non-zero exit (canonical invocation).    |
+| `cliJson<T>(...args)`    | `cli` with `--output json` prepended; returns parsed JSON.                |
+| `cliRaw(args, opts?)`    | Structured `{ ok, stdout } \| { ok: false, status, stdout, stderr }`.     |
+| `skipIfNotFound(...)`    | Run CLI, return `SKIP` on HTTP 404, throw on any other error.             |
+| `skipIfQontoStatus(...)` | Generalized form taking `readonly number[]` of skippable statuses.        |
+| `qontoHttpStatus(text)`  | Extract status from CLI's `Qonto API error (HTTP NNN):` stderr prefix.    |
+| `firstTextFromMcpResult` | Extract the first text-typed content entry from an MCP `callTool` result. |
+| `CLI_PATH`               | Absolute path to the bundled CLI binary (for spawning MCP transport).     |
+
+Tests that adopt the helpers should remove their inlined copies of the
+same boilerplate to keep the codebase DRY — the helpers are the single
+source of truth for "how E2E tests talk to the CLI / MCP server".

--- a/packages/cli/src/pagination.test.ts
+++ b/packages/cli/src/pagination.test.ts
@@ -145,6 +145,53 @@ describe("pagination", () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("treats next_page: 0 as terminal (Qonto payment_links empty-result quirk)", async () => {
+      // Regression for #490: Qonto's `/v2/payment_links` returns
+      // `next_page: 0` (not `null`/omitted) on an empty result set, which
+      // would loop forever requesting `?page=0` if the guard only checked
+      // `typeof === "number"` (since `0` is a number). The `> 0` clause
+      // covers this quirk.
+      const items: { id: string }[] = [];
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({
+          items,
+          meta: makeMeta({
+            current_page: 1,
+            next_page: 0,
+            prev_page: 1,
+            total_pages: 0,
+            total_count: 0,
+          }),
+        }),
+      );
+
+      const result = await fetchAllPages(client, "/v2/items", "items", 100);
+      expect(result.items).toEqual([]);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops if next_page does not advance past current_page (defensive)", async () => {
+      // Defends against any malformed pagination meta where `next_page` is
+      // a positive number but does not strictly advance — e.g. a server
+      // returning `current_page: 1, next_page: 1`. Without the strict-
+      // progress guard, this would loop forever fetching the same page.
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({
+          items: [{ id: "1" }],
+          meta: makeMeta({
+            current_page: 1,
+            next_page: 1,
+            total_pages: 1,
+            total_count: 1,
+          }),
+        }),
+      );
+
+      const result = await fetchAllPages(client, "/v2/items", "items", 100);
+      expect(result.items).toHaveLength(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("stops at MAX_PAGES safety limit", async () => {
       // Always return a next_page to simulate infinite pagination
       fetchSpy.mockImplementation(() => {

--- a/packages/cli/src/pagination.ts
+++ b/packages/cli/src/pagination.ts
@@ -75,9 +75,19 @@ export async function fetchAllPages<T>(
 
   let currentMeta = firstPage.meta;
   let pagesFetched = 1;
-  // Some Qonto endpoints (e.g. `/v2/cards`) omit `next_page` entirely on
-  // the final page rather than returning `null`; treat both as terminal.
-  while (typeof currentMeta.next_page === "number") {
+  // Per-endpoint quirks observed in the Qonto API:
+  //   - `/v2/cards` (#489): omits `next_page` entirely on the final page
+  //     rather than returning `null`. `typeof === "number"` covers both.
+  //   - `/v2/payment_links` (#490): returns `next_page: 0` (rather than
+  //     `null`) on empty result sets — without the `> 0` guard the loop
+  //     would request `?page=0` forever.
+  // Strict forward progress (`next > current`) defends against any other
+  // malformed meta (e.g. `next_page: 1` when `current_page: 1`).
+  while (
+    typeof currentMeta.next_page === "number" &&
+    currentMeta.next_page > 0 &&
+    currentMeta.next_page > currentMeta.current_page
+  ) {
     if (pagesFetched >= MAX_PAGES) {
       break;
     }

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -53,11 +53,11 @@ describe.skipIf(!hasApiKeyCredentials())("label commands (e2e)", () => {
       const firstLabel = labels[0];
       expect(firstLabel).toBeDefined();
       const labelId = (firstLabel as { id: string }).id;
+      // `label show --output json` emits the bare label object, not an
+      // array (table mode wraps it in a 1-row array; JSON does not).
+      // See `packages/cli/src/commands/label.ts` § show action.
       const output = cli("--output", "json", "label", "show", labelId);
-      const parsed = JSON.parse(output) as unknown[];
-      expect(parsed).toHaveLength(1);
-
-      const label = parsed[0] as Record<string, unknown>;
+      const label = JSON.parse(output) as Record<string, unknown>;
       LabelSchema.parse(label);
       expect(label).toHaveProperty("id", labelId);
       expect(label).toHaveProperty("name");

--- a/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
@@ -1,21 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PaymentLinkListResponseSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = result.content as { type: string; text: string }[];
-  expect(content).toHaveLength(1);
-  const entry = content[0] as { type: string; text: string };
-  expect(entry.type).toBe("text");
-  return entry.text;
+/**
+ * Best-effort detection of "feature unavailable" errors surfaced by MCP
+ * tools. The MCP server marks tool results as `isError: true` and embeds a
+ * stringified error payload in the first `text` content. The bundled CLI's
+ * core HTTP client throws `QontoApiError` with `status: 404` on missing
+ * features, which the MCP error wrapper preserves verbatim — we look for
+ * that signal and treat the result as a soft skip.
+ */
+function isFeatureUnavailable(result: { isError?: boolean | undefined; content: unknown }): boolean {
+  if (result.isError !== true) return false;
+  const content = result.content as { type: string; text?: string }[];
+  const text = content[0]?.text ?? "";
+  // Match either the stringified `QontoApiError` payload (`status: 404`) or
+  // the human-readable "HTTP 404" prefix used by the CLI's error handler.
+  return /\b(status[":\s]*404|HTTP 404)\b/.test(text);
 }
 
 describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
@@ -44,8 +51,12 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         name: "payment_link_list",
         arguments: {},
       });
+      if (isFeatureUnavailable(result)) {
+        console.warn("[e2e] skipping payment_link_list: payment-link feature unavailable in sandbox (#490)");
+        return;
+      }
 
-      const parsed = JSON.parse(firstText(result)) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         payment_links: unknown[];
         meta: Record<string, unknown>;
       };
@@ -62,12 +73,12 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         name: "payment_link_list",
         arguments: {},
       });
-      const listParsed = JSON.parse(firstText(listResult)) as {
+      if (isFeatureUnavailable(listResult)) return;
+
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         payment_links: { id: string }[];
       };
-      if (listParsed.payment_links.length === 0) {
-        return; // No payment links in sandbox
-      }
+      if (listParsed.payment_links.length === 0) return; // No payment links in sandbox
 
       const firstLink = listParsed.payment_links[0] as { id: string };
       const result = await client.callTool({
@@ -75,7 +86,7 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         arguments: { id: firstLink.id },
       });
 
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       PaymentLinkSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", firstLink.id);
       expect(parsed).toHaveProperty("status");
@@ -89,12 +100,12 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         name: "payment_link_list",
         arguments: {},
       });
-      const listParsed = JSON.parse(firstText(listResult)) as {
+      if (isFeatureUnavailable(listResult)) return;
+
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         payment_links: { id: string }[];
       };
-      if (listParsed.payment_links.length === 0) {
-        return; // No payment links in sandbox
-      }
+      if (listParsed.payment_links.length === 0) return; // No payment links in sandbox
 
       const firstLink = listParsed.payment_links[0] as { id: string };
       const result = await client.callTool({
@@ -102,7 +113,7 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         arguments: { id: firstLink.id },
       });
 
-      const parsed = JSON.parse(firstText(result)) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         payments: unknown[];
         meta: Record<string, unknown>;
       };
@@ -119,7 +130,7 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         arguments: {},
       });
 
-      const parsed = JSON.parse(firstText(result)) as { name: string; enabled: boolean }[];
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as { name: string; enabled: boolean }[];
       expect(Array.isArray(parsed)).toBe(true);
       for (const method of parsed) {
         expect(method).toHaveProperty("name");
@@ -134,8 +145,12 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
         name: "payment_link_connection_status",
         arguments: {},
       });
+      if (isFeatureUnavailable(result)) {
+        console.warn("[e2e] skipping payment_link_connection_status: no payment-link connection configured (#490)");
+        return;
+      }
 
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toBeDefined();
     });
   });

--- a/packages/e2e/src/commands/payment-link.e2e.test.ts
+++ b/packages/e2e/src/commands/payment-link.e2e.test.ts
@@ -1,32 +1,26 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { PaymentLinkSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    timeout: 15_000,
-  });
-}
+import { cliJson, SKIP, skipIfNotFound } from "../helpers.js";
+import { hasOAuthCredentials } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
   describe("payment-link list", () => {
     it("lists payment links", () => {
-      const output = cli("payment-link", "list");
-      expect(output).toBeDefined();
+      // `payment-link` requires the Qonto Payment Links subscription to be
+      // enabled on the organization. Sandboxes without it return HTTP 404 on
+      // list endpoints — skip rather than fail (#490).
+      const stdout = skipIfNotFound("payment-link", "list");
+      if (stdout === SKIP) return;
+      expect(stdout).toBeDefined();
     });
 
     it("produces valid JSON with --output json", () => {
-      const output = cli("--output", "json", "payment-link", "list");
-      const parsed = JSON.parse(output) as unknown[];
+      const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
+      if (stdout === SKIP) return;
+      const parsed = JSON.parse(stdout) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
       for (const item of parsed) {
         const pl = item as Record<string, unknown>;
@@ -40,18 +34,16 @@ describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
 
   describe("payment-link show", () => {
     it("shows payment link details", () => {
-      const listOutput = cli("--output", "json", "payment-link", "list");
-      const links = JSON.parse(listOutput) as { id: string }[];
-      if (links.length === 0) {
-        return; // No payment links in sandbox
-      }
+      const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
+      if (stdout === SKIP) return;
+      const links = JSON.parse(stdout) as { id: string }[];
+      if (links.length === 0) return; // No payment links in sandbox
 
       const firstLink = links[0] as { id: string };
-      const output = cli("--output", "json", "payment-link", "show", firstLink.id);
-      const parsed = JSON.parse(output) as unknown;
+      const output = cliJson<unknown>("payment-link", "show", firstLink.id);
 
       // Show returns the full object in JSON mode
-      const pl = (Array.isArray(parsed) ? parsed[0] : parsed) as Record<string, unknown>;
+      const pl = (Array.isArray(output) ? output[0] : output) as Record<string, unknown>;
       PaymentLinkSchema.parse(pl);
       expect(pl).toHaveProperty("id", firstLink.id);
       expect(pl).toHaveProperty("status");
@@ -61,23 +53,20 @@ describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
 
   describe("payment-link payments", () => {
     it("lists payments for a payment link", () => {
-      const listOutput = cli("--output", "json", "payment-link", "list");
-      const links = JSON.parse(listOutput) as { id: string }[];
-      if (links.length === 0) {
-        return; // No payment links in sandbox
-      }
+      const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
+      if (stdout === SKIP) return;
+      const links = JSON.parse(stdout) as { id: string }[];
+      if (links.length === 0) return; // No payment links in sandbox
 
       const firstLink = links[0] as { id: string };
-      const output = cli("--output", "json", "payment-link", "payments", firstLink.id);
-      const parsed = JSON.parse(output) as unknown[];
+      const parsed = cliJson<unknown[]>("payment-link", "payments", firstLink.id);
       expect(Array.isArray(parsed)).toBe(true);
     });
   });
 
   describe("payment-link methods", () => {
     it("lists available payment methods", () => {
-      const output = cli("--output", "json", "payment-link", "methods");
-      const parsed = JSON.parse(output) as unknown[];
+      const parsed = cliJson<unknown[]>("payment-link", "methods");
       expect(Array.isArray(parsed)).toBe(true);
       for (const item of parsed) {
         const method = item as Record<string, unknown>;
@@ -89,8 +78,12 @@ describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
 
   describe("payment-link connection-status", () => {
     it("returns connection status", () => {
-      const output = cli("--output", "json", "payment-link", "connection-status");
-      const parsed = JSON.parse(output) as unknown;
+      // The connection endpoint returns 404 when no payment-link connection
+      // is established for the organization (sandbox default). Skip rather
+      // than fail (#490).
+      const stdout = skipIfNotFound("--output", "json", "payment-link", "connection-status");
+      if (stdout === SKIP) return;
+      const parsed = JSON.parse(stdout) as unknown;
       expect(parsed).toBeDefined();
     });
   });

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
+import { resolve } from "node:path";
+import { expect } from "vitest";
+import { cliEnv } from "./sandbox.js";
+
+/**
+ * Absolute path to the bundled CLI binary used by spawned-process E2E
+ * tests. Computed once at module load via `import.meta.url`, so it is
+ * independent of the spawning test's location within `packages/e2e/src/`.
+ */
+export const CLI_PATH = resolve(import.meta.dirname, "..", "..", "qontoctl", "dist", "cli.js");
+
+/**
+ * Default timeout for CLI invocations from E2E tests (15s). Individual
+ * tests can override via {@link cliRaw}'s `options.timeout`.
+ */
+const DEFAULT_CLI_TIMEOUT_MS = 15_000;
+
+/**
+ * Outcome of a CLI invocation that may legitimately fail in some
+ * sandbox configurations. The `failed` variant carries enough context
+ * for tests to make per-test skip vs. fail decisions.
+ */
+export type CliResult =
+  | { readonly ok: true; readonly stdout: string }
+  | { readonly ok: false; readonly status: number; readonly stdout: string; readonly stderr: string };
+
+interface ExecError {
+  readonly status?: number;
+  readonly stdout?: Buffer | string;
+  readonly stderr?: Buffer | string;
+  readonly message: string;
+}
+
+/**
+ * Run the bundled CLI with the given arguments and return the structured
+ * outcome (success or non-zero exit with captured streams). Inherits
+ * credentials from {@link cliEnv}.
+ *
+ * Use this when a test wants to inspect the failure shape before deciding
+ * whether to skip or fail (e.g. detecting HTTP 404 from sandbox feature
+ * gating). For the simpler "throw on failure" pattern, use {@link cli}.
+ */
+export function cliRaw(args: readonly string[], options: { timeout?: number } = {}): CliResult {
+  const execOptions: ExecFileSyncOptions = {
+    encoding: "utf-8",
+    env: cliEnv(),
+    timeout: options.timeout ?? DEFAULT_CLI_TIMEOUT_MS,
+  };
+
+  try {
+    const stdout = execFileSync("node", [CLI_PATH, ...args], execOptions);
+    return { ok: true, stdout: typeof stdout === "string" ? stdout : stdout.toString("utf-8") };
+  } catch (error: unknown) {
+    const e = error as ExecError;
+    return {
+      ok: false,
+      status: e.status ?? 1,
+      stdout: bufferToString(e.stdout),
+      stderr: bufferToString(e.stderr),
+    };
+  }
+}
+
+function bufferToString(value: Buffer | string | undefined): string {
+  if (value === undefined) return "";
+  return typeof value === "string" ? value : value.toString("utf-8");
+}
+
+/**
+ * Run the bundled CLI with the given arguments and return stdout.
+ * Throws on non-zero exit (mirrors `execFileSync` semantics).
+ *
+ * The single canonical CLI invocation helper for E2E tests — use this
+ * instead of duplicating the `execFileSync(node, [CLI_PATH, ...args], ...)`
+ * boilerplate in every test file.
+ */
+export function cli(...args: string[]): string {
+  return execFileSync("node", [CLI_PATH, ...args], {
+    encoding: "utf-8",
+    env: cliEnv(),
+    timeout: DEFAULT_CLI_TIMEOUT_MS,
+  });
+}
+
+/**
+ * Run the bundled CLI with `--output json` (prepended) and parse the
+ * stdout as JSON. Convenience over {@link cli} for the very common
+ * "list/show as JSON" pattern.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters -- callers pin the parsed shape via `cliJson<Foo[]>(...)`
+export function cliJson<T>(...args: string[]): T {
+  const output = cli("--output", "json", ...args);
+  return JSON.parse(output) as T;
+}
+
+/**
+ * Pattern matchers for stderr text emitted by the CLI's error handler
+ * (`packages/cli/src/error-handler.ts`). The CLI exits non-zero with a
+ * standardized "Qonto API error (HTTP {status}):" prefix, so tests can
+ * cheaply inspect `result.stderr` to distinguish sandbox-feature 404s
+ * from genuine bugs.
+ */
+const QONTO_HTTP_STATUS_RE = /^Qonto API error \(HTTP (\d+)\):/m;
+
+/**
+ * Extract the HTTP status code from a failed CLI invocation's stderr,
+ * matching the canonical "Qonto API error (HTTP {status}):" prefix.
+ * Returns `undefined` when stderr does not contain the prefix (e.g.
+ * config error, unknown failure mode, timeout).
+ */
+export function qontoHttpStatus(stderr: string): number | undefined {
+  const match = QONTO_HTTP_STATUS_RE.exec(stderr);
+  if (match === null || match[1] === undefined) return undefined;
+  const code = Number.parseInt(match[1], 10);
+  return Number.isFinite(code) ? code : undefined;
+}
+
+/**
+ * Sentinel returned by {@link skipIfQontoStatus} when the CLI failed
+ * with one of the caller-supplied "ok to skip" HTTP statuses. Tests
+ * compare via `=== SKIP` and `return` to short-circuit, mirroring the
+ * existing `if (items.length === 0) return;` skip-if-empty idiom.
+ */
+export const SKIP: unique symbol = Symbol("skip");
+export type Skip = typeof SKIP;
+
+/**
+ * Run a CLI invocation and either return its stdout or {@link SKIP}
+ * when the call failed with one of the caller-supplied HTTP statuses
+ * (typically `404`, sometimes `403`/`422`). Re-throws on any other
+ * failure shape — only "expected" sandbox-feature gaps are absorbed.
+ *
+ * Standard usage in a test:
+ *
+ * ```ts
+ * const stdout = skipIfQontoStatus([404], "payment-link", "list");
+ * if (stdout === SKIP) return; // Feature unavailable in this sandbox
+ * const items = JSON.parse(stdout) as { id: string }[];
+ * ```
+ *
+ * Uses Vitest's `console.warn` so the skip reason is visible in CI
+ * logs without forcing a custom reporter.
+ */
+export function skipIfQontoStatus(skippableStatuses: readonly number[], ...args: string[]): string | Skip {
+  const result = cliRaw(args);
+  if (result.ok) return result.stdout;
+
+  const status = qontoHttpStatus(result.stderr);
+  if (status !== undefined && skippableStatuses.includes(status)) {
+    console.warn(`[e2e] skipping: ${args.join(" ")} -> HTTP ${String(status)} (sandbox feature unavailable)`);
+    return SKIP;
+  }
+
+  // Genuine failure — re-throw the original error so the test fails with
+  // useful context.
+  throw new Error(
+    `CLI failed: \`${args.join(" ")}\` exit=${String(result.status)}\n--- stderr ---\n${result.stderr}\n--- stdout ---\n${result.stdout}`,
+  );
+}
+
+/**
+ * Convenience over {@link skipIfQontoStatus} for the very common "skip
+ * on 404 (feature gated, resource missing) but fail on anything else"
+ * pattern.
+ */
+export function skipIfNotFound(...args: string[]): string | Skip {
+  return skipIfQontoStatus([404], ...args);
+}
+
+/**
+ * Single-entry MCP tool result content shape (text payload).
+ */
+interface McpTextContent {
+  readonly type: string;
+  readonly text: string;
+}
+
+/**
+ * Extract the first `text`-typed content entry from an MCP `callTool`
+ * result. Centralizes the assertion-laden boilerplate previously
+ * duplicated across every MCP E2E test file.
+ */
+export function firstTextFromMcpResult(result: { content: unknown }): string {
+  const content = result.content as McpTextContent[];
+  expect(content).toHaveLength(1);
+  const entry = content[0] as McpTextContent;
+  expect(entry.type).toBe("text");
+  return entry.text;
+}


### PR DESCRIPTION
## Summary

- Establishes the **project pattern for sandbox-data-dependent E2E tests** in `packages/e2e/src/helpers.ts` (`cli` / `cliJson` / `cliRaw` / `skipIfNotFound` / `skipIfQontoStatus` / `qontoHttpStatus` / `firstTextFromMcpResult` / `SKIP` sentinel / `CLI_PATH`) and documents it in `docs/e2e-testing.md` § Sandbox-data-dependent tests.
- Applies the pattern to the **payment-link** and **mcp-payment-links** suites as the canonical reference. These were the worst offenders (entire feature gated by subscription → HTTP 404, plus a pagination quirk causing infinite loops).
- Fixes the underlying **pagination next_page:0 quirk** (extends #489): Qonto's `/v2/payment_links` returns `next_page: 0` rather than `null` on empty result sets, looping forever requesting `?page=0`. The combined guard (`typeof === "number" && > 0 && > current_page`) covers the cards quirk (#489), the payment-links quirk (#490), and any future malformed meta.
- Fixes a small **label show** test bug: `label show --output json` emits a bare object, but the test was parsing as a 1-row array.

Per #490's explicit "**OK to do payment-link first as a pattern reference and split the rest into follow-ups**" guidance, the remaining failing suites are deferred to:

- **#514** — Zod schema mismatches surfaced during the audit (real `core` bugs, not test brittleness): `MembershipSchema` (role/team_id nullable for invitable members), `BeneficiarySchema` (bank_account nesting in sandbox), `CreditNoteSchema` (relax `header` / `footer` / `client` / `invoice_url` / `einvoicing_status`), `ClientInvoiceClientSchema` (first_name/last_name optional for company type — same class as #496).
- **#515** — apply the new helpers to the ~30 remaining E2E suites for consistency / DRY cleanup.

Closes #490.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — 712+ unit tests pass, including 2 new pagination regressions (next_page:0 + strict-progress)
- [ ] `pnpm test:e2e` — **blocked locally** by an expired OAuth refresh token in the authoring environment (rotated upstream during the session). The CI E2E job is api-key-only and won't exercise these OAuth-gated tests; reviewer should run `pnpm test:e2e` locally with fresh OAuth to confirm the skip paths trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)