### PR TITLE
(fix) SCA continuation E2E: select non-trusted beneficiary, redirect spinner to stderr, allow null bic (#491)

### DIFF
--- a/packages/cli/src/commands/beneficiary/add.ts
+++ b/packages/cli/src/commands/beneficiary/add.ts
@@ -23,7 +23,7 @@ function toTableRow(b: Beneficiary): Record<string, string | boolean> {
     id: b.id,
     name: b.name,
     iban: b.iban,
-    bic: b.bic,
+    bic: b.bic ?? "",
     status: b.status,
     trusted: b.trusted,
   };

--- a/packages/cli/src/commands/beneficiary/show.ts
+++ b/packages/cli/src/commands/beneficiary/show.ts
@@ -25,7 +25,7 @@ export function registerBeneficiaryShowCommand(parent: Command): void {
               id: b.id,
               name: b.name,
               iban: b.iban,
-              bic: b.bic,
+              bic: b.bic ?? "",
               email: b.email ?? "",
               activity_tag: b.activity_tag ?? "",
               status: b.status,

--- a/packages/cli/src/commands/beneficiary/update.ts
+++ b/packages/cli/src/commands/beneficiary/update.ts
@@ -22,7 +22,7 @@ function toTableRow(b: Beneficiary): Record<string, string | boolean> {
     id: b.id,
     name: b.name,
     iban: b.iban,
-    bic: b.bic,
+    bic: b.bic ?? "",
     status: b.status,
     trusted: b.trusted,
   };

--- a/packages/cli/src/sca.ts
+++ b/packages/cli/src/sca.ts
@@ -53,7 +53,12 @@ export async function executeWithCliSca<T>(
   try {
     return await executeWithSca(client, operation, {
       onScaRequired: () => {
-        s = (options?.createSpinner ?? spinner)();
+        // Spinner writes to stderr (not the default stdout) so machine-readable
+        // output modes (`--output json`, `--output yaml`) keep a clean stdout
+        // — escape sequences and progress frames would otherwise corrupt the
+        // structured payload (#491). stderr is the conventional channel for
+        // progress indicators and is what interactive users already see.
+        s = (options?.createSpinner ?? (() => spinner({ output: process.stderr })))();
         s.start("Waiting for SCA approval on your Qonto mobile app...");
       },
       onPoll: (_attempt, elapsedMs) => {

--- a/packages/core/src/beneficiaries/schemas.test.ts
+++ b/packages/core/src/beneficiaries/schemas.test.ts
@@ -24,16 +24,19 @@ describe("BeneficiarySchema", () => {
   });
 
   it("accepts null for nullable fields", () => {
-    const result = BeneficiarySchema.parse({ ...validBeneficiary, email: null, activity_tag: null });
+    const result = BeneficiarySchema.parse({ ...validBeneficiary, bic: null, email: null, activity_tag: null });
+    expect(result.bic).toBeNull();
     expect(result.email).toBeNull();
     expect(result.activity_tag).toBeNull();
   });
 
-  it("defaults absent email and activity_tag to null", () => {
+  it("defaults absent bic, email, and activity_tag to null", () => {
     const input = { ...validBeneficiary };
+    delete (input as Record<string, unknown>).bic;
     delete (input as Record<string, unknown>).email;
     delete (input as Record<string, unknown>).activity_tag;
     const result = BeneficiarySchema.parse(input);
+    expect(result.bic).toBeNull();
     expect(result.email).toBeNull();
     expect(result.activity_tag).toBeNull();
   });

--- a/packages/core/src/beneficiaries/schemas.ts
+++ b/packages/core/src/beneficiaries/schemas.ts
@@ -13,7 +13,10 @@ export const BeneficiarySchema = z
     id: z.string(),
     name: z.string(),
     iban: z.string(),
-    bic: z.string(),
+    // BIC is nullable: the Qonto API derives BIC from IBAN where possible
+    // (e.g., French SEPA IBANs), but returns `null` when derivation fails
+    // (typical for foreign-bank or partial-data beneficiaries).
+    bic: z.nullable(z.string()).optional().default(null),
     email: z.nullable(z.string()).optional().default(null),
     activity_tag: z.nullable(z.string()).optional().default(null),
     status: z.enum(["pending", "validated", "declined"]),

--- a/packages/core/src/types/beneficiary.ts
+++ b/packages/core/src/types/beneficiary.ts
@@ -3,12 +3,16 @@
 
 /**
  * A SEPA beneficiary — a recipient of SEPA transfers.
+ *
+ * `bic` is nullable: the Qonto API derives BIC from IBAN where possible (e.g.,
+ * French SEPA IBANs), but returns `null` when derivation fails (typical for
+ * foreign-bank or partial-data beneficiaries).
  */
 export interface Beneficiary {
   readonly id: string;
   readonly name: string;
   readonly iban: string;
-  readonly bic: string;
+  readonly bic: string | null;
   readonly email: string | null;
   readonly activity_tag: string | null;
   readonly status: "pending" | "validated" | "declined";

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -27,6 +27,7 @@ interface BeneficiaryItem {
   readonly name: string;
   readonly iban: string;
   readonly status: string;
+  readonly trusted: boolean;
 }
 
 interface BankAccountItem {
@@ -59,11 +60,27 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
 
   beforeAll(() => {
     const beneficiaries = cliJson<BeneficiaryItem[]>("beneficiary", "list");
-    const validatedBeneficiary = beneficiaries.find((b) => b.status === "validated") ?? beneficiaries[0];
-    if (validatedBeneficiary === undefined) {
-      throw new Error("E2E setup: no beneficiaries available in sandbox");
+    // PSD2 Article 13(b): transfers to "trusted" beneficiaries are exempt from
+    // SCA. To exercise the SCA continuation flow under test we MUST pick a
+    // non-trusted beneficiary — otherwise the sandbox responds to the initial
+    // POST with 200 OK directly, no 428/polling URL is logged, and the test
+    // fails at the "capture SCA session token" assertion (#491).
+    //
+    // Prefer `validated && !trusted` so the SCA challenge under test is the
+    // transfer-level one (the code path the SCA continuation flow is designed
+    // for). Fall back to any `!trusted` beneficiary (typically `pending`),
+    // whose first-use validation challenge produces an equivalent SCA session
+    // that exercises the same client polling/retry code path.
+    const beneficiary =
+      beneficiaries.find((b) => b.status === "validated" && !b.trusted) ?? beneficiaries.find((b) => !b.trusted);
+    if (beneficiary === undefined) {
+      throw new Error(
+        "E2E setup: no non-trusted beneficiaries available in sandbox; " +
+          "SCA-continuation tests need an untrusted beneficiary to trigger the SCA gate " +
+          "(trusted beneficiaries are SCA-exempt under PSD2 Article 13(b))",
+      );
     }
-    beneficiaryId = validatedBeneficiary.id;
+    beneficiaryId = beneficiary.id;
 
     const accounts = cliJson<BankAccountItem[]>("account", "list");
     const firstAccount = accounts[0];
@@ -78,9 +95,9 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       "transfer",
       "verify-payee",
       "--iban",
-      validatedBeneficiary.iban,
+      beneficiary.iban,
       "--name",
-      validatedBeneficiary.name,
+      beneficiary.name,
     );
     vopProofToken = vop.proof_token.token;
   });

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -34,6 +34,7 @@ interface BeneficiaryItem {
   readonly name: string;
   readonly iban: string;
   readonly status: string;
+  readonly trusted: boolean;
 }
 
 interface BankAccountItem {
@@ -98,10 +99,26 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     const beneficiaryList = JSON.parse(firstText(beneficiaryListResult.content)) as {
       beneficiaries: BeneficiaryItem[];
     };
+    // PSD2 Article 13(b): transfers to "trusted" beneficiaries are exempt from
+    // SCA. To exercise the SCA continuation flow under test we MUST pick a
+    // non-trusted beneficiary — otherwise the sandbox responds to the initial
+    // POST with 200 OK directly, no 428/polling URL is logged, and the test
+    // fails at the "capture SCA session token" assertion (#491).
+    //
+    // Prefer `validated && !trusted` so the SCA challenge under test is the
+    // transfer-level one (the code path the SCA continuation flow is designed
+    // for). Fall back to any `!trusted` beneficiary (typically `pending`),
+    // whose first-use validation challenge produces an equivalent SCA session
+    // that exercises the same client polling/retry code path.
     const beneficiary =
-      beneficiaryList.beneficiaries.find((b) => b.status === "validated") ?? beneficiaryList.beneficiaries[0];
+      beneficiaryList.beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
+      beneficiaryList.beneficiaries.find((b) => !b.trusted);
     if (beneficiary === undefined) {
-      throw new Error("E2E setup: no beneficiaries available in sandbox");
+      throw new Error(
+        "E2E setup: no non-trusted beneficiaries available in sandbox; " +
+          "SCA-continuation tests need an untrusted beneficiary to trigger the SCA gate " +
+          "(trusted beneficiaries are SCA-exempt under PSD2 Article 13(b))",
+      );
     }
     beneficiaryId = beneficiary.id;
     beneficiaryName = beneficiary.name;


### PR DESCRIPTION
## Summary

Fixes #491 — SCA continuation E2E tests failed with `expected to capture SCA session token from polling URL: expected undefined to be defined`. Three independent root causes had to be fixed for both CLI and MCP suites to pass:

- **Beneficiary selection (test, CLI + MCP)**: under PSD2 Article 13(b), trusted beneficiaries are SCA-exempt; every validated sandbox beneficiary is also trusted, so the transfer POST returned 200 OK directly with no 428/polling URL. Tests now prefer `validated && !trusted`, falling back to any `!trusted` beneficiary (typically `pending` — its first-use validation challenge exercises the same client polling/retry path).
- **CLI spinner stream (`packages/cli/src/sca.ts`)**: spinner now writes to `process.stderr` (was the clack default `process.stdout`). Cursor escape sequences and progress frames were corrupting `--output json` payloads, breaking the test's `JSON.parse(stdout)` assertion. stderr is the conventional channel for progress indicators; interactive UX is unchanged.
- **Beneficiary BIC schema (`packages/core/src/beneficiaries/schemas.ts`)**: Qonto returns `bic: null` for beneficiaries where derivation from IBAN fails (foreign-bank or partial-data entries). The strict `bic: z.string()` rejected the entire list, blocking the MCP `beneficiary_list` tool — even before the test's setup ran. Aligned with the existing `email` / `activity_tag` nullable pattern; `Beneficiary.bic` is now `string | null`. CLI table-display callers gain `?? ""` fallback.

## Test plan

- [x] `pnpm test:e2e` for `packages/e2e/src/sca-continuation/` — all 4 tests pass (1 CLI + 3 MCP), ~12s
- [x] `pnpm test` — all 710 unit tests pass (incl. updated `BeneficiarySchema` test for null `bic` field + default-when-absent)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean

Other E2E failures observed during full-suite run (cards, intl-beneficiaries, international, payment-link, insurance) are unrelated to this PR — being addressed by parallel work (e.g. #488 international schema alignment, #489 cards pagination, #490 E2E shared helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)