### PR TITLE
(test) E2E: skip account iban-certificate when org is not KYB-accepted (#511)

### DIFF
--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -172,6 +172,55 @@ export function skipIfNotFound(...args: string[]): string | Skip {
 }
 
 /**
+ * Run a CLI invocation and return {@link SKIP} when the call failed with
+ * one of the caller-supplied HTTP statuses **and** the stderr contains
+ * any of the caller-supplied substrings. More restrictive than
+ * {@link skipIfQontoStatus} alone — useful for HTTP 400 cases where the
+ * status is generic but the error message identifies a specific known
+ * environmental limitation (e.g. `"Organization is not KYB accepted"`
+ * for IBAN-certificate generation against non-KYB-validated test orgs).
+ *
+ * Re-throws on any other failure shape — only the explicitly-named
+ * limitation is absorbed; unrelated 400s still fail the test.
+ *
+ * Standard usage:
+ *
+ * ```ts
+ * const stdout = skipIfQontoErrorContains(
+ *   [400],
+ *   ["KYB accepted"],
+ *   "account", "iban-certificate", id, "--output-file", path,
+ * );
+ * if (stdout === SKIP) return; // Test org not KYB-validated
+ * ```
+ */
+export function skipIfQontoErrorContains(
+  skippableStatuses: readonly number[],
+  errorPatterns: readonly string[],
+  ...args: string[]
+): string | Skip {
+  const result = cliRaw(args);
+  if (result.ok) return result.stdout;
+
+  const status = qontoHttpStatus(result.stderr);
+  if (status !== undefined && skippableStatuses.includes(status)) {
+    const matched = errorPatterns.find((p) => result.stderr.includes(p));
+    if (matched !== undefined) {
+      console.warn(
+        `[e2e] skipping: ${args.join(" ")} -> HTTP ${String(status)} matching "${matched}" (known environmental limitation)`,
+      );
+      return SKIP;
+    }
+  }
+
+  // Genuine failure — re-throw the original error so the test fails with
+  // useful context.
+  throw new Error(
+    `CLI failed: \`${args.join(" ")}\` exit=${String(result.status)}\n--- stderr ---\n${result.stderr}\n--- stdout ---\n${result.stdout}`,
+  );
+}
+
+/**
  * Single-entry MCP tool result content shape (text payload).
  */
 interface McpTextContent {

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
+import { SKIP, skipIfQontoErrorContains } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
@@ -105,9 +106,25 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   it("account iban-certificate downloads a PDF file", () => {
     const outputFile = join(tmpdir(), `iban-cert-e2e-${Date.now()}.pdf`);
     try {
-      const output = cli(["account", "iban-certificate", knownAccountId, "--output-file", outputFile]);
-      expect(output).toContain("Downloaded:");
-      expect(output).toContain(outputFile);
+      // The IBAN-certificate endpoint requires the organization to be
+      // KYB-validated. Sandbox test orgs and Qonto-issued test API-key
+      // orgs are typically not KYB-accepted, returning HTTP 400
+      // `iban_generation_failed: Organization is not KYB accepted`. Skip
+      // rather than fail in that environmental case (#511); KYB-validated
+      // orgs still exercise the full PDF download path.
+      const stdout = skipIfQontoErrorContains(
+        [400],
+        ["KYB accepted"],
+        "account",
+        "iban-certificate",
+        knownAccountId,
+        "--output-file",
+        outputFile,
+      );
+      if (stdout === SKIP) return;
+
+      expect(stdout).toContain("Downloaded:");
+      expect(stdout).toContain(outputFile);
       expect(existsSync(outputFile)).toBe(true);
 
       const content = readFileSync(outputFile);

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -136,7 +136,25 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
       name: "account_iban_certificate",
       arguments: { id: accountId },
     });
-    expect(result.isError).not.toBe(true);
+
+    // The IBAN-certificate endpoint requires the organization to be
+    // KYB-validated. Sandbox test orgs and Qonto-issued test API-key
+    // orgs are typically not KYB-accepted, surfacing as MCP
+    // `isError: true` with text `Qonto API error (HTTP 400): …
+    // iban_generation_failed: Organization is not KYB accepted`. Skip
+    // rather than fail in that environmental case (#511); KYB-validated
+    // orgs still exercise the full PDF download path. Mirrors the CLI
+    // test's `skipIfQontoErrorContains([400], ["KYB accepted"])` pattern.
+    if (result.isError === true) {
+      const errorText = (result.content as { type: string; text?: string }[])[0]?.text ?? "";
+      if (errorText.includes("KYB accepted")) {
+        console.warn(
+          `[e2e] skipping: account_iban_certificate -> HTTP 400 matching "KYB accepted" (known environmental limitation)`,
+        );
+        return;
+      }
+      throw new Error(`account_iban_certificate failed unexpectedly: ${errorText}`);
+    }
 
     const content = result.content as { type: string; resource?: { blob: string; mimeType: string } }[];
     expect(content).toHaveLength(1);


### PR DESCRIPTION
## Summary

The IBAN-certificate endpoint requires the organization to be KYB-validated. Sandbox test orgs and Qonto-issued test API-key orgs are typically not KYB-accepted, returning HTTP 400 `iban_generation_failed: Organization is not KYB accepted`.

This change adds a graceful skip with documented limitation note, so non-KYB test orgs no longer fail the suite while KYB-validated orgs still exercise the full PDF download path.

Closes #511.

## Changes

- **`packages/e2e/src/helpers.ts`** — Add `skipIfQontoErrorContains(statuses, patterns, ...args)` that layers error-message substring matching atop the existing `skipIfQontoStatus` pattern (introduced in #490). Only skips when status matches AND stderr contains a known-environmental phrase, so unrelated 400s still fail the test (re-throws with full context).
- **`packages/e2e/src/org-accounts/cli.e2e.test.ts`** — Use the new helper in the `account iban-certificate` test with `[400]` + `["KYB accepted"]`.
- **`packages/e2e/src/org-accounts/mcp.e2e.test.ts`** — Parallel inline check on the MCP `result.isError` + content text (no MCP-side helper exists). Throws on any non-KYB error to preserve prior strictness.

## Verification

Local sandbox repro (OAuth + staging-token; api-key path not exercisable locally because credentials are OAuth-only and the suite gates on `hasApiKeyCredentials()`):

- **Positive case** — direct call against sandbox `account iban-certificate` returns HTTP 400 `iban_generation_failed: Organization is not KYB accepted`. Helper returns `SKIP` with `console.warn`:
  ```
  [e2e] skipping: account iban-certificate <id> --output-file <path> -> HTTP 400 matching "KYB accepted" (known environmental limitation)
  ```
- **Negative case** — same call with a non-matching pattern (e.g. `["nonexistent-pattern-xyz"]`) re-throws with the full `CLI failed: …` error, confirming unrelated 400s still fail the test.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, and full unit test suite (716 tests) all pass.
- Local OAuth-only E2E run shows org-accounts suite skips naturally (no api-key creds), as expected; CI E2E (api-key + production) will exercise the new skip path on this PR.

## Test plan

- [x] Build / typecheck / lint / format-check clean
- [x] Helper verified live against sandbox (positive + negative)
- [x] Unit tests pass (716/716)
- [ ] CI E2E confirms iban-certificate test now skips with the documented warn (instead of failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)