### PR TITLE
(fix) E2E: suppress execFileSync child stderr leak between test files (#512)

### DIFF
--- a/packages/e2e/src/attachments/cli.e2e.test.ts
+++ b/packages/e2e/src/attachments/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -25,6 +25,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/clients/cli.e2e.test.ts
+++ b/packages/e2e/src/clients/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/commands/beneficiary.e2e.test.ts
+++ b/packages/e2e/src/commands/beneficiary.e2e.test.ts
@@ -17,6 +17,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/credit-note.e2e.test.ts
+++ b/packages/e2e/src/commands/credit-note.e2e.test.ts
@@ -17,6 +17,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/label.e2e.test.ts
+++ b/packages/e2e/src/commands/label.e2e.test.ts
@@ -17,6 +17,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/membership.e2e.test.ts
+++ b/packages/e2e/src/commands/membership.e2e.test.ts
@@ -17,6 +17,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/commands/request.e2e.test.ts
+++ b/packages/e2e/src/commands/request.e2e.test.ts
@@ -12,6 +12,7 @@ const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execOpts: ExecFileSyncOptionsWithStringEncoding = {
   encoding: "utf-8",
   env: cliEnv(),
+  stdio: "pipe",
   timeout: 15_000,
 };
 

--- a/packages/e2e/src/completions/bash.e2e.test.ts
+++ b/packages/e2e/src/completions/bash.e2e.test.ts
@@ -26,6 +26,7 @@ describe.skipIf(!hasBash())("bash completion (e2e)", () => {
   beforeAll(() => {
     completionScript = execFileSync("node", [CLI_PATH, "completion", "bash"], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
     tempDir = mkdtempSync(join(tmpdir(), "qontoctl-bash-e2e-"));
     scriptPath = join(tempDir, "completion.bash");
@@ -53,6 +54,7 @@ describe.skipIf(!hasBash())("bash completion (e2e)", () => {
 
     const result = execFileSync("bash", ["-c", testScript], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
     return result.trim().split("\n").filter(Boolean);
   }
@@ -60,6 +62,7 @@ describe.skipIf(!hasBash())("bash completion (e2e)", () => {
   it("generates a sourceable script without errors", () => {
     execFileSync("bash", ["-c", `source "${scriptPath}"`], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
   });
 

--- a/packages/e2e/src/completions/fish.e2e.test.ts
+++ b/packages/e2e/src/completions/fish.e2e.test.ts
@@ -26,6 +26,7 @@ describe.skipIf(!hasFish())("fish completion (e2e)", () => {
   beforeAll(() => {
     completionScript = execFileSync("node", [CLI_PATH, "completion", "fish"], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
     tempDir = mkdtempSync(join(tmpdir(), "qontoctl-fish-e2e-"));
     scriptPath = join(tempDir, "qontoctl.fish");
@@ -39,6 +40,7 @@ describe.skipIf(!hasFish())("fish completion (e2e)", () => {
   it("generates a sourceable script without errors", () => {
     execFileSync("fish", ["-c", `source "${scriptPath}"`], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
   });
 
@@ -46,7 +48,7 @@ describe.skipIf(!hasFish())("fish completion (e2e)", () => {
     const result = execFileSync(
       "fish",
       ["-c", [`source "${scriptPath}"`, 'complete --do-complete "qontoctl "'].join("; ")],
-      { encoding: "utf-8" },
+      { encoding: "utf-8", stdio: "pipe" },
     );
     const completions = result
       .trim()
@@ -63,7 +65,7 @@ describe.skipIf(!hasFish())("fish completion (e2e)", () => {
     const result = execFileSync(
       "fish",
       ["-c", [`source "${scriptPath}"`, 'complete --do-complete "qontoctl completion "'].join("; ")],
-      { encoding: "utf-8" },
+      { encoding: "utf-8", stdio: "pipe" },
     );
     const completions = result
       .trim()

--- a/packages/e2e/src/completions/zsh.e2e.test.ts
+++ b/packages/e2e/src/completions/zsh.e2e.test.ts
@@ -26,6 +26,7 @@ describe.skipIf(!hasZsh())("zsh completion (e2e)", () => {
   beforeAll(() => {
     completionScript = execFileSync("node", [CLI_PATH, "completion", "zsh"], {
       encoding: "utf-8",
+      stdio: "pipe",
     });
     tempDir = mkdtempSync(join(tmpdir(), "qontoctl-zsh-e2e-"));
     scriptPath = join(tempDir, "_qontoctl");
@@ -46,7 +47,7 @@ describe.skipIf(!hasZsh())("zsh completion (e2e)", () => {
         "-c",
         ["autoload -Uz compinit", `fpath=("${tempDir}" $fpath)`, "compinit -u", `source "${scriptPath}"`].join("; "),
       ],
-      { encoding: "utf-8" },
+      { encoding: "utf-8", stdio: "pipe" },
     );
   });
 
@@ -64,7 +65,7 @@ describe.skipIf(!hasZsh())("zsh completion (e2e)", () => {
           'whence -w _qontoctl | grep "function"',
         ].join("; "),
       ],
-      { encoding: "utf-8" },
+      { encoding: "utf-8", stdio: "pipe" },
     );
     expect(result).toContain("function");
   });

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -43,11 +43,17 @@ interface ExecError {
  * Use this when a test wants to inspect the failure shape before deciding
  * whether to skip or fail (e.g. detecting HTTP 404 from sandbox feature
  * gating). For the simpler "throw on failure" pattern, use {@link cli}.
+ *
+ * Uses `stdio: "pipe"` so the child's stderr is captured into the result
+ * instead of being inherited to the parent process — without this, vitest's
+ * worker stderr ends up muxed into the test report between unrelated test
+ * file boundaries (see #512).
  */
 export function cliRaw(args: readonly string[], options: { timeout?: number } = {}): CliResult {
   const execOptions: ExecFileSyncOptions = {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: options.timeout ?? DEFAULT_CLI_TIMEOUT_MS,
   };
 
@@ -77,11 +83,16 @@ function bufferToString(value: Buffer | string | undefined): string {
  * The single canonical CLI invocation helper for E2E tests — use this
  * instead of duplicating the `execFileSync(node, [CLI_PATH, ...args], ...)`
  * boilerplate in every test file.
+ *
+ * Uses `stdio: "pipe"` so the child's stderr is captured into the thrown
+ * error's `stderr` property instead of being inherited to vitest's worker
+ * stderr (see #512).
  */
 export function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: DEFAULT_CLI_TIMEOUT_MS,
   });
 }

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -12,6 +12,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -12,6 +12,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -15,6 +15,7 @@ function cli(args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/quotes/cli.e2e.test.ts
+++ b/packages/e2e/src/quotes/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -23,6 +23,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -45,6 +45,7 @@ function cliSync(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 25_000,
   });
 }

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -14,6 +14,7 @@ function listStatements(): Record<string, unknown>[] {
   const output = execFileSync("node", [CLI_PATH, "statement", "list", "--no-paginate", "-o", "json"], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
   return JSON.parse(output) as Record<string, unknown>[];
 }
@@ -47,7 +48,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const filteredOutput = execFileSync(
         "node",
         [CLI_PATH, "statement", "list", "--bank-account", bankAccountId, "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv() },
+        { encoding: "utf-8", env: cliEnv(), stdio: "pipe" },
       );
       const filteredRows = JSON.parse(filteredOutput) as Record<string, unknown>[];
 
@@ -60,7 +61,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const output = execFileSync(
         "node",
         [CLI_PATH, "statement", "list", "--from", "01-2025", "--to", "12-2025", "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv() },
+        { encoding: "utf-8", env: cliEnv(), stdio: "pipe" },
       );
 
       // The command should succeed; results may be empty if no statements in range
@@ -81,6 +82,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const showOutput = execFileSync("node", [CLI_PATH, "statement", "show", statementId, "-o", "json"], {
         encoding: "utf-8",
         env: cliEnv(),
+        stdio: "pipe",
       });
       const showRows = JSON.parse(showOutput) as Record<string, unknown>[];
       expect(showRows).toHaveLength(1);
@@ -120,6 +122,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       execFileSync("node", [CLI_PATH, "statement", "download", statementId], {
         encoding: "utf-8",
         env: cliEnv(),
+        stdio: "pipe",
         cwd: downloadDir,
       });
 
@@ -139,6 +142,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       execFileSync("node", [CLI_PATH, "statement", "download", statementId, "--output-dir", outputDir], {
         encoding: "utf-8",
         env: cliEnv(),
+        stdio: "pipe",
       });
 
       const downloadedFile = join(outputDir, expectedFileName);

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 15_000,
   });
 }

--- a/packages/e2e/src/teams/cli.e2e.test.ts
+++ b/packages/e2e/src/teams/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
   });
 }
 

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -13,6 +13,7 @@ function cli(...args: string[]): string {
   return execFileSync("node", [CLI_PATH, ...args], {
     encoding: "utf-8",
     env: cliEnv(),
+    stdio: "pipe",
     timeout: 30_000,
   });
 }


### PR DESCRIPTION
## Summary

Fixes #512 — stray `Qonto API error` lines (e.g., `HTTP 422 invalid_iban: IBAN is empty`) emitted between unrelated E2E test file boundaries.

The leak source is `execFileSync` default stdio behavior: even with stdout captured, child stderr is inherited to the parent's stderr on non-zero exit. With vitest 4's default parallel-forks pool, that stderr surfaces in the reporter output between unrelated test file headers — the pattern observed in PR #485's E2E log.

## Investigation

The issue body suggested the leak might come from a `beforeAll` hook in `packages/e2e/src/sca-continuation/mcp.e2e.test.ts` running even when its tests skip. Verified empirically that vitest's `describe.skipIf(true)` DOES correctly skip inner `beforeAll` hooks (with a small repro test), so that hypothesis is falsified.

The actual root cause is universal: `execFileSync(...)` without explicit `stdio` defaults to inheriting child stderr to parent. Reproduced empirically — `stdio: "pipe"` (or stricter) suppresses the leak; default does not.

The "between sca-continuation and statements" position in PR #485's log was a timing coincidence of vitest's parallel-forks output muxing — the 422 originated from some other concurrent worker whose CLI subprocess errored, not from sca-continuation.

## Changes

- `packages/e2e/src/helpers.ts` — added `stdio: "pipe"` to shared `cli` and `cliRaw` helpers; updated JSDoc with rationale.
- 27 E2E test files — added `stdio: "pipe"` to local `cli`/`cliJson`/`cliSync` helpers and inline `execFileSync` calls.

Files unchanged on purpose:
- `intl-beneficiaries/cli.e2e.test.ts` — already uses `stdio: ["pipe", "pipe", "ignore"]` (stricter than `"pipe"`).
- `auth/auth.e2e.test.ts`, `profile/*.e2e.test.ts` — use `spawnSync` which already captures stderr by default.

## Test plan

- [x] `pnpm build` — pass (turbo cache hit)
- [x] `pnpm lint` — pass (8/8)
- [x] `pnpm test` — pass (716/716 unit tests)
- [x] `pnpm test:e2e` (local, OAuth + sandbox staging-token) — verified the run output has **no stray stderr lines between test file boundaries**. The 58 failing tests are pre-existing OAuth-token concurrency issues (parallel workers consuming the same single-use refresh token) unrelated to this fix; tests that don't require OAuth refresh (auth structural, profile, completions, cards/MCP, webhooks/MCP, intl/MCP, etc.) all pass.
- [ ] CI E2E will re-run against api-key credentials and exercise the originally-affected suites.