### PR TITLE
(fix) align Membership/Beneficiary/CreditNote/ClientInvoice schemas with actual API (#514)

### DIFF
--- a/packages/cli/src/commands/client-invoice.ts
+++ b/packages/cli/src/commands/client-invoice.ts
@@ -85,7 +85,9 @@ function clientDisplayName(client: ClientInvoice["client"]): string {
   if (client.name !== null) {
     return client.name;
   }
-  const parts = [client.first_name, client.last_name].filter((p) => p !== null);
+  // `!= null` (not `!== null`) to also strip undefined: for company clients,
+  // first_name/last_name are omitted from the response, not present-and-null.
+  const parts = [client.first_name, client.last_name].filter((p) => p != null);
   return parts.length > 0 ? parts.join(" ") : "";
 }
 

--- a/packages/cli/src/commands/credit-note.ts
+++ b/packages/cli/src/commands/credit-note.ts
@@ -9,6 +9,16 @@ import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, PaginationOptions } from "../options.js";
 
+function creditNoteClientDisplay(client: CreditNote["client"]): string {
+  if (client === undefined) {
+    return "";
+  }
+  if (client.name) {
+    return client.name;
+  }
+  return `${client.first_name} ${client.last_name}`.trim();
+}
+
 export function createCreditNoteCommand(): Command {
   const creditNote = new Command("credit-note").description("Manage credit notes");
 
@@ -26,9 +36,9 @@ export function createCreditNoteCommand(): Command {
         : result.items.map((cn) => ({
             id: cn.id,
             number: cn.number,
-            client: cn.client.name || `${cn.client.first_name} ${cn.client.last_name}`.trim(),
+            client: creditNoteClientDisplay(cn.client),
             total_amount: `${cn.total_amount.value} ${cn.total_amount.currency}`,
-            status: cn.einvoicing_status,
+            status: cn.einvoicing_status ?? "",
             issue_date: cn.issue_date,
           }));
 
@@ -51,10 +61,10 @@ export function createCreditNoteCommand(): Command {
             {
               id: cn.id,
               number: cn.number,
-              client: cn.client.name || `${cn.client.first_name} ${cn.client.last_name}`.trim(),
+              client: creditNoteClientDisplay(cn.client),
               total_amount: `${cn.total_amount.value} ${cn.total_amount.currency}`,
               vat_amount: `${cn.vat_amount.value} ${cn.vat_amount.currency}`,
-              status: cn.einvoicing_status,
+              status: cn.einvoicing_status ?? "",
               issue_date: cn.issue_date,
               invoice_id: cn.invoice_id,
               currency: cn.currency,

--- a/packages/core/src/beneficiaries/schemas.test.ts
+++ b/packages/core/src/beneficiaries/schemas.test.ts
@@ -53,6 +53,58 @@ describe("BeneficiarySchema", () => {
   it("rejects invalid status", () => {
     expect(() => BeneficiarySchema.parse({ ...validBeneficiary, status: "unknown" })).toThrow();
   });
+
+  it("hoists iban and bic from nested bank_account (regression: #514)", () => {
+    // Production returns flat `iban`/`bic`. The Qonto sandbox wraps both
+    // under `bank_account: { iban, bic, currency }`. The schema's
+    // preprocess hoists the nested values so downstream consumers always
+    // see flat fields.
+    const sandboxShape = {
+      id: "ben-2",
+      name: "Sandbox SARL",
+      status: "validated",
+      trusted: true,
+      created_at: "2026-05-09T10:00:00.000Z",
+      updated_at: "2026-05-09T10:00:00.000Z",
+      bank_account: {
+        iban: "FR7630001007941234567890185",
+        bic: "QNTOFRP1XXX",
+        currency: "EUR",
+      },
+    };
+    const result = BeneficiarySchema.parse(sandboxShape);
+    expect(result.iban).toBe("FR7630001007941234567890185");
+    expect(result.bic).toBe("QNTOFRP1XXX");
+    expect(result).not.toHaveProperty("bank_account");
+  });
+
+  it("hoists null bic from nested bank_account", () => {
+    const sandboxShape = {
+      id: "ben-3",
+      name: "Foreign bank",
+      status: "validated" as const,
+      trusted: false,
+      created_at: "2026-05-09T10:00:00.000Z",
+      updated_at: "2026-05-09T10:00:00.000Z",
+      bank_account: { iban: "DE89370400440532013000", bic: null, currency: "EUR" },
+    };
+    const result = BeneficiarySchema.parse(sandboxShape);
+    expect(result.iban).toBe("DE89370400440532013000");
+    expect(result.bic).toBeNull();
+  });
+
+  it("flat fields take precedence over nested bank_account fields", () => {
+    // If both flat and nested are present, the flat field wins. This
+    // matches the production contract — preprocess only fills absent
+    // flat fields from `bank_account`.
+    const mixedShape = {
+      ...validBeneficiary,
+      bank_account: { iban: "DIFFERENT", bic: "DIFFERENT", currency: "EUR" },
+    };
+    const result = BeneficiarySchema.parse(mixedShape);
+    expect(result.iban).toBe(validBeneficiary.iban);
+    expect(result.bic).toBe(validBeneficiary.bic);
+  });
 });
 
 describe("BeneficiaryResponseSchema", () => {

--- a/packages/core/src/beneficiaries/schemas.ts
+++ b/packages/core/src/beneficiaries/schemas.ts
@@ -8,7 +8,14 @@ import type { Beneficiary } from "../types/beneficiary.js";
 
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/beneficiaries/sepa-beneficiaries/show
 // https://docs.qonto.com/api-reference/business-api/payments-transfers/sepa-transfers/beneficiaries/sepa-beneficiaries/index
-export const BeneficiarySchema = z
+//
+// Production returns `iban`/`bic` as flat top-level fields per the official
+// SepaBeneficiary schema. The Qonto sandbox additionally wraps them under
+// `bank_account: { iban, bic, currency }`. The preprocess hoists those
+// nested values to the top level when the flat fields are absent, so a
+// single Beneficiary type serves both environments and existing CLI/MCP
+// code (which reads `.iban`/`.bic`) keeps working unchanged.
+const BeneficiaryObjectSchema = z
   .object({
     id: z.string(),
     name: z.string(),
@@ -24,7 +31,27 @@ export const BeneficiarySchema = z
     created_at: z.string(),
     updated_at: z.string(),
   })
-  .strip() satisfies z.ZodType<Beneficiary>;
+  .strip();
+
+export const BeneficiarySchema: z.ZodType<Beneficiary> = z.preprocess((input) => {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+  const obj = input as Record<string, unknown>;
+  const bankAccount = obj["bank_account"];
+  if (bankAccount === null || typeof bankAccount !== "object" || Array.isArray(bankAccount)) {
+    return input;
+  }
+  const ba = bankAccount as Record<string, unknown>;
+  const out: Record<string, unknown> = { ...obj };
+  if (!("iban" in out) && typeof ba["iban"] === "string") {
+    out["iban"] = ba["iban"];
+  }
+  if (!("bic" in out) && (typeof ba["bic"] === "string" || ba["bic"] === null)) {
+    out["bic"] = ba["bic"];
+  }
+  return out;
+}, BeneficiaryObjectSchema);
 
 export const BeneficiaryResponseSchema = z
   .object({

--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -198,6 +198,32 @@ describe("ClientInvoiceClientSchema", () => {
   it("rejects invalid client type", () => {
     expect(() => ClientInvoiceClientSchema.parse({ ...validClient, type: "unknown" })).toThrow();
   });
+
+  it("accepts company clients without first_name/last_name (regression: #514)", () => {
+    // Per the Qonto API docs, `first_name` and `last_name` are returned
+    // only for `type: "individual"` or `"freelancer"` — they are omitted
+    // entirely (not just null) for `type: "company"`. Mirrors #496 for
+    // the standalone ClientSchema.
+    const companyClient = {
+      id: "client-company-1",
+      type: "company" as const,
+      name: "Acme Corp",
+      email: "billing@acme.com",
+      vat_number: "FR12345678901",
+      tax_identification_number: null,
+      address: null,
+      city: null,
+      zip_code: null,
+      country_code: null,
+      locale: "fr",
+      billing_address: null,
+    };
+    const result = ClientInvoiceClientSchema.parse(companyClient);
+    expect(result.name).toBe("Acme Corp");
+    expect(result.first_name).toBeUndefined();
+    expect(result.last_name).toBeUndefined();
+    expect(result.type).toBe("company");
+  });
 });
 
 describe("ClientInvoiceUploadSchema", () => {

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -60,13 +60,17 @@ export const ClientInvoiceAddressSchema = z
   })
   .strip() satisfies z.ZodType<ClientInvoiceAddress>;
 
+// Per the Qonto API docs, `first_name` and `last_name` "will be returned
+// only if the client is an individual or a freelancer" — i.e., omitted
+// entirely (not just null) for `type: "company"`. Make them optional in
+// addition to nullable. Mirrors the standalone-ClientSchema fix from #496.
 export const ClientInvoiceClientSchema = z
   .object({
     id: z.string(),
     type: z.enum(["individual", "company", "freelancer"]),
     name: z.string().nullable(),
-    first_name: z.string().nullable(),
-    last_name: z.string().nullable(),
+    first_name: z.string().nullable().optional(),
+    last_name: z.string().nullable().optional(),
     email: z.string().nullable(),
     vat_number: z.string().nullable(),
     tax_identification_number: z.string().nullable(),

--- a/packages/core/src/client-invoices/types.ts
+++ b/packages/core/src/client-invoices/types.ts
@@ -53,13 +53,17 @@ export interface ClientInvoiceAddress {
 
 /**
  * A client embedded in a client invoice.
+ *
+ * `first_name` and `last_name` are returned only when `type` is
+ * `"individual"` or `"freelancer"` — they are omitted entirely (not just
+ * null) for `type: "company"`.
  */
 export interface ClientInvoiceClient {
   readonly id: string;
   readonly type: "individual" | "company" | "freelancer";
   readonly name: string | null;
-  readonly first_name: string | null;
-  readonly last_name: string | null;
+  readonly first_name?: string | null | undefined;
+  readonly last_name?: string | null | undefined;
   readonly email: string | null;
   readonly vat_number: string | null;
   readonly tax_identification_number: string | null;

--- a/packages/core/src/types/credit-note.schema.test.ts
+++ b/packages/core/src/types/credit-note.schema.test.ts
@@ -125,4 +125,42 @@ describe("CreditNoteSchema", () => {
   it("rejects missing required fields", () => {
     expect(() => CreditNoteSchema.parse({ id: "cn-1" })).toThrow();
   });
+
+  it("accepts sandbox shape that omits client/header/footer/einvoicing_status/invoice_url/invoice_issue_date (regression: #514)", () => {
+    // The Qonto sandbox returns credit notes that omit the listed fields
+    // entirely (per the official schema, only `id` is strictly required).
+    // The capital-`I` `Invoice_issue_date` and `reason` keys appear in
+    // sandbox responses; `.strip()` discards them silently.
+    const sandboxShape = {
+      id: "cn-2",
+      invoice_id: "inv-2",
+      attachment_id: "att-2",
+      number: "CN-2026-002",
+      issue_date: "2026-05-09",
+      terms_and_conditions: "Standard terms",
+      currency: "EUR",
+      vat_amount: amount,
+      vat_amount_cents: 4000,
+      total_amount: amount,
+      total_amount_cents: 20000,
+      stamp_duty_amount: "0",
+      created_at: "2026-05-09T00:00:00.000Z",
+      finalized_at: "2026-05-09T12:00:00.000Z",
+      contact_email: "contact@acme.com",
+      items: [item],
+      // Sandbox-specific extras — silently dropped by `.strip()`:
+      Invoice_issue_date: "2026-04-09",
+      reason: "duplicated",
+    };
+    const result = CreditNoteSchema.parse(sandboxShape);
+    expect(result.id).toBe("cn-2");
+    expect(result.invoice_issue_date).toBeUndefined();
+    expect(result.header).toBeUndefined();
+    expect(result.footer).toBeUndefined();
+    expect(result.einvoicing_status).toBeUndefined();
+    expect(result.client).toBeUndefined();
+    expect(result.invoice_url).toBeUndefined();
+    expect(result).not.toHaveProperty("Invoice_issue_date");
+    expect(result).not.toHaveProperty("reason");
+  });
 });

--- a/packages/core/src/types/credit-note.schema.ts
+++ b/packages/core/src/types/credit-note.schema.ts
@@ -49,6 +49,13 @@ export const CreditNoteClientSchema = z
   })
   .strip() satisfies z.ZodType<CreditNoteClient>;
 
+// Per the Qonto credit-note schema, only `id` is strictly required; all
+// other fields are technically optional. The sandbox confirms that
+// `invoice_issue_date`, `header`, `footer`, `einvoicing_status`, `client`,
+// and `invoice_url` may be omitted from the response (the sandbox returns
+// a capital-`I` `Invoice_issue_date` and a `reason` field instead — both
+// silently dropped by `.strip()`). Loosen those six fields to optional;
+// other fields stay required by convention until evidence demands change.
 export const CreditNoteSchema = z
   .object({
     id: z.string(),
@@ -56,9 +63,9 @@ export const CreditNoteSchema = z
     attachment_id: z.string(),
     number: z.string(),
     issue_date: z.string(),
-    invoice_issue_date: z.string(),
-    header: z.string(),
-    footer: z.string(),
+    invoice_issue_date: z.string().optional(),
+    header: z.string().optional(),
+    footer: z.string().optional(),
     terms_and_conditions: z.string(),
     currency: z.string(),
     vat_amount: CreditNoteAmountSchema,
@@ -69,10 +76,10 @@ export const CreditNoteSchema = z
     created_at: z.string(),
     finalized_at: z.string(),
     contact_email: z.string(),
-    invoice_url: z.string(),
-    einvoicing_status: z.string(),
+    invoice_url: z.string().optional(),
+    einvoicing_status: z.string().optional(),
     items: z.array(CreditNoteItemSchema).readonly(),
-    client: CreditNoteClientSchema,
+    client: CreditNoteClientSchema.optional(),
   })
   .strip() satisfies z.ZodType<CreditNote>;
 

--- a/packages/core/src/types/credit-note.ts
+++ b/packages/core/src/types/credit-note.ts
@@ -49,6 +49,10 @@ export interface CreditNoteClient {
 
 /**
  * A Qonto credit note issued to correct or cancel a previously issued invoice.
+ *
+ * Per the Qonto credit-note schema, only `id` is strictly required; in
+ * practice the sandbox may omit `invoice_issue_date`, `header`, `footer`,
+ * `einvoicing_status`, `client`, and `invoice_url`.
  */
 export interface CreditNote {
   readonly id: string;
@@ -56,9 +60,9 @@ export interface CreditNote {
   readonly attachment_id: string;
   readonly number: string;
   readonly issue_date: string;
-  readonly invoice_issue_date: string;
-  readonly header: string;
-  readonly footer: string;
+  readonly invoice_issue_date?: string | undefined;
+  readonly header?: string | undefined;
+  readonly footer?: string | undefined;
   readonly terms_and_conditions: string;
   readonly currency: string;
   readonly vat_amount: CreditNoteAmount;
@@ -69,8 +73,8 @@ export interface CreditNote {
   readonly created_at: string;
   readonly finalized_at: string;
   readonly contact_email: string;
-  readonly invoice_url: string;
-  readonly einvoicing_status: string;
+  readonly invoice_url?: string | undefined;
+  readonly einvoicing_status?: string | undefined;
   readonly items: readonly CreditNoteItem[];
-  readonly client: CreditNoteClient;
+  readonly client?: CreditNoteClient | undefined;
 }

--- a/packages/core/src/types/membership.schema.test.ts
+++ b/packages/core/src/types/membership.schema.test.ts
@@ -74,4 +74,23 @@ describe("MembershipSchema", () => {
   it("rejects missing required fields", () => {
     expect(() => MembershipSchema.parse({ id: "member-1" })).toThrow();
   });
+
+  it("accepts invitable memberships with null role and team_id (regression: #514)", () => {
+    // Invitable memberships have not yet accepted the invitation, so the
+    // Qonto API returns null for role and team_id and `status: "invitable"`.
+    // The captured sandbox response also omits `email` for these entries.
+    const invitable = {
+      id: "019aeeb2-fff8-7404-81ae-cc62d41ae9be",
+      first_name: "Nicolas",
+      last_name: "Muller",
+      role: null,
+      status: "invitable",
+      team_id: null,
+    };
+    const result = MembershipSchema.parse(invitable);
+    expect(result.role).toBeNull();
+    expect(result.team_id).toBeNull();
+    expect(result.status).toBe("invitable");
+    expect(result.email).toBeUndefined();
+  });
 });

--- a/packages/core/src/types/membership.schema.ts
+++ b/packages/core/src/types/membership.schema.ts
@@ -6,14 +6,16 @@ import { z } from "zod";
 import { PaginationMetaSchema } from "../api-types.schema.js";
 import type { Membership } from "./membership.js";
 
+// `role` and `team_id` are nullable: invitable memberships (status: "invitable")
+// have not yet accepted the invitation, so the API returns null for both fields.
 export const MembershipSchema = z
   .object({
     id: z.string(),
     first_name: z.string(),
     last_name: z.string(),
     email: z.string().optional(),
-    role: z.enum(["owner", "admin", "manager", "reporting", "employee", "accountant"]),
-    team_id: z.string(),
+    role: z.enum(["owner", "admin", "manager", "reporting", "employee", "accountant"]).nullable(),
+    team_id: z.string().nullable(),
     residence_country: z.string().nullable().optional(),
     birthdate: z.string().nullable().optional(),
     nationality: z.string().nullable().optional(),

--- a/packages/core/src/types/membership.ts
+++ b/packages/core/src/types/membership.ts
@@ -3,14 +3,18 @@
 
 /**
  * A Qonto organization membership representing a team member.
+ *
+ * `role` and `team_id` are nullable: invitable memberships (status:
+ * "invitable") have not yet accepted the invitation, so the API returns
+ * null for both fields.
  */
 export interface Membership {
   readonly id: string;
   readonly first_name: string;
   readonly last_name: string;
   readonly email?: string | undefined;
-  readonly role: "owner" | "admin" | "manager" | "reporting" | "employee" | "accountant";
-  readonly team_id: string;
+  readonly role: "owner" | "admin" | "manager" | "reporting" | "employee" | "accountant" | null;
+  readonly team_id: string | null;
   readonly residence_country?: string | null | undefined;
   readonly birthdate?: string | null | undefined;
   readonly nationality?: string | null | undefined;


### PR DESCRIPTION
## Description

Four Zod schemas in `@qontoctl/core` declared fields as required where the actual Qonto API returns them null or omits them, causing `Schema.parse()` to throw inside affected E2E tests against the live sandbox. This is the same class of issue as #496 (`ClientSchema.name`) — that fix is the precedent for shape and reasoning.

All shapes were verified against the official Qonto API docs at https://docs.qonto.com/api-reference/ before any schema edit (per project policy: never infer from sibling endpoints).

### Schemas

- **`MembershipSchema`** (`packages/core/src/types/membership.schema.ts`): `role` and `team_id` are now `.nullable()`. Invitable memberships (`status: "invitable"`) have not yet accepted the invitation — the API returns `null` for both. Membership type updated to `... | null`.

- **`BeneficiarySchema`** (`packages/core/src/beneficiaries/schemas.ts`): docs confirm production returns `iban`/`bic` as flat top-level fields per the official `SepaBeneficiary` schema. The Qonto sandbox additionally wraps them under `bank_account: { iban, bic, currency }`. Added a `z.preprocess` that hoists nested values to the top level when the flat fields are absent. Public `Beneficiary` type stays flat — 12+ CLI/MCP downstream consumers reading `b.iban`/`b.bic` are unchanged. When both flat and nested are present, flat wins (no silent overwriting).

- **`CreditNoteSchema`** (`packages/core/src/types/credit-note.schema.ts`): per docs, only `id` is strictly required on a credit note; sandbox capture confirms `header`, `footer`, `einvoicing_status`, `client`, `invoice_url`, and `invoice_issue_date` may be omitted. Loosened those six fields to `.optional()`. The capital-`I` `Invoice_issue_date` and `reason` keys returned by the sandbox are silently discarded by `.strip()` rather than baked into the schema (docs are authoritative).

- **`ClientInvoiceClientSchema`** (`packages/core/src/client-invoices/schemas.ts`): per docs, `first_name` and `last_name` are returned only when `type` is `individual` or `freelancer` — omitted entirely (not just `null`) for `company`. Added `.optional()` on top of `.nullable()`. Mirrors fix #496 for the standalone `ClientSchema`.

### CLI fallbacks

- `credit-note` CLI: extracted `creditNoteClientDisplay()` helper handling undefined client; `einvoicing_status ?? ""` for table display.
- `client-invoice` CLI: filter switched from `!== null` to `!= null` so company clients (which omit, not null) are also stripped (mirrors #496).

### Tests

Six regression cases pinning the captured shapes from the issue body so future schema tightening fails CI:

- Membership invitable member with null role + null team_id.
- Beneficiary nested `bank_account` shape (iban + bic hoisted; both bic-populated and bic-null variants; flat-takes-precedence when mixed).
- CreditNote sandbox shape with all six fields omitted plus `Invoice_issue_date` / `reason` extras silently stripped.
- ClientInvoiceClient `type: "company"` without `first_name`/`last_name`.

## Related Issue

Closes #514

## Testing

- `pnpm exec vitest run` — **964 / 964 unit tests pass** (was 958; +6 regression cases pin the captured sandbox shapes).
- `pnpm lint` — clean across all packages.
- `pnpm -r build` — clean (TypeScript types compile across all packages).
- `pnpm test:e2e` — 31 suites pass / 27 skipped / 1 pre-existing unrelated failure (`src/insurance/cli.e2e.test.ts > insurance CRUD lifecycle > creates an insurance contract` — HTTP 400 missing fields, reproduces against `main`, separate concern).
- The four affected E2E suites (`commands/membership.e2e.test.ts`, `commands/mcp-labels-memberships.e2e.test.ts`, `commands/mcp-beneficiaries.e2e.test.ts`, `commands/credit-note.e2e.test.ts`, `client-invoices/cli.e2e.test.ts`) gate on `hasApiKeyCredentials()` and skip in OAuth-only worktrees; CI's api-key configuration will run them against production.
- Adversarial verification: a `probe-shapes.mjs` script runs the 4 schemas against the verbatim shapes from the issue body — all 7 captured shapes parse correctly; 2 adversarial edge cases (no iban anywhere; bank_account.iban=null) correctly reject per schema invariant.

## CLA Acknowledgment

- [x] I agree to the [Contributor License Agreement](https://github.com/alexey-pelykh/qontoctl/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)