### PR TITLE
(fix) align insurance-contracts Zod schemas and CLI/MCP surface with actual Qonto API (#509)

### DIFF
--- a/packages/cli/src/commands/insurance.test.ts
+++ b/packages/cli/src/commands/insurance.test.ts
@@ -15,14 +15,16 @@ import { createClient } from "../client.js";
 
 const sampleContract = {
   id: "ic-123",
-  insurance_type: "professional_liability",
+  name: "ProLiability Plan 2026",
+  contract_id: "CNT-12345",
+  origin: "qonto_other",
+  provider_slug: "axa",
+  type: "business_liability",
   status: "active",
-  provider_name: "AXA",
-  contract_number: "CNT-12345",
+  payment_frequency: "annual",
+  price: { value: "99.99", currency: "EUR" },
   start_date: "2026-01-01",
-  end_date: "2027-01-01",
-  created_at: "2026-01-01T10:00:00Z",
-  updated_at: "2026-01-01T10:00:00Z",
+  expiration_date: "2027-01-01",
 };
 
 const sampleDocument = {
@@ -79,7 +81,7 @@ describe("insurance commands", () => {
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("ic-123");
-      expect(output).toContain("AXA");
+      expect(output).toContain("axa");
     });
 
     it("shows contract details in json format", async () => {
@@ -95,8 +97,8 @@ describe("insurance commands", () => {
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", "ic-123");
-      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
-      expect(parsed).toHaveProperty("provider_name", "AXA");
+      expect(parsed).toHaveProperty("type", "business_liability");
+      expect(parsed).toHaveProperty("provider_slug", "axa");
     });
 
     it("sends GET to the correct API endpoint", async () => {
@@ -115,6 +117,29 @@ describe("insurance commands", () => {
   });
 
   describe("insurance create", () => {
+    const createArgs = [
+      "insurance",
+      "create",
+      "--name",
+      "ProLiability Plan 2026",
+      "--contract-id",
+      "CNT-12345",
+      "--origin",
+      "qonto_other",
+      "--provider-slug",
+      "axa",
+      "--type",
+      "business_liability",
+      "--status",
+      "active",
+      "--payment-frequency",
+      "annual",
+      "--price-value",
+      "99.99",
+      "--price-currency",
+      "EUR",
+    ];
+
     it("creates a contract in table format", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
@@ -122,48 +147,22 @@ describe("insurance commands", () => {
       const program = createProgram();
       program.exitOverride();
 
-      await program.parseAsync(
-        [
-          "insurance",
-          "create",
-          "--insurance-type",
-          "professional_liability",
-          "--provider-name",
-          "AXA",
-          "--start-date",
-          "2026-01-01",
-        ],
-        { from: "user" },
-      );
+      await program.parseAsync(createArgs, { from: "user" });
 
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("ic-123");
-      expect(output).toContain("AXA");
+      expect(output).toContain("axa");
     });
 
-    it("sends POST with correct body", async () => {
+    it("sends POST with correct body (mandatory fields only)", async () => {
       fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
       program.exitOverride();
 
-      await program.parseAsync(
-        [
-          "insurance",
-          "create",
-          "--insurance-type",
-          "professional_liability",
-          "--provider-name",
-          "AXA",
-          "--start-date",
-          "2026-01-01",
-          "--contract-number",
-          "CNT-12345",
-        ],
-        { from: "user" },
-      );
+      await program.parseAsync(createArgs, { from: "user" });
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/insurance_contracts");
@@ -172,12 +171,63 @@ describe("insurance commands", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         insurance_contract: {
-          insurance_type: "professional_liability",
-          provider_name: "AXA",
-          start_date: "2026-01-01",
-          contract_number: "CNT-12345",
+          name: "ProLiability Plan 2026",
+          contract_id: "CNT-12345",
+          origin: "qonto_other",
+          provider_slug: "axa",
+          type: "business_liability",
+          status: "active",
+          payment_frequency: "annual",
+          price: { value: "99.99", currency: "EUR" },
         },
       });
+    });
+
+    it("sends POST with all optional fields when provided", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(
+        [
+          ...createArgs,
+          "--start-date",
+          "2026-01-01",
+          "--expiration-date",
+          "2027-01-01",
+          "--renewal-date",
+          "2026-12-15",
+          "--service-url",
+          "https://service.example.com",
+          "--troubleshooting-url",
+          "https://help.example.com",
+        ],
+        { from: "user" },
+      );
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const body = JSON.parse(opts.body as string) as { insurance_contract: Record<string, unknown> };
+      expect(body.insurance_contract).toMatchObject({
+        start_date: "2026-01-01",
+        expiration_date: "2027-01-01",
+        renewal_date: "2026-12-15",
+        service_url: "https://service.example.com",
+        troubleshooting_url: "https://help.example.com",
+      });
+    });
+
+    it("rejects unknown origin values", async () => {
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      const argsWithBadOrigin = createArgs.map((arg, idx) => {
+        return idx > 0 && createArgs[idx - 1] === "--origin" ? "made_up" : arg;
+      });
+
+      await expect(program.parseAsync(argsWithBadOrigin, { from: "user" })).rejects.toThrow();
     });
   });
 
@@ -189,14 +239,41 @@ describe("insurance commands", () => {
       const program = createProgram();
       program.exitOverride();
 
-      await program.parseAsync(["insurance", "update", "ic-123", "--provider-name", "Allianz"], { from: "user" });
+      await program.parseAsync(["insurance", "update", "ic-123", "--provider-slug", "allianz"], { from: "user" });
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/insurance_contracts/ic-123");
-      expect(opts.method).toBe("PUT");
+      expect(opts.method).toBe("PATCH");
 
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toEqual({ insurance_contract: { provider_name: "Allianz" } });
+      expect(body).toEqual({ insurance_contract: { provider_slug: "allianz" } });
+    });
+
+    it("sends a price object when both --price-value and --price-currency are provided", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ insurance_contract: sampleContract }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await program.parseAsync(
+        ["insurance", "update", "ic-123", "--price-value", "120.00", "--price-currency", "EUR"],
+        { from: "user" },
+      );
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const body = JSON.parse(opts.body as string) as { insurance_contract: Record<string, unknown> };
+      expect(body.insurance_contract).toEqual({ price: { value: "120.00", currency: "EUR" } });
+    });
+
+    it("rejects partial --price-value without --price-currency", async () => {
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["insurance", "update", "ic-123", "--price-value", "120.00"], { from: "user" }),
+      ).rejects.toThrow(/--price-value and --price-currency must be provided together/);
     });
   });
 

--- a/packages/cli/src/commands/insurance.ts
+++ b/packages/cli/src/commands/insurance.ts
@@ -4,7 +4,12 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { Command, Option } from "commander";
-import type { InsuranceContract } from "@qontoctl/core";
+import type {
+  InsuranceContract,
+  InsuranceContractOrigin,
+  InsuranceContractPaymentFrequency,
+  InsuranceContractStatus,
+} from "@qontoctl/core";
 import {
   getInsuranceContract,
   createInsuranceContract,
@@ -17,31 +22,64 @@ import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, WriteOptions } from "../options.js";
 
+const ORIGIN_CHOICES = ["insurance_hub", "qonto_other", "stello"] as const;
+const STATUS_CHOICES = [
+  "active",
+  "pending_payment",
+  "pending_others",
+  "action_required",
+  "expired",
+  "archived",
+] as const;
+const PAYMENT_FREQUENCY_CHOICES = ["month", "quarter", "semester", "annual"] as const;
+
 interface InsuranceCreateOptions extends GlobalOptions, WriteOptions {
-  readonly insuranceType: string;
-  readonly providerName: string;
-  readonly contractNumber?: string | undefined;
-  readonly startDate: string;
-  readonly endDate?: string | undefined;
+  readonly name: string;
+  readonly contractId: string;
+  readonly origin: InsuranceContractOrigin;
+  readonly providerSlug: string;
+  readonly type: string;
+  readonly status: InsuranceContractStatus;
+  readonly paymentFrequency: InsuranceContractPaymentFrequency;
+  readonly priceValue: string;
+  readonly priceCurrency: string;
+  readonly startDate?: string | undefined;
+  readonly expirationDate?: string | undefined;
+  readonly renewalDate?: string | undefined;
+  readonly serviceUrl?: string | undefined;
+  readonly troubleshootingUrl?: string | undefined;
 }
 
 interface InsuranceUpdateOptions extends GlobalOptions, WriteOptions {
-  readonly insuranceType?: string | undefined;
-  readonly providerName?: string | undefined;
-  readonly contractNumber?: string | undefined;
+  readonly name?: string | undefined;
+  readonly contractId?: string | undefined;
+  readonly origin?: InsuranceContractOrigin | undefined;
+  readonly providerSlug?: string | undefined;
+  readonly type?: string | undefined;
+  readonly status?: InsuranceContractStatus | undefined;
+  readonly paymentFrequency?: InsuranceContractPaymentFrequency | undefined;
+  readonly priceValue?: string | undefined;
+  readonly priceCurrency?: string | undefined;
   readonly startDate?: string | undefined;
-  readonly endDate?: string | undefined;
+  readonly expirationDate?: string | undefined;
+  readonly renewalDate?: string | undefined;
+  readonly serviceUrl?: string | undefined;
+  readonly troubleshootingUrl?: string | undefined;
 }
 
 function contractToTableRow(c: InsuranceContract): Record<string, string> {
   return {
     id: c.id,
-    insurance_type: c.insurance_type,
+    name: c.name,
+    type: c.type,
     status: c.status,
-    provider_name: c.provider_name,
-    contract_number: c.contract_number ?? "",
-    start_date: c.start_date,
-    end_date: c.end_date ?? "",
+    provider_slug: c.provider_slug,
+    contract_id: c.contract_id,
+    origin: c.origin,
+    payment_frequency: c.payment_frequency,
+    price: `${c.price.value} ${c.price.currency}`,
+    start_date: c.start_date ?? "",
+    expiration_date: c.expiration_date ?? "",
   };
 }
 
@@ -66,11 +104,32 @@ export function registerInsuranceCommands(program: Command): void {
   const create = insurance
     .command("create")
     .description("Create a new insurance contract")
-    .addOption(new Option("--insurance-type <type>", "insurance type").makeOptionMandatory())
-    .addOption(new Option("--provider-name <name>", "insurance provider name").makeOptionMandatory())
-    .option("--contract-number <number>", "contract number")
-    .addOption(new Option("--start-date <date>", "contract start date (YYYY-MM-DD)").makeOptionMandatory())
-    .option("--end-date <date>", "contract end date (YYYY-MM-DD)");
+    .addOption(new Option("--name <name>", "contract display name").makeOptionMandatory())
+    .addOption(new Option("--contract-id <id>", "partner-generated contract identifier").makeOptionMandatory())
+    .addOption(
+      new Option("--origin <origin>", "contract origin")
+        .choices([...ORIGIN_CHOICES])
+        .makeOptionMandatory(),
+    )
+    .addOption(new Option("--provider-slug <slug>", "insurance provider identifier (e.g. axa)").makeOptionMandatory())
+    .addOption(new Option("--type <type>", "insurance category (e.g. business_liability)").makeOptionMandatory())
+    .addOption(
+      new Option("--status <status>", "contract status")
+        .choices([...STATUS_CHOICES])
+        .makeOptionMandatory(),
+    )
+    .addOption(
+      new Option("--payment-frequency <frequency>", "payment frequency")
+        .choices([...PAYMENT_FREQUENCY_CHOICES])
+        .makeOptionMandatory(),
+    )
+    .addOption(new Option("--price-value <amount>", "price amount as a decimal string (e.g. 99.99)").makeOptionMandatory())
+    .addOption(new Option("--price-currency <code>", "price currency code (ISO 4217, e.g. EUR)").makeOptionMandatory())
+    .option("--start-date <date>", "coverage start date (YYYY-MM-DD)")
+    .option("--expiration-date <date>", "contract expiration date (YYYY-MM-DD)")
+    .option("--renewal-date <date>", "policy renewal date (YYYY-MM-DD)")
+    .option("--service-url <url>", "customer portal access URL")
+    .option("--troubleshooting-url <url>", "support / troubleshooting URL");
   addInheritableOptions(create);
   addWriteOptions(create);
   create.action(async (_options: unknown, cmd: Command) => {
@@ -80,11 +139,19 @@ export function registerInsuranceCommands(program: Command): void {
     const contract = await createInsuranceContract(
       client,
       {
-        insurance_type: opts.insuranceType,
-        provider_name: opts.providerName,
-        start_date: opts.startDate,
-        contract_number: opts.contractNumber,
-        end_date: opts.endDate,
+        name: opts.name,
+        contract_id: opts.contractId,
+        origin: opts.origin,
+        provider_slug: opts.providerSlug,
+        type: opts.type,
+        status: opts.status,
+        payment_frequency: opts.paymentFrequency,
+        price: { value: opts.priceValue, currency: opts.priceCurrency },
+        ...(opts.startDate !== undefined ? { start_date: opts.startDate } : {}),
+        ...(opts.expirationDate !== undefined ? { expiration_date: opts.expirationDate } : {}),
+        ...(opts.renewalDate !== undefined ? { renewal_date: opts.renewalDate } : {}),
+        ...(opts.serviceUrl !== undefined ? { service_url: opts.serviceUrl } : {}),
+        ...(opts.troubleshootingUrl !== undefined ? { troubleshooting_url: opts.troubleshootingUrl } : {}),
       },
       opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
     );
@@ -98,26 +165,49 @@ export function registerInsuranceCommands(program: Command): void {
   const update = insurance
     .command("update <id>")
     .description("Update an insurance contract")
-    .option("--insurance-type <type>", "insurance type")
-    .option("--provider-name <name>", "insurance provider name")
-    .option("--contract-number <number>", "contract number")
-    .option("--start-date <date>", "contract start date (YYYY-MM-DD)")
-    .option("--end-date <date>", "contract end date (YYYY-MM-DD)");
+    .option("--name <name>", "contract display name")
+    .option("--contract-id <id>", "partner-generated contract identifier")
+    .addOption(new Option("--origin <origin>", "contract origin").choices([...ORIGIN_CHOICES]))
+    .option("--provider-slug <slug>", "insurance provider identifier")
+    .option("--type <type>", "insurance category")
+    .addOption(new Option("--status <status>", "contract status").choices([...STATUS_CHOICES]))
+    .addOption(new Option("--payment-frequency <frequency>", "payment frequency").choices([...PAYMENT_FREQUENCY_CHOICES]))
+    .option("--price-value <amount>", "price amount as a decimal string")
+    .option("--price-currency <code>", "price currency code (ISO 4217)")
+    .option("--start-date <date>", "coverage start date (YYYY-MM-DD)")
+    .option("--expiration-date <date>", "contract expiration date (YYYY-MM-DD)")
+    .option("--renewal-date <date>", "policy renewal date (YYYY-MM-DD)")
+    .option("--service-url <url>", "customer portal access URL")
+    .option("--troubleshooting-url <url>", "support / troubleshooting URL");
   addInheritableOptions(update);
   addWriteOptions(update);
   update.action(async (id: string, _options: unknown, cmd: Command) => {
     const opts = resolveGlobalOptions<InsuranceUpdateOptions>(cmd);
     const client = await createClient(opts);
 
+    if ((opts.priceValue === undefined) !== (opts.priceCurrency === undefined)) {
+      throw new Error("--price-value and --price-currency must be provided together.");
+    }
+
     const contract = await updateInsuranceContract(
       client,
       id,
       {
-        insurance_type: opts.insuranceType,
-        provider_name: opts.providerName,
-        contract_number: opts.contractNumber,
-        start_date: opts.startDate,
-        end_date: opts.endDate,
+        ...(opts.name !== undefined ? { name: opts.name } : {}),
+        ...(opts.contractId !== undefined ? { contract_id: opts.contractId } : {}),
+        ...(opts.origin !== undefined ? { origin: opts.origin } : {}),
+        ...(opts.providerSlug !== undefined ? { provider_slug: opts.providerSlug } : {}),
+        ...(opts.type !== undefined ? { type: opts.type } : {}),
+        ...(opts.status !== undefined ? { status: opts.status } : {}),
+        ...(opts.paymentFrequency !== undefined ? { payment_frequency: opts.paymentFrequency } : {}),
+        ...(opts.priceValue !== undefined && opts.priceCurrency !== undefined
+          ? { price: { value: opts.priceValue, currency: opts.priceCurrency } }
+          : {}),
+        ...(opts.startDate !== undefined ? { start_date: opts.startDate } : {}),
+        ...(opts.expirationDate !== undefined ? { expiration_date: opts.expirationDate } : {}),
+        ...(opts.renewalDate !== undefined ? { renewal_date: opts.renewalDate } : {}),
+        ...(opts.serviceUrl !== undefined ? { service_url: opts.serviceUrl } : {}),
+        ...(opts.troubleshootingUrl !== undefined ? { troubleshooting_url: opts.troubleshootingUrl } : {}),
       },
       opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
     );

--- a/packages/cli/src/commands/insurance.ts
+++ b/packages/cli/src/commands/insurance.ts
@@ -106,24 +106,18 @@ export function registerInsuranceCommands(program: Command): void {
     .description("Create a new insurance contract")
     .addOption(new Option("--name <name>", "contract display name").makeOptionMandatory())
     .addOption(new Option("--contract-id <id>", "partner-generated contract identifier").makeOptionMandatory())
-    .addOption(
-      new Option("--origin <origin>", "contract origin")
-        .choices([...ORIGIN_CHOICES])
-        .makeOptionMandatory(),
-    )
+    .addOption(new Option("--origin <origin>", "contract origin").choices([...ORIGIN_CHOICES]).makeOptionMandatory())
     .addOption(new Option("--provider-slug <slug>", "insurance provider identifier (e.g. axa)").makeOptionMandatory())
     .addOption(new Option("--type <type>", "insurance category (e.g. business_liability)").makeOptionMandatory())
-    .addOption(
-      new Option("--status <status>", "contract status")
-        .choices([...STATUS_CHOICES])
-        .makeOptionMandatory(),
-    )
+    .addOption(new Option("--status <status>", "contract status").choices([...STATUS_CHOICES]).makeOptionMandatory())
     .addOption(
       new Option("--payment-frequency <frequency>", "payment frequency")
         .choices([...PAYMENT_FREQUENCY_CHOICES])
         .makeOptionMandatory(),
     )
-    .addOption(new Option("--price-value <amount>", "price amount as a decimal string (e.g. 99.99)").makeOptionMandatory())
+    .addOption(
+      new Option("--price-value <amount>", "price amount as a decimal string (e.g. 99.99)").makeOptionMandatory(),
+    )
     .addOption(new Option("--price-currency <code>", "price currency code (ISO 4217, e.g. EUR)").makeOptionMandatory())
     .option("--start-date <date>", "coverage start date (YYYY-MM-DD)")
     .option("--expiration-date <date>", "contract expiration date (YYYY-MM-DD)")
@@ -171,7 +165,9 @@ export function registerInsuranceCommands(program: Command): void {
     .option("--provider-slug <slug>", "insurance provider identifier")
     .option("--type <type>", "insurance category")
     .addOption(new Option("--status <status>", "contract status").choices([...STATUS_CHOICES]))
-    .addOption(new Option("--payment-frequency <frequency>", "payment frequency").choices([...PAYMENT_FREQUENCY_CHOICES]))
+    .addOption(
+      new Option("--payment-frequency <frequency>", "payment frequency").choices([...PAYMENT_FREQUENCY_CHOICES]),
+    )
     .option("--price-value <amount>", "price amount as a decimal string")
     .option("--price-currency <code>", "price currency code (ISO 4217)")
     .option("--start-date <date>", "coverage start date (YYYY-MM-DD)")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -455,16 +455,26 @@ export {
   updateInsuranceContract,
   uploadInsuranceDocument,
   removeInsuranceDocument,
-  InsuranceContractSchema,
+  InsuranceContractDocumentRefSchema,
+  InsuranceContractOriginSchema,
+  InsuranceContractPaymentFrequencySchema,
+  InsuranceContractPriceSchema,
   InsuranceContractResponseSchema,
-  InsuranceDocumentSchema,
+  InsuranceContractSchema,
+  InsuranceContractStatusSchema,
   InsuranceDocumentResponseSchema,
+  InsuranceDocumentSchema,
 } from "./insurance-contracts/index.js";
 
 export type {
-  InsuranceContract,
-  InsuranceDocument,
   CreateInsuranceContractParams,
+  InsuranceContract,
+  InsuranceContractDocumentRef,
+  InsuranceContractOrigin,
+  InsuranceContractPaymentFrequency,
+  InsuranceContractPrice,
+  InsuranceContractStatus,
+  InsuranceDocument,
   UpdateInsuranceContractParams,
 } from "./insurance-contracts/index.js";
 

--- a/packages/core/src/insurance-contracts/index.ts
+++ b/packages/core/src/insurance-contracts/index.ts
@@ -11,11 +11,24 @@ export {
 
 export type { CreateInsuranceContractParams, UpdateInsuranceContractParams } from "./service.js";
 
-export type { InsuranceContract, InsuranceDocument } from "./types.js";
+export type {
+  InsuranceContract,
+  InsuranceContractDocumentRef,
+  InsuranceContractOrigin,
+  InsuranceContractPaymentFrequency,
+  InsuranceContractPrice,
+  InsuranceContractStatus,
+  InsuranceDocument,
+} from "./types.js";
 
 export {
-  InsuranceContractSchema,
+  InsuranceContractDocumentRefSchema,
+  InsuranceContractOriginSchema,
+  InsuranceContractPaymentFrequencySchema,
+  InsuranceContractPriceSchema,
   InsuranceContractResponseSchema,
-  InsuranceDocumentSchema,
+  InsuranceContractSchema,
+  InsuranceContractStatusSchema,
   InsuranceDocumentResponseSchema,
+  InsuranceDocumentSchema,
 } from "./schemas.js";

--- a/packages/core/src/insurance-contracts/schemas.test.ts
+++ b/packages/core/src/insurance-contracts/schemas.test.ts
@@ -56,14 +56,16 @@ describe("InsuranceDocumentResponseSchema", () => {
 describe("InsuranceContractSchema", () => {
   const validContract = {
     id: "contract-1",
-    insurance_type: "health",
+    name: "ProLiability Plan 2026",
+    contract_id: "POL-12345",
+    origin: "qonto_other",
+    provider_slug: "axa",
+    type: "business_liability",
     status: "active",
-    provider_name: "Allianz",
-    contract_number: "POL-12345",
-    start_date: "2025-01-01",
-    end_date: "2026-01-01",
-    created_at: "2025-01-01T00:00:00.000Z",
-    updated_at: "2025-06-01T00:00:00.000Z",
+    payment_frequency: "annual",
+    price: { value: "99.99", currency: "EUR" },
+    start_date: "2026-01-01",
+    expiration_date: "2027-01-01",
   };
 
   it("accepts a valid contract", () => {
@@ -71,20 +73,117 @@ describe("InsuranceContractSchema", () => {
     expect(result).toEqual(validContract);
   });
 
-  it("accepts null for nullable fields", () => {
-    const result = InsuranceContractSchema.parse({
-      ...validContract,
-      contract_number: null,
-      end_date: null,
-    });
-    expect(result.contract_number).toBeNull();
-    expect(result.end_date).toBeNull();
+  it("accepts a minimal contract (omitting all optional fields)", () => {
+    const minimal = {
+      id: "contract-1",
+      name: "ProLiability Plan 2026",
+      contract_id: "POL-12345",
+      origin: "qonto_other",
+      provider_slug: "axa",
+      type: "business_liability",
+      status: "active",
+      payment_frequency: "annual",
+      price: { value: "99.99", currency: "EUR" },
+    };
+    const result = InsuranceContractSchema.parse(minimal);
+    expect(result.id).toBe("contract-1");
+    expect(result.start_date).toBeUndefined();
+    expect(result.expiration_date).toBeUndefined();
+  });
+
+  it("accepts null for nullable date and URL fields", () => {
+    const withNulls = {
+      id: "contract-1",
+      name: "ProLiability Plan 2026",
+      contract_id: "POL-12345",
+      origin: "qonto_other",
+      provider_slug: "axa",
+      type: "business_liability",
+      status: "active",
+      payment_frequency: "annual",
+      price: { value: "99.99", currency: "EUR" },
+      start_date: null,
+      expiration_date: null,
+      renewal_date: null,
+      service_url: null,
+      troubleshooting_url: null,
+    };
+    const result = InsuranceContractSchema.parse(withNulls);
+    expect(result.expiration_date).toBeNull();
+    expect(result.renewal_date).toBeNull();
+    expect(result.service_url).toBeNull();
+    expect(result.troubleshooting_url).toBeNull();
+  });
+
+  it("accepts all known origin enum values", () => {
+    for (const origin of ["insurance_hub", "qonto_other", "stello"] as const) {
+      expect(() => InsuranceContractSchema.parse({ ...validContract, origin })).not.toThrow();
+    }
+  });
+
+  it("rejects unknown origin values", () => {
+    expect(() => InsuranceContractSchema.parse({ ...validContract, origin: "unknown_source" })).toThrow();
+  });
+
+  it("accepts all known status enum values", () => {
+    for (const status of [
+      "active",
+      "pending_payment",
+      "pending_others",
+      "action_required",
+      "expired",
+      "archived",
+    ] as const) {
+      expect(() => InsuranceContractSchema.parse({ ...validContract, status })).not.toThrow();
+    }
+  });
+
+  it("rejects unknown status values", () => {
+    expect(() => InsuranceContractSchema.parse({ ...validContract, status: "draft" })).toThrow();
+  });
+
+  it("accepts all known payment_frequency values", () => {
+    for (const payment_frequency of ["month", "quarter", "semester", "annual"] as const) {
+      expect(() => InsuranceContractSchema.parse({ ...validContract, payment_frequency })).not.toThrow();
+    }
+  });
+
+  it("rejects unknown payment_frequency values", () => {
+    expect(() => InsuranceContractSchema.parse({ ...validContract, payment_frequency: "weekly" })).toThrow();
   });
 
   it("rejects missing required fields", () => {
     expect(() => InsuranceContractSchema.parse({ ...validContract, id: undefined })).toThrow();
-    expect(() => InsuranceContractSchema.parse({ ...validContract, insurance_type: undefined })).toThrow();
-    expect(() => InsuranceContractSchema.parse({ ...validContract, start_date: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, name: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, contract_id: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, origin: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, provider_slug: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, type: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, status: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, payment_frequency: undefined })).toThrow();
+    expect(() => InsuranceContractSchema.parse({ ...validContract, price: undefined })).toThrow();
+  });
+
+  it("accepts a documents array on the contract", () => {
+    const withDocs = {
+      ...validContract,
+      documents: [{ id: "doc-1", name: "policy.pdf", type: "contract" }],
+    };
+    const result = InsuranceContractSchema.parse(withDocs);
+    expect(result.documents).toHaveLength(1);
+    expect(result.documents?.[0]?.id).toBe("doc-1");
+  });
+
+  it("strips unknown fields", () => {
+    const result = InsuranceContractSchema.parse({
+      ...validContract,
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-06-01T00:00:00.000Z",
+      undocumented_field: "ignored",
+    } as unknown);
+    expect(result).not.toHaveProperty("created_at");
+    expect(result).not.toHaveProperty("updated_at");
+    expect(result).not.toHaveProperty("undocumented_field");
   });
 });
 
@@ -93,14 +192,14 @@ describe("InsuranceContractResponseSchema", () => {
     const response = {
       insurance_contract: {
         id: "contract-1",
-        insurance_type: "health",
+        name: "ProLiability Plan 2026",
+        contract_id: "POL-12345",
+        origin: "qonto_other",
+        provider_slug: "axa",
+        type: "business_liability",
         status: "active",
-        provider_name: "Allianz",
-        contract_number: null,
-        start_date: "2025-01-01",
-        end_date: null,
-        created_at: "2025-01-01T00:00:00.000Z",
-        updated_at: "2025-06-01T00:00:00.000Z",
+        payment_frequency: "annual",
+        price: { value: "99.99", currency: "EUR" },
       },
     };
     const result = InsuranceContractResponseSchema.parse(response);

--- a/packages/core/src/insurance-contracts/schemas.ts
+++ b/packages/core/src/insurance-contracts/schemas.ts
@@ -4,6 +4,34 @@
 import { z } from "zod";
 import type { InsuranceContract, InsuranceDocument } from "./types.js";
 
+export const InsuranceContractOriginSchema = z.enum(["insurance_hub", "qonto_other", "stello"]);
+
+export const InsuranceContractStatusSchema = z.enum([
+  "active",
+  "pending_payment",
+  "pending_others",
+  "action_required",
+  "expired",
+  "archived",
+]);
+
+export const InsuranceContractPaymentFrequencySchema = z.enum(["month", "quarter", "semester", "annual"]);
+
+export const InsuranceContractPriceSchema = z
+  .object({
+    value: z.string(),
+    currency: z.string(),
+  })
+  .strip();
+
+export const InsuranceContractDocumentRefSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    type: z.string(),
+  })
+  .strip();
+
 export const InsuranceDocumentSchema = z
   .object({
     id: z.string(),
@@ -15,17 +43,27 @@ export const InsuranceDocumentSchema = z
   })
   .strip() satisfies z.ZodType<InsuranceDocument>;
 
+// The Qonto API returns `null` (not `undefined` / omitted) for date and URL
+// fields that are not set on a contract — so these are modeled as
+// `nullish()` (optional + nullable). Empirically observed against the
+// sandbox `/v2/insurance_contracts` create response (issue #509).
 export const InsuranceContractSchema = z
   .object({
     id: z.string(),
-    insurance_type: z.string(),
-    status: z.string(),
-    provider_name: z.string(),
-    contract_number: z.string().nullable(),
-    start_date: z.string(),
-    end_date: z.string().nullable(),
-    created_at: z.string(),
-    updated_at: z.string(),
+    name: z.string(),
+    contract_id: z.string(),
+    origin: InsuranceContractOriginSchema,
+    provider_slug: z.string(),
+    type: z.string(),
+    status: InsuranceContractStatusSchema,
+    payment_frequency: InsuranceContractPaymentFrequencySchema,
+    price: InsuranceContractPriceSchema,
+    start_date: z.string().nullish(),
+    expiration_date: z.string().nullish(),
+    renewal_date: z.string().nullish(),
+    service_url: z.string().nullish(),
+    troubleshooting_url: z.string().nullish(),
+    documents: z.array(InsuranceContractDocumentRefSchema).nullish(),
   })
   .strip() satisfies z.ZodType<InsuranceContract>;
 

--- a/packages/core/src/insurance-contracts/service.test.ts
+++ b/packages/core/src/insurance-contracts/service.test.ts
@@ -14,14 +14,16 @@ import {
 
 const sampleContract = {
   id: "ic-1",
-  insurance_type: "professional_liability",
-  status: "active",
-  provider_name: "AXA",
-  contract_number: "CNT-12345",
+  name: "ProLiability Plan 2026",
+  contract_id: "CNT-12345",
+  origin: "qonto_other" as const,
+  provider_slug: "axa",
+  type: "business_liability",
+  status: "active" as const,
+  payment_frequency: "annual" as const,
+  price: { value: "99.99", currency: "EUR" },
   start_date: "2026-01-01",
-  end_date: "2027-01-01",
-  created_at: "2026-01-01T10:00:00Z",
-  updated_at: "2026-01-01T10:00:00Z",
+  expiration_date: "2027-01-01",
 };
 
 const sampleDocument = {
@@ -69,9 +71,14 @@ describe("insurance contract service", () => {
       fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
 
       const result = await createInsuranceContract(client, {
-        insurance_type: "professional_liability",
-        provider_name: "AXA",
-        start_date: "2026-01-01",
+        name: "ProLiability Plan 2026",
+        contract_id: "CNT-12345",
+        origin: "qonto_other",
+        provider_slug: "axa",
+        type: "business_liability",
+        status: "active",
+        payment_frequency: "annual",
+        price: { value: "99.99", currency: "EUR" },
       });
 
       expect(result).toEqual(sampleContract);
@@ -83,9 +90,14 @@ describe("insurance contract service", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         insurance_contract: {
-          insurance_type: "professional_liability",
-          provider_name: "AXA",
-          start_date: "2026-01-01",
+          name: "ProLiability Plan 2026",
+          contract_id: "CNT-12345",
+          origin: "qonto_other",
+          provider_slug: "axa",
+          type: "business_liability",
+          status: "active",
+          payment_frequency: "annual",
+          price: { value: "99.99", currency: "EUR" },
         },
       });
     });
@@ -95,7 +107,16 @@ describe("insurance contract service", () => {
 
       await createInsuranceContract(
         client,
-        { insurance_type: "health", provider_name: "MAIF", start_date: "2026-01-01" },
+        {
+          name: "Health Cover",
+          contract_id: "CNT-2",
+          origin: "qonto_other",
+          provider_slug: "maif",
+          type: "health",
+          status: "active",
+          payment_frequency: "annual",
+          price: { value: "499.00", currency: "EUR" },
+        },
         { idempotencyKey: "key-123" },
       );
 
@@ -110,23 +131,23 @@ describe("insurance contract service", () => {
       fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
 
       const result = await updateInsuranceContract(client, "ic-1", {
-        provider_name: "Allianz",
+        provider_slug: "allianz",
       });
 
       expect(result).toEqual(sampleContract);
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
-      expect(opts.method).toBe("PUT");
+      expect(opts.method).toBe("PATCH");
 
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
-      expect(body).toEqual({ insurance_contract: { provider_name: "Allianz" } });
+      expect(body).toEqual({ insurance_contract: { provider_slug: "allianz" } });
     });
 
     it("passes idempotency key when provided", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
 
-      await updateInsuranceContract(client, "ic-1", { end_date: "2028-01-01" }, { idempotencyKey: "key-456" });
+      await updateInsuranceContract(client, "ic-1", { expiration_date: "2028-01-01" }, { idempotencyKey: "key-456" });
 
       const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       const headers = opts.headers as Record<string, string>;

--- a/packages/core/src/insurance-contracts/service.ts
+++ b/packages/core/src/insurance-contracts/service.ts
@@ -4,22 +4,58 @@
 import type { HttpClient } from "../http-client.js";
 import { parseResponse } from "../response.js";
 import { InsuranceContractResponseSchema, InsuranceDocumentResponseSchema } from "./schemas.js";
-import type { InsuranceContract, InsuranceDocument } from "./types.js";
+import type {
+  InsuranceContract,
+  InsuranceContractOrigin,
+  InsuranceContractPaymentFrequency,
+  InsuranceContractPrice,
+  InsuranceContractStatus,
+  InsuranceDocument,
+} from "./types.js";
 
+/**
+ * Parameters for creating a new insurance contract.
+ *
+ * Per the Qonto API docs, `name`, `contract_id`, `origin`, `provider_slug`,
+ * `type`, and `status` are required. The Qonto sandbox additionally rejects
+ * requests missing `payment_frequency` or `price` with HTTP 400, so this
+ * type marks them required as well.
+ */
 export interface CreateInsuranceContractParams {
-  readonly insurance_type: string;
-  readonly provider_name: string;
-  readonly contract_number?: string | undefined;
-  readonly start_date: string;
-  readonly end_date?: string | undefined;
+  readonly name: string;
+  readonly contract_id: string;
+  readonly origin: InsuranceContractOrigin;
+  readonly provider_slug: string;
+  readonly type: string;
+  readonly status: InsuranceContractStatus;
+  readonly payment_frequency: InsuranceContractPaymentFrequency;
+  readonly price: InsuranceContractPrice;
+  readonly start_date?: string | undefined;
+  readonly expiration_date?: string | undefined;
+  readonly renewal_date?: string | undefined;
+  readonly service_url?: string | undefined;
+  readonly troubleshooting_url?: string | undefined;
 }
 
+/**
+ * Parameters for updating an existing insurance contract.
+ *
+ * All fields are optional per the Qonto API docs.
+ */
 export interface UpdateInsuranceContractParams {
-  readonly insurance_type?: string | undefined;
-  readonly provider_name?: string | undefined;
-  readonly contract_number?: string | undefined;
+  readonly name?: string | undefined;
+  readonly contract_id?: string | undefined;
+  readonly origin?: InsuranceContractOrigin | undefined;
+  readonly provider_slug?: string | undefined;
+  readonly type?: string | undefined;
+  readonly status?: InsuranceContractStatus | undefined;
+  readonly payment_frequency?: InsuranceContractPaymentFrequency | undefined;
+  readonly price?: InsuranceContractPrice | undefined;
   readonly start_date?: string | undefined;
-  readonly end_date?: string | undefined;
+  readonly expiration_date?: string | undefined;
+  readonly renewal_date?: string | undefined;
+  readonly service_url?: string | undefined;
+  readonly troubleshooting_url?: string | undefined;
 }
 
 /**
@@ -69,7 +105,7 @@ export async function updateInsuranceContract(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<InsuranceContract> {
   const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(id)}`;
-  const response = await client.put(endpointPath, { insurance_contract: params }, options);
+  const response = await client.patch(endpointPath, { insurance_contract: params }, options);
   return parseResponse(InsuranceContractResponseSchema, response, endpointPath).insurance_contract;
 }
 

--- a/packages/core/src/insurance-contracts/types.ts
+++ b/packages/core/src/insurance-contracts/types.ts
@@ -2,22 +2,71 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 /**
- * An insurance contract as returned by the Qonto API.
+ * Allowed values for `InsuranceContract.origin`.
  */
-export interface InsuranceContract {
-  readonly id: string;
-  readonly insurance_type: string;
-  readonly status: string;
-  readonly provider_name: string;
-  readonly contract_number: string | null;
-  readonly start_date: string;
-  readonly end_date: string | null;
-  readonly created_at: string;
-  readonly updated_at: string;
+export type InsuranceContractOrigin = "insurance_hub" | "qonto_other" | "stello";
+
+/**
+ * Allowed values for `InsuranceContract.status`.
+ */
+export type InsuranceContractStatus =
+  | "active"
+  | "pending_payment"
+  | "pending_others"
+  | "action_required"
+  | "expired"
+  | "archived";
+
+/**
+ * Allowed values for `InsuranceContract.payment_frequency`.
+ */
+export type InsuranceContractPaymentFrequency = "month" | "quarter" | "semester" | "annual";
+
+/**
+ * Price object on an insurance contract.
+ */
+export interface InsuranceContractPrice {
+  readonly value: string;
+  readonly currency: string;
 }
 
 /**
- * A document attached to an insurance contract.
+ * Document attached to an insurance contract, as returned in the contract response.
+ */
+export interface InsuranceContractDocumentRef {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+}
+
+/**
+ * An insurance contract as returned by the Qonto API.
+ *
+ * Date and URL fields that are not set on a contract are returned as `null`
+ * (not omitted) by the Qonto API, so they are typed as `string | null | undefined`.
+ *
+ * @see https://docs.qonto.com/api-reference/business-api/expense-management/insurance-contracts
+ */
+export interface InsuranceContract {
+  readonly id: string;
+  readonly name: string;
+  readonly contract_id: string;
+  readonly origin: InsuranceContractOrigin;
+  readonly provider_slug: string;
+  readonly type: string;
+  readonly status: InsuranceContractStatus;
+  readonly payment_frequency: InsuranceContractPaymentFrequency;
+  readonly price: InsuranceContractPrice;
+  readonly start_date?: string | null | undefined;
+  readonly expiration_date?: string | null | undefined;
+  readonly renewal_date?: string | null | undefined;
+  readonly service_url?: string | null | undefined;
+  readonly troubleshooting_url?: string | null | undefined;
+  readonly documents?: readonly InsuranceContractDocumentRef[] | null | undefined;
+}
+
+/**
+ * A document attached to an insurance contract, as returned by the upload-document endpoint.
  */
 export interface InsuranceDocument {
   readonly id: string;

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -68,15 +68,7 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
     it("updates the created insurance contract", () => {
       if (createdId === undefined) return;
 
-      const output = cli(
-        "--output",
-        "json",
-        "insurance",
-        "update",
-        createdId,
-        "--provider-slug",
-        "allianz",
-      );
+      const output = cli("--output", "json", "insurance", "update", createdId, "--provider-slug", "allianz");
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdId);
       expect(parsed).toHaveProperty("provider_slug", "allianz");

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -27,16 +27,31 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
         "json",
         "insurance",
         "create",
-        "--insurance-type",
+        "--name",
+        "E2E ProLiability Plan",
+        "--contract-id",
+        `e2e-cli-${Date.now()}`,
+        "--origin",
+        "qonto_other",
+        "--provider-slug",
+        "axa",
+        "--type",
         "professional_liability",
-        "--provider-name",
-        "E2E Test Provider",
+        "--status",
+        "active",
+        "--payment-frequency",
+        "annual",
+        "--price-value",
+        "99.99",
+        "--price-currency",
+        "EUR",
         "--start-date",
         "2026-01-01",
       );
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id");
-      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
+      expect(parsed).toHaveProperty("type", "professional_liability");
+      expect(parsed).toHaveProperty("provider_slug", "axa");
       InsuranceContractSchema.parse(parsed);
       createdId = parsed["id"] as string;
     });
@@ -59,12 +74,12 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
         "insurance",
         "update",
         createdId,
-        "--provider-name",
-        "Updated E2E Provider",
+        "--provider-slug",
+        "allianz",
       );
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdId);
-      expect(parsed).toHaveProperty("provider_name", "Updated E2E Provider");
+      expect(parsed).toHaveProperty("provider_slug", "allianz");
     });
   });
 });

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -45,8 +45,15 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       const result = await client.callTool({
         name: "insurance_create",
         arguments: {
-          insurance_type: "professional_liability",
-          provider_name: "E2E MCP Test Provider",
+          name: "E2E MCP ProLiability Plan",
+          contract_id: `e2e-mcp-${Date.now()}`,
+          origin: "qonto_other",
+          provider_slug: "axa",
+          type: "professional_liability",
+          status: "active",
+          payment_frequency: "annual",
+          price_value: "99.99",
+          price_currency: "EUR",
           start_date: "2026-01-01",
         },
       });
@@ -56,7 +63,7 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
       expect(parsed).toHaveProperty("id");
-      expect(parsed).toHaveProperty("insurance_type", "professional_liability");
+      expect(parsed).toHaveProperty("type", "professional_liability");
       createdId = parsed["id"] as string;
     });
 
@@ -81,14 +88,14 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
         name: "insurance_update",
         arguments: {
           id: createdId,
-          provider_name: "Updated E2E MCP Provider",
+          provider_slug: "allianz",
         },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdId);
-      expect(parsed).toHaveProperty("provider_name", "Updated E2E MCP Provider");
+      expect(parsed).toHaveProperty("provider_slug", "allianz");
     });
   });
 });

--- a/packages/mcp/src/tools/insurance.test.ts
+++ b/packages/mcp/src/tools/insurance.test.ts
@@ -8,14 +8,16 @@ import { connectInMemory } from "../testing/mcp-helpers.js";
 
 const sampleContract = {
   id: "ic-1",
-  insurance_type: "professional_liability",
+  name: "ProLiability Plan 2026",
+  contract_id: "CNT-12345",
+  origin: "qonto_other",
+  provider_slug: "axa",
+  type: "business_liability",
   status: "active",
-  provider_name: "AXA",
-  contract_number: "CNT-12345",
+  payment_frequency: "annual",
+  price: { value: "99.99", currency: "EUR" },
   start_date: "2026-01-01",
-  end_date: "2027-01-01",
-  created_at: "2026-01-01T10:00:00Z",
-  updated_at: "2026-01-01T10:00:00Z",
+  expiration_date: "2027-01-01",
 };
 
 const sampleDocument = {
@@ -71,16 +73,24 @@ describe("insurance MCP tools", () => {
   });
 
   describe("insurance_create", () => {
+    const createArgs = {
+      name: "ProLiability Plan 2026",
+      contract_id: "CNT-12345",
+      origin: "qonto_other",
+      provider_slug: "axa",
+      type: "business_liability",
+      status: "active",
+      payment_frequency: "annual",
+      price_value: "99.99",
+      price_currency: "EUR",
+    };
+
     it("creates an insurance contract", async () => {
       fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
 
       const result = await mcpClient.callTool({
         name: "insurance_create",
-        arguments: {
-          insurance_type: "professional_liability",
-          provider_name: "AXA",
-          start_date: "2026-01-01",
-        },
+        arguments: createArgs,
       });
 
       const content = result.content as { type: string; text: string }[];
@@ -94,12 +104,7 @@ describe("insurance MCP tools", () => {
 
       await mcpClient.callTool({
         name: "insurance_create",
-        arguments: {
-          insurance_type: "professional_liability",
-          provider_name: "AXA",
-          start_date: "2026-01-01",
-          contract_number: "CNT-12345",
-        },
+        arguments: createArgs,
       });
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
@@ -109,11 +114,37 @@ describe("insurance MCP tools", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         insurance_contract: {
-          insurance_type: "professional_liability",
-          provider_name: "AXA",
-          start_date: "2026-01-01",
-          contract_number: "CNT-12345",
+          name: "ProLiability Plan 2026",
+          contract_id: "CNT-12345",
+          origin: "qonto_other",
+          provider_slug: "axa",
+          type: "business_liability",
+          status: "active",
+          payment_frequency: "annual",
+          price: { value: "99.99", currency: "EUR" },
         },
+      });
+    });
+
+    it("includes optional fields when provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await mcpClient.callTool({
+        name: "insurance_create",
+        arguments: {
+          ...createArgs,
+          start_date: "2026-01-01",
+          expiration_date: "2027-01-01",
+          service_url: "https://service.example.com",
+        },
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const body = JSON.parse(opts.body as string) as { insurance_contract: Record<string, unknown> };
+      expect(body.insurance_contract).toMatchObject({
+        start_date: "2026-01-01",
+        expiration_date: "2027-01-01",
+        service_url: "https://service.example.com",
       });
     });
   });
@@ -126,7 +157,7 @@ describe("insurance MCP tools", () => {
         name: "insurance_update",
         arguments: {
           id: "ic-1",
-          provider_name: "Allianz",
+          provider_slug: "allianz",
         },
       });
 
@@ -137,7 +168,7 @@ describe("insurance MCP tools", () => {
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/insurance_contracts/ic-1");
-      expect(opts.method).toBe("PUT");
+      expect(opts.method).toBe("PATCH");
     });
 
     it("omits undefined optional fields from the request body", async () => {
@@ -147,7 +178,7 @@ describe("insurance MCP tools", () => {
         name: "insurance_update",
         arguments: {
           id: "ic-1",
-          provider_name: "Allianz",
+          provider_slug: "allianz",
         },
       });
 
@@ -155,9 +186,40 @@ describe("insurance MCP tools", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         insurance_contract: {
-          provider_name: "Allianz",
+          provider_slug: "allianz",
         },
       });
+    });
+
+    it("sends a price object when both price_value and price_currency are provided", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ insurance_contract: sampleContract }));
+
+      await mcpClient.callTool({
+        name: "insurance_update",
+        arguments: {
+          id: "ic-1",
+          price_value: "120.00",
+          price_currency: "EUR",
+        },
+      });
+
+      const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const body = JSON.parse(opts.body as string) as { insurance_contract: Record<string, unknown> };
+      expect(body.insurance_contract).toEqual({ price: { value: "120.00", currency: "EUR" } });
+    });
+
+    it("returns an error result when only price_value is provided", async () => {
+      const result = await mcpClient.callTool({
+        name: "insurance_update",
+        arguments: {
+          id: "ic-1",
+          price_value: "120.00",
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as { type: string; text: string }[];
+      expect(content[0]?.text).toContain("price_value and price_currency must be provided together");
     });
   });
 

--- a/packages/mcp/src/tools/insurance.ts
+++ b/packages/mcp/src/tools/insurance.ts
@@ -7,6 +7,9 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type HttpClient,
+  type InsuranceContractOrigin,
+  type InsuranceContractPaymentFrequency,
+  type InsuranceContractStatus,
   getInsuranceContract,
   createInsuranceContract,
   updateInsuranceContract,
@@ -14,6 +17,17 @@ import {
   removeInsuranceDocument,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+
+const ORIGIN_VALUES = ["insurance_hub", "qonto_other", "stello"] as const;
+const STATUS_VALUES = [
+  "active",
+  "pending_payment",
+  "pending_others",
+  "action_required",
+  "expired",
+  "archived",
+] as const;
+const PAYMENT_FREQUENCY_VALUES = ["month", "quarter", "semester", "annual"] as const;
 
 export function registerInsuranceTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -44,21 +58,38 @@ export function registerInsuranceTools(server: McpServer, getClient: () => Promi
     {
       description: "Create a new insurance contract",
       inputSchema: {
-        insurance_type: z.string().describe("Insurance type (e.g. professional_liability, health)"),
-        provider_name: z.string().describe("Insurance provider name"),
-        contract_number: z.string().optional().describe("Contract number"),
-        start_date: z.string().describe("Contract start date (YYYY-MM-DD)"),
-        end_date: z.string().optional().describe("Contract end date (YYYY-MM-DD)"),
+        name: z.string().describe("Contract display name (e.g. 'ProLiability Plan 2026')"),
+        contract_id: z.string().describe("Partner-generated contract identifier"),
+        origin: z.enum(ORIGIN_VALUES).describe("Contract origin"),
+        provider_slug: z.string().describe("Insurance provider identifier (e.g. 'axa')"),
+        type: z.string().describe("Insurance category (e.g. 'business_liability', 'health')"),
+        status: z.enum(STATUS_VALUES).describe("Contract status"),
+        payment_frequency: z.enum(PAYMENT_FREQUENCY_VALUES).describe("Payment frequency"),
+        price_value: z.string().describe("Price amount as a decimal string (e.g. '99.99')"),
+        price_currency: z.string().describe("Price currency code (ISO 4217, e.g. 'EUR')"),
+        start_date: z.string().optional().describe("Coverage start date (YYYY-MM-DD)"),
+        expiration_date: z.string().optional().describe("Contract expiration date (YYYY-MM-DD)"),
+        renewal_date: z.string().optional().describe("Policy renewal date (YYYY-MM-DD)"),
+        service_url: z.string().optional().describe("Customer portal access URL"),
+        troubleshooting_url: z.string().optional().describe("Support / troubleshooting URL"),
       },
     },
     async (args) =>
       withClient(getClient, async (client) => {
         const contract = await createInsuranceContract(client, {
-          insurance_type: args.insurance_type,
-          provider_name: args.provider_name,
-          start_date: args.start_date,
-          contract_number: args.contract_number,
-          end_date: args.end_date,
+          name: args.name,
+          contract_id: args.contract_id,
+          origin: args.origin,
+          provider_slug: args.provider_slug,
+          type: args.type,
+          status: args.status,
+          payment_frequency: args.payment_frequency,
+          price: { value: args.price_value, currency: args.price_currency },
+          ...(args.start_date !== undefined ? { start_date: args.start_date } : {}),
+          ...(args.expiration_date !== undefined ? { expiration_date: args.expiration_date } : {}),
+          ...(args.renewal_date !== undefined ? { renewal_date: args.renewal_date } : {}),
+          ...(args.service_url !== undefined ? { service_url: args.service_url } : {}),
+          ...(args.troubleshooting_url !== undefined ? { troubleshooting_url: args.troubleshooting_url } : {}),
         });
 
         return {
@@ -78,23 +109,61 @@ export function registerInsuranceTools(server: McpServer, getClient: () => Promi
       description: "Update an insurance contract",
       inputSchema: {
         id: z.string().describe("Insurance contract ID (UUID)"),
-        insurance_type: z.string().optional().describe("Insurance type"),
-        provider_name: z.string().optional().describe("Insurance provider name"),
-        contract_number: z.string().optional().describe("Contract number"),
-        start_date: z.string().optional().describe("Contract start date (YYYY-MM-DD)"),
-        end_date: z.string().optional().describe("Contract end date (YYYY-MM-DD)"),
+        name: z.string().optional().describe("Contract display name"),
+        contract_id: z.string().optional().describe("Partner-generated contract identifier"),
+        origin: z.enum(ORIGIN_VALUES).optional().describe("Contract origin"),
+        provider_slug: z.string().optional().describe("Insurance provider identifier"),
+        type: z.string().optional().describe("Insurance category"),
+        status: z.enum(STATUS_VALUES).optional().describe("Contract status"),
+        payment_frequency: z.enum(PAYMENT_FREQUENCY_VALUES).optional().describe("Payment frequency"),
+        price_value: z.string().optional().describe("Price amount as a decimal string (must be paired with price_currency)"),
+        price_currency: z.string().optional().describe("Price currency code (must be paired with price_value)"),
+        start_date: z.string().optional().describe("Coverage start date (YYYY-MM-DD)"),
+        expiration_date: z.string().optional().describe("Contract expiration date (YYYY-MM-DD)"),
+        renewal_date: z.string().optional().describe("Policy renewal date (YYYY-MM-DD)"),
+        service_url: z.string().optional().describe("Customer portal access URL"),
+        troubleshooting_url: z.string().optional().describe("Support / troubleshooting URL"),
       },
     },
     async (args) =>
       withClient(getClient, async (client) => {
-        const { id, ...fields } = args;
-        const contract = await updateInsuranceContract(client, id, {
-          ...(fields.insurance_type !== undefined ? { insurance_type: fields.insurance_type } : {}),
-          ...(fields.provider_name !== undefined ? { provider_name: fields.provider_name } : {}),
-          ...(fields.contract_number !== undefined ? { contract_number: fields.contract_number } : {}),
-          ...(fields.start_date !== undefined ? { start_date: fields.start_date } : {}),
-          ...(fields.end_date !== undefined ? { end_date: fields.end_date } : {}),
-        });
+        if ((args.price_value === undefined) !== (args.price_currency === undefined)) {
+          throw new Error("price_value and price_currency must be provided together.");
+        }
+
+        const fields: {
+          name?: string;
+          contract_id?: string;
+          origin?: InsuranceContractOrigin;
+          provider_slug?: string;
+          type?: string;
+          status?: InsuranceContractStatus;
+          payment_frequency?: InsuranceContractPaymentFrequency;
+          price?: { value: string; currency: string };
+          start_date?: string;
+          expiration_date?: string;
+          renewal_date?: string;
+          service_url?: string;
+          troubleshooting_url?: string;
+        } = {};
+
+        if (args.name !== undefined) fields.name = args.name;
+        if (args.contract_id !== undefined) fields.contract_id = args.contract_id;
+        if (args.origin !== undefined) fields.origin = args.origin;
+        if (args.provider_slug !== undefined) fields.provider_slug = args.provider_slug;
+        if (args.type !== undefined) fields.type = args.type;
+        if (args.status !== undefined) fields.status = args.status;
+        if (args.payment_frequency !== undefined) fields.payment_frequency = args.payment_frequency;
+        if (args.price_value !== undefined && args.price_currency !== undefined) {
+          fields.price = { value: args.price_value, currency: args.price_currency };
+        }
+        if (args.start_date !== undefined) fields.start_date = args.start_date;
+        if (args.expiration_date !== undefined) fields.expiration_date = args.expiration_date;
+        if (args.renewal_date !== undefined) fields.renewal_date = args.renewal_date;
+        if (args.service_url !== undefined) fields.service_url = args.service_url;
+        if (args.troubleshooting_url !== undefined) fields.troubleshooting_url = args.troubleshooting_url;
+
+        const contract = await updateInsuranceContract(client, args.id, fields);
 
         return {
           content: [

--- a/packages/mcp/src/tools/insurance.ts
+++ b/packages/mcp/src/tools/insurance.ts
@@ -116,7 +116,10 @@ export function registerInsuranceTools(server: McpServer, getClient: () => Promi
         type: z.string().optional().describe("Insurance category"),
         status: z.enum(STATUS_VALUES).optional().describe("Contract status"),
         payment_frequency: z.enum(PAYMENT_FREQUENCY_VALUES).optional().describe("Payment frequency"),
-        price_value: z.string().optional().describe("Price amount as a decimal string (must be paired with price_currency)"),
+        price_value: z
+          .string()
+          .optional()
+          .describe("Price amount as a decimal string (must be paired with price_currency)"),
         price_currency: z.string().optional().describe("Price currency code (must be paired with price_value)"),
         start_date: z.string().optional().describe("Coverage start date (YYYY-MM-DD)"),
         expiration_date: z.string().optional().describe("Contract expiration date (YYYY-MM-DD)"),


### PR DESCRIPTION
## Summary

Fixes the insurance create E2E HTTP 400 (insurance subgroup of #489 / split out as #509).

The insurance-contracts domain in QontoCtl used field names inferred at implementation time that don't match the actual Qonto API spec. The CLI sent only 3 fields (`insurance_type`, `provider_name`, `start_date`); the live `/v2/insurance_contracts` POST returned HTTP 400 with 9 missing-field errors. Same anti-pattern PR #488 fixed for the international domain — verified against the official Qonto API docs and the live sandbox.

## Verified mismatches

Cross-checked against the Qonto API docs (`/api-reference/business-api/expense-management/insurance-contracts/{create,retrieve,update}`) and the live sandbox 400 message:

**Field renames**:

- `insurance_type`  → `type`
- `provider_name`   → `provider_slug`
- `contract_number` → `contract_id`
- `end_date`        → `expiration_date`

**Required fields the CLI/MCP surface didn't expose**:

- `name`, `origin` (enum), `status` (enum), `payment_frequency` (enum), `price.value` + `price.currency`. Docs mark `payment_frequency` and `price` as optional but the live sandbox lists them as missing on HTTP 400 — required at runtime.

**Optional fields added**:

- `service_url`, `troubleshooting_url`, `renewal_date`. Plus `documents` array on the response.

**Two latent bugs caught during E2E validation**:

- Update endpoint was using `PUT` — sandbox returns HTTP 404; spec requires `PATCH`.
- Optional response fields are returned as `null` (not omitted), so schema needed `nullish()` not `optional()`.

## Changes

- **`packages/core/src/insurance-contracts/`** — rewrite `InsuranceContract`, `InsuranceContractSchema`, `CreateInsuranceContractParams`, `UpdateInsuranceContractParams`. Add `InsuranceContractOrigin` / `Status` / `PaymentFrequency` / `Price` / `DocumentRef` types and Zod schemas. Mark date/URL response fields as `nullish()`. Switch `updateInsuranceContract` from `client.put` to `client.patch`.
- **`packages/cli/src/commands/insurance.ts`** — `insurance create` exposes 9 mandatory and 5 optional flags, including `--price-value` + `--price-currency` (paired). `insurance update` mirrors create with all flags optional and validates `--price-value` / `--price-currency` are provided together.
- **`packages/mcp/src/tools/insurance.ts`** — `insurance_create` and `insurance_update` input schemas mirror the CLI surface with explicit enum types and the `price_value` / `price_currency` pairing requirement.
- **`packages/e2e/src/insurance/{cli,mcp}.e2e.test.ts`** — fixtures send all 9 sandbox-required fields; update test switches to `--provider-slug allianz`.

## Verification

- ✅ All unit tests pass (2061 total: 720 cli, 967 core, 357 mcp, 18 qontoctl umbrella).
- ✅ Insurance E2E (CLI + MCP) — 6/6 pass against Qonto sandbox (was failing 1/3 each).
- ✅ Full E2E sweep — 137 passed, 118 skipped (api-key-only suites naturally skip without api-key creds in OAuth-only local config), 0 failed.
- ✅ Lint clean, license-check clean.

## Scope discipline

This PR addresses **the insurance subgroup** of #489 only. The cards subgroup landed in #508 (merged); iban-certificate (CLI + MCP) and the transactions HTTP 422 remain as separate splits.

Closes #509.

## Test plan

- [x] `pnpm test` — 2061 unit tests pass
- [x] `pnpm lint`, `pnpm license-check` — clean
- [x] Insurance E2E (CLI + MCP) — 6/6 pass against Qonto sandbox
- [x] Full E2E sweep — 137 passed, 0 failed (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)