### PR TITLE
(test) E2E: real API exercise for internal-transfers (#463)

### DIFF
--- a/packages/cli/src/commands/internal-transfer.test.ts
+++ b/packages/cli/src/commands/internal-transfer.test.ts
@@ -14,14 +14,11 @@ import { HttpClient } from "@qontoctl/core";
 
 const sampleInternalTransfer = {
   id: "it-123",
-  debit_iban: "FR7630001007941234567890185",
-  credit_iban: "FR7630001007949876543210142",
-  debit_bank_account_id: "ba-1",
-  credit_bank_account_id: "ba-2",
+  slug: "org-slug-1-transfer-12",
   reference: "Monthly allocation",
   amount: 1000.0,
   amount_cents: 100000,
-  currency: "EUR",
+  amount_currency: "EUR",
   status: "processing",
   created_at: "2026-03-01T10:00:00Z",
 };
@@ -108,11 +105,10 @@ describe("internal-transfer commands", () => {
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", "it-123");
-      expect(parsed).toHaveProperty("debit_iban", "FR7630001007941234567890185");
-      expect(parsed).toHaveProperty("credit_iban", "FR7630001007949876543210142");
+      expect(parsed).toHaveProperty("slug", "org-slug-1-transfer-12");
       expect(parsed).toHaveProperty("reference", "Monthly allocation");
       expect(parsed).toHaveProperty("amount", 1000.0);
-      expect(parsed).toHaveProperty("currency", "EUR");
+      expect(parsed).toHaveProperty("amount_currency", "EUR");
     });
 
     it("sends POST to the correct API endpoint with body", async () => {

--- a/packages/cli/src/commands/internal-transfer.ts
+++ b/packages/cli/src/commands/internal-transfer.ts
@@ -19,10 +19,9 @@ interface InternalTransferCreateOptions extends GlobalOptions, WriteOptions {
 function internalTransferToTableRow(t: InternalTransfer): Record<string, string | number> {
   return {
     id: t.id,
-    debit_iban: t.debit_iban,
-    credit_iban: t.credit_iban,
+    slug: t.slug,
     reference: t.reference,
-    amount: `${t.amount} ${t.currency}`,
+    amount: `${String(t.amount)} ${t.amount_currency}`,
     status: t.status,
     created_at: t.created_at,
   };

--- a/packages/core/src/internal-transfers/schemas.test.ts
+++ b/packages/core/src/internal-transfers/schemas.test.ts
@@ -7,14 +7,11 @@ import { InternalTransferSchema, InternalTransferResponseSchema } from "./schema
 describe("InternalTransferSchema", () => {
   const validInternalTransfer = {
     id: "it-1",
-    debit_iban: "FR7630001007941234567890185",
-    credit_iban: "FR7630001007949876543210185",
-    debit_bank_account_id: "ba-1",
-    credit_bank_account_id: "ba-2",
+    slug: "org-slug-1-transfer-1",
     reference: "Internal transfer",
     amount: 500,
     amount_cents: 50000,
-    currency: "EUR",
+    amount_currency: "EUR",
     status: "completed",
     created_at: "2025-01-01T00:00:00.000Z",
   };
@@ -43,14 +40,11 @@ describe("InternalTransferResponseSchema", () => {
     const response = {
       internal_transfer: {
         id: "it-1",
-        debit_iban: "FR7630001007941234567890185",
-        credit_iban: "FR7630001007949876543210185",
-        debit_bank_account_id: "ba-1",
-        credit_bank_account_id: "ba-2",
+        slug: "org-slug-1-transfer-1",
         reference: "Internal transfer",
         amount: 500,
         amount_cents: 50000,
-        currency: "EUR",
+        amount_currency: "EUR",
         status: "completed",
         created_at: "2025-01-01T00:00:00.000Z",
       },

--- a/packages/core/src/internal-transfers/schemas.ts
+++ b/packages/core/src/internal-transfers/schemas.ts
@@ -5,17 +5,26 @@ import { z } from "zod";
 
 import type { InternalTransfer } from "./types.js";
 
+/**
+ * Schema for the internal-transfer object returned by `POST /v2/internal_transfers`.
+ *
+ * Empirical observation (2026-05-10, org `0909-future-club-2702`,
+ * production api-key endpoint): the create response is slimmer than a typical
+ * Qonto resource — it does NOT include IBANs or bank-account IDs, and the
+ * currency field is named `amount_currency` rather than `currency`. This
+ * schema models the actual API contract; previous versions of the schema
+ * (with `debit_iban`, `credit_iban`, `debit_bank_account_id`,
+ * `credit_bank_account_id`, `currency`) were aspirational and caused MCP
+ * tool calls to fail with response-validation errors.
+ */
 export const InternalTransferSchema = z
   .object({
     id: z.string(),
-    debit_iban: z.string(),
-    credit_iban: z.string(),
-    debit_bank_account_id: z.string(),
-    credit_bank_account_id: z.string(),
+    slug: z.string(),
     reference: z.string(),
     amount: z.number(),
     amount_cents: z.number(),
-    currency: z.string(),
+    amount_currency: z.string(),
     status: z.string(),
     created_at: z.string(),
   })

--- a/packages/core/src/internal-transfers/service.test.ts
+++ b/packages/core/src/internal-transfers/service.test.ts
@@ -26,14 +26,11 @@ describe("createInternalTransfer", () => {
   it("creates an internal transfer and returns the result", async () => {
     const internalTransfer = {
       id: "it-1",
-      debit_iban: "FR7630001007941234567890185",
-      credit_iban: "FR7630001007949876543210142",
-      debit_bank_account_id: "ba-1",
-      credit_bank_account_id: "ba-2",
+      slug: "org-slug-1-transfer-1",
       reference: "Monthly allocation",
       amount: 1000.0,
       amount_cents: 100000,
-      currency: "EUR",
+      amount_currency: "EUR",
       status: "processing",
       created_at: "2026-03-01T10:00:00Z",
     };
@@ -69,14 +66,11 @@ describe("createInternalTransfer", () => {
       jsonResponse({
         internal_transfer: {
           id: "it-2",
-          debit_iban: "FR76X",
-          credit_iban: "FR76Y",
-          debit_bank_account_id: "ba-1",
-          credit_bank_account_id: "ba-2",
+          slug: "org-slug-1-transfer-2",
           reference: "Test",
           amount: 50.0,
           amount_cents: 5000,
-          currency: "EUR",
+          amount_currency: "EUR",
           status: "processing",
           created_at: "2026-03-01T10:00:00Z",
         },

--- a/packages/core/src/internal-transfers/types.ts
+++ b/packages/core/src/internal-transfers/types.ts
@@ -2,27 +2,31 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 /**
- * An internal transfer returned by the Qonto API.
+ * An internal transfer returned by `POST /v2/internal_transfers`.
  *
- * Internal transfers move funds between bank accounts
- * within the same Qonto organization.
+ * Internal transfers move funds between bank accounts within the same Qonto
+ * organization. The create response is slimmer than typical Qonto resources:
+ * it does not echo the source/destination IBANs or bank-account IDs, and
+ * the currency field is named `amount_currency` (verified empirically against
+ * the production api-key endpoint, 2026-05-10).
  */
 export interface InternalTransfer {
   readonly id: string;
-  readonly debit_iban: string;
-  readonly credit_iban: string;
-  readonly debit_bank_account_id: string;
-  readonly credit_bank_account_id: string;
+  readonly slug: string;
   readonly reference: string;
   readonly amount: number;
   readonly amount_cents: number;
-  readonly currency: string;
+  readonly amount_currency: string;
   readonly status: string;
   readonly created_at: string;
 }
 
 /**
  * Parameters for creating an internal transfer.
+ *
+ * Note the request/response field-name asymmetry: the request body uses
+ * `currency`, but the response (`InternalTransfer`) uses `amount_currency`.
+ * This mirrors the actual Qonto API contract — do not conflate the two.
  */
 export interface CreateInternalTransferParams {
   readonly debit_iban: string;

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -1,20 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
+import { InternalTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cli, cliJson, cliRaw } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+interface OrgBankAccount {
+  readonly id: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly is_external_account: boolean;
+  readonly balance: number;
+}
 
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-    timeout: 30_000,
-  });
+interface Organization {
+  readonly bank_accounts: readonly OrgBankAccount[];
+}
+
+/**
+ * Discover internal Qonto-owned bank accounts via `org show` rather than
+ * `account list`. The list/show endpoints return masked IBANs
+ * (`FRXXXXXXXXXXXXXXXXXXXXXXXXX`) which are rejected by `internal_transfers`
+ * with `not_found: debit_iban is not found or not active`. The organization
+ * endpoint returns real IBANs in `bank_accounts[]` and only includes
+ * Qonto-internal accounts (excluding aggregated external bank accounts).
+ */
+function discoverInternalAccounts(): readonly OrgBankAccount[] {
+  const org = cliJson<Organization>("org", "show");
+  return org.bank_accounts.filter((a) => !a.is_external_account && a.status === "active");
 }
 
 describe.skipIf(!hasApiKeyCredentials())("internal-transfer CLI commands (e2e)", () => {
@@ -27,6 +41,89 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer CLI commands (e2e)",
         const execError = error as { status: number; stderr: Buffer };
         expect(execError.status).not.toBe(0);
       }
+    });
+
+    // Empirical SCA observation (2026-05-10, org `0909-future-club-2702`,
+    // production api-key endpoint): internal-transfer create succeeds without
+    // triggering SCA at amount=1 EUR. #438's probe confirmed the same at
+    // amount=1.50, and the prior local probe at amount=0.01 also succeeded.
+    // If a future test run starts failing with HTTP 428 / `sca_required`,
+    // the org's SCA enforcement may have changed — coordinate with #449
+    // Group 6 (SCA-gated paths) and migrate this exercise to the
+    // SCA-orchestrated pattern used by `bulk-transfers/` and
+    // `recurring-transfers/`.
+    //
+    // Precondition: the test organization must have ≥2 active internal
+    // (Qonto-owned, non-aggregated) bank accounts. The original test org
+    // (`0001-7324`) ships with one (`Compte principal`); the working test
+    // org (`0909-future-club-2702`) has two pre-provisioned accounts. Local
+    // OAuth `account create` was confirmed to work in principle (returns
+    // HTTP 400 plan-limit on `0909-future-club-2702`, HTTP 403 on
+    // `0001-7324`); api-key cannot self-provision since `/v2/bank_accounts`
+    // POST is OAuth-only. When <2 sufficiently-funded internal accounts are
+    // available, the test skips with a console warning so the gap is visible
+    // without breaking the suite.
+    it("creates an internal transfer between two existing accounts", () => {
+      const accounts = discoverInternalAccounts();
+      // Pick any active internal account with funds to spare (> 1 EUR) for the
+      // debit side; any other active internal account works as credit. We
+      // transfer 1 EUR — small enough that even ~250 such transfers would
+      // perturb a typical test-org balance by less than 0.1%, large enough
+      // to make the > 1 EUR funded threshold unambiguous against rounding /
+      // settlement noise. (#463 AC suggested 0.01 EUR or balance assertions;
+      // post-transfer balance is async-`processing`, so a synchronous
+      // balance assertion is unreliable. The "negligible perturbation" goal
+      // is met at 1 EUR against the working test org's funded balance.)
+      const TRANSFER_AMOUNT_EUR = 1;
+      const debit = accounts.find((a) => a.balance > TRANSFER_AMOUNT_EUR);
+      const credit = accounts.find((a) => a.id !== debit?.id);
+      if (debit === undefined || credit === undefined) {
+        console.warn(
+          `[e2e] internal-transfer create: skipping — requires ≥2 active internal Qonto bank ` +
+            `accounts with at least one funded above ${String(TRANSFER_AMOUNT_EUR)} EUR. ` +
+            `Found ${String(accounts.length)} internal account(s). Provision a second account ` +
+            `via \`qontoctl account create\` (OAuth) and/or fund an existing one.`,
+        );
+        return;
+      }
+
+      const reference = `e2e-internal-${String(Date.now())}`;
+
+      const result = cliRaw(
+        [
+          "--output",
+          "json",
+          "internal-transfer",
+          "create",
+          "--debit-iban",
+          debit.iban,
+          "--credit-iban",
+          credit.iban,
+          "--reference",
+          reference,
+          "--amount",
+          String(TRANSFER_AMOUNT_EUR),
+          "--currency",
+          "EUR",
+        ],
+        { timeout: 30_000 },
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          `internal-transfer create failed: exit=${String(result.status)}\n--- stderr ---\n${result.stderr}\n--- stdout ---\n${result.stdout}`,
+        );
+      }
+
+      const transfer = InternalTransferSchema.parse(JSON.parse(result.stdout));
+      expect(transfer.id.length).toBeGreaterThan(0);
+      expect(transfer.slug.length).toBeGreaterThan(0);
+      expect(transfer.reference).toBe(reference);
+      expect(transfer.amount_currency).toBe("EUR");
+      expect(transfer.amount).toBe(TRANSFER_AMOUNT_EUR);
+      expect(transfer.amount_cents).toBe(TRANSFER_AMOUNT_EUR * 100);
+      expect(transfer.status.length).toBeGreaterThan(0);
+      expect(transfer.created_at.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
@@ -1,13 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { InternalTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
+interface OrgBankAccount {
+  readonly id: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly is_external_account: boolean;
+  readonly balance: number;
+}
+
+interface Organization {
+  readonly bank_accounts: readonly OrgBankAccount[];
+}
 
 describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", () => {
   let client: Client;
@@ -29,6 +40,21 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", ()
     await client.close();
   });
 
+  /**
+   * Discover internal Qonto-owned bank accounts via `org_show` rather than
+   * `account_list`. The latter returns masked IBANs which are rejected by
+   * `internal_transfer_create` (`not_found: debit_iban is not found or
+   * not active`). The organization endpoint returns real IBANs in
+   * `bank_accounts[]` and only includes Qonto-internal accounts.
+   */
+  async function discoverInternalAccounts(): Promise<readonly OrgBankAccount[]> {
+    const result = await client.callTool({ name: "org_show", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const text = firstTextFromMcpResult(result);
+    const org = JSON.parse(text) as Organization;
+    return org.bank_accounts.filter((a) => !a.is_external_account && a.status === "active");
+  }
+
   describe("internal_transfer_create", () => {
     it("rejects create with missing required fields", async () => {
       const result = await client.callTool({
@@ -37,6 +63,73 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", ()
       });
 
       expect(result.isError).toBe(true);
+    });
+
+    // Empirical SCA observation (2026-05-10, org `0909-future-club-2702`,
+    // production api-key endpoint): internal-transfer create succeeds without
+    // triggering SCA at amount=1 EUR. #438's probe confirmed the same at
+    // amount=1.50, and the prior local probe at amount=0.01 also succeeded.
+    // If a future test run starts returning the `executeWithMcpSca`
+    // SCA-pending fallback (a structured text response instead of the
+    // InternalTransfer JSON), coordinate with #449 Group 6 and adapt this
+    // test to the inline mock-decision orchestration pattern used by
+    // `bulk-transfers/mcp.e2e.test.ts`.
+    //
+    // Precondition: the test organization must have ≥2 active internal
+    // (Qonto-owned, non-aggregated) bank accounts. See cli.e2e.test.ts for
+    // the rationale and provisioning note.
+    it("creates an internal transfer between two existing accounts", async () => {
+      const accounts = await discoverInternalAccounts();
+      // Pick any active internal account with funds to spare (> 1 EUR) for the
+      // debit side; any other active internal account works as credit. We
+      // transfer 1 EUR — small enough that even ~250 such transfers would
+      // perturb a typical test-org balance by less than 0.1%, large enough
+      // to make the > 1 EUR funded threshold unambiguous against rounding /
+      // settlement noise. (#463 AC suggested 0.01 EUR or balance assertions;
+      // post-transfer balance is async-`processing`, so a synchronous
+      // balance assertion is unreliable. The "negligible perturbation" goal
+      // is met at 1 EUR against the working test org's funded balance.)
+      const TRANSFER_AMOUNT_EUR = 1;
+      const debit = accounts.find((a) => a.balance > TRANSFER_AMOUNT_EUR);
+      const credit = accounts.find((a) => a.id !== debit?.id);
+      if (debit === undefined || credit === undefined) {
+        console.warn(
+          `[e2e] internal_transfer_create: skipping — requires ≥2 active internal Qonto bank ` +
+            `accounts with at least one funded above ${String(TRANSFER_AMOUNT_EUR)} EUR. ` +
+            `Found ${String(accounts.length)} internal account(s). Provision a second account ` +
+            `via \`qontoctl account create\` (OAuth) and/or fund an existing one.`,
+        );
+        return;
+      }
+
+      const reference = `e2e-mcp-internal-${String(Date.now())}`;
+
+      const result = await client.callTool({
+        name: "internal_transfer_create",
+        arguments: {
+          debit_iban: debit.iban,
+          credit_iban: credit.iban,
+          reference,
+          amount: TRANSFER_AMOUNT_EUR,
+          currency: "EUR",
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+
+      const text = firstTextFromMcpResult(result);
+      // The api-key path returns the InternalTransfer JSON directly. If SCA
+      // is required, `executeWithMcpSca` returns a structured pending text
+      // (e.g. "SCA required: ..."). We expect the JSON path here.
+      const transfer = InternalTransferSchema.parse(JSON.parse(text));
+      expect(transfer.id.length).toBeGreaterThan(0);
+      expect(transfer.slug.length).toBeGreaterThan(0);
+      expect(transfer.reference).toBe(reference);
+      expect(transfer.amount_currency).toBe("EUR");
+      expect(transfer.amount).toBe(TRANSFER_AMOUNT_EUR);
+      expect(transfer.amount_cents).toBe(TRANSFER_AMOUNT_EUR * 100);
+      expect(transfer.status.length).toBeGreaterThan(0);
+      expect(transfer.created_at.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/mcp/src/tools/internal-transfer.test.ts
+++ b/packages/mcp/src/tools/internal-transfer.test.ts
@@ -8,14 +8,11 @@ import { connectInMemory } from "../testing/mcp-helpers.js";
 
 const sampleInternalTransfer = {
   id: "it-123",
-  debit_iban: "FR7630001007941234567890185",
-  credit_iban: "FR7630001007949876543210142",
-  debit_bank_account_id: "ba-1",
-  credit_bank_account_id: "ba-2",
+  slug: "org-slug-1-transfer-12",
   reference: "Monthly allocation",
   amount: 1000.0,
   amount_cents: 100000,
-  currency: "EUR",
+  amount_currency: "EUR",
   status: "processing",
   created_at: "2026-03-01T10:00:00Z",
 };


### PR DESCRIPTION
## Summary

- Replaces structural-only input-rejection tests in `packages/e2e/src/internal-transfers/{cli,mcp}.e2e.test.ts` with real `POST /v2/internal_transfers` exercise against the live Qonto API. Sources real IBANs via `org show` (not masked `account list`), picks a debit account with balance > 1 EUR, transfers 1 EUR, asserts response shape via the aligned `InternalTransferSchema` + per-field assertions.
- Aligns `InternalTransferSchema` and downstream consumers with the actual API response (slimmer than prior schema): removed `debit_iban`, `credit_iban`, `debit_bank_account_id`, `credit_bank_account_id`; renamed `currency` → `amount_currency`; added `slug`. Same approach as #514, #509. Without this, the MCP path is hard-blocked by response-validation failure and the AC cannot be met.
- Bundled both because the schema misalignment was discovered while exercising the real API, and the E2E AC cannot pass without it.

## Test plan

- [x] Unit tests pass: `pnpm test` (cli 720, mcp 357, core full suite green).
- [x] Internal-transfers E2E pass: 4/4 against `0909-future-club-2702` via api-key auth.
- [x] Other E2E failures observed (8 tests in profile/cards/clients/sca-continuation) are pre-existing org-environment issues unrelated to internal-transfers code paths.
- [x] Lint clean (`pnpm lint`).
- [x] Build clean (`pnpm build`).

## Notes

- Empirical SCA observation: amount=1 EUR succeeds without SCA on the working test org. If a future run returns HTTP 428 / SCA-pending, the test will surface the change clearly so we can migrate to the SCA-orchestrated pattern used by `bulk-transfers/`.
- Test-org provisioning finding: api-key alone cannot self-provision a 2nd account on either probed org (`0001-7324`: HTTP 403, `0909-future-club-2702`: HTTP 400 plan-limit). The working test org ships with two pre-provisioned accounts.
- Auth-precedence redesign filed separately as #523 (council-synthesized scope).

Closes #463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)