### PR TITLE
(feat) explicit auth precedence control via auth.preference (#523)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,8 @@ QontoCtl resolves its config file via a deterministic precedence chain (highest 
 
 The MCP server has no CLI flags, so `QONTOCTL_CONFIG_FILE` is its only mechanism for pointing at a non-default file. The path is captured at MCP startup.
 
+Auth precedence between api-key and OAuth credentials is governed by the explicit `auth.preference` field (or `--auth <mode>` flag, or `QONTOCTL_AUTH` env var) with four modes (`api-key`, `api-key-first`, `oauth`, `oauth-first`); default is `oauth-first` — see [`docs/configuration.md`](docs/configuration.md) § Authentication precedence.
+
 Full reference (per-field env overlay, profile semantics, migration guidance for users coming from pre-#479 builds): [`docs/configuration.md`](docs/configuration.md).
 
 ## Conventions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,16 +70,17 @@ scopes) lives in the file only.
 
 Without `--profile`:
 
-| Variable                     | Field                       | Notes                                            |
-| ---------------------------- | --------------------------- | ------------------------------------------------ |
-| `QONTOCTL_ORGANIZATION_SLUG` | `api-key.organization-slug` |                                                  |
-| `QONTOCTL_SECRET_KEY`        | `api-key.secret-key`        |                                                  |
-| `QONTOCTL_CLIENT_ID`         | `oauth.client-id`           |                                                  |
-| `QONTOCTL_CLIENT_SECRET`     | `oauth.client-secret`       |                                                  |
-| `QONTOCTL_ACCESS_TOKEN`      | `oauth.access-token`        | Read-only — see semantics note below             |
-| `QONTOCTL_ENDPOINT`          | `endpoint`                  | Custom API endpoint                              |
-| `QONTOCTL_STAGING_TOKEN`     | `oauth.staging-token`       | Activates sandbox URLs                           |
-| `QONTOCTL_SCA_METHOD`        | `sca.method`                | See [`sandbox-testing.md`](./sandbox-testing.md) |
+| Variable                     | Field                       | Notes                                                                    |
+| ---------------------------- | --------------------------- | ------------------------------------------------------------------------ |
+| `QONTOCTL_ORGANIZATION_SLUG` | `api-key.organization-slug` |                                                                          |
+| `QONTOCTL_SECRET_KEY`        | `api-key.secret-key`        |                                                                          |
+| `QONTOCTL_CLIENT_ID`         | `oauth.client-id`           |                                                                          |
+| `QONTOCTL_CLIENT_SECRET`     | `oauth.client-secret`       |                                                                          |
+| `QONTOCTL_ACCESS_TOKEN`      | `oauth.access-token`        | Read-only — see semantics note below                                     |
+| `QONTOCTL_ENDPOINT`          | `endpoint`                  | Custom API endpoint                                                      |
+| `QONTOCTL_STAGING_TOKEN`     | `oauth.staging-token`       | Activates sandbox URLs                                                   |
+| `QONTOCTL_SCA_METHOD`        | `sca.method`                | See [`sandbox-testing.md`](./sandbox-testing.md)                         |
+| `QONTOCTL_AUTH`              | `auth.preference`           | See [`auth.preference`](#authentication-precedence-authpreference) below |
 
 With `--profile <name>`, the prefix becomes `QONTOCTL_{NAME}_` (uppercased,
 hyphens replaced with underscores). For example, `--profile acme` reads
@@ -97,6 +98,94 @@ hyphens replaced with underscores). For example, `--profile acme` reads
 > file-based credentials (`~/.qontoctl.yaml` or a profile) for OAuth flows
 > that need refresh, or stick with API-key env vars in CI. See
 > [#495](https://github.com/alexey-pelykh/qontoctl/pull/497).
+
+## Authentication precedence (`auth.preference`)
+
+When both api-key and OAuth credentials are configured, QontoCtl needs to
+decide which one is **primary** (used first) and whether the other is a
+**fallback** (used when the primary fails). Pre-[#523](https://github.com/alexey-pelykh/qontoctl/issues/523)
+builds inferred this implicitly from the presence of `oauth.access-token`;
+`#523` replaced that heuristic with an explicit four-mode setting.
+
+### The four modes
+
+| Mode            | Primary | Fallback | Use when                                                                              |
+| --------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
+| `api-key`       | api-key | none     | Force api-key only, never attempt OAuth (CI determinism, pinned-credential workflows) |
+| `api-key-first` | api-key | OAuth    | Prefer api-key but fall back to OAuth on failure                                      |
+| `oauth`         | OAuth   | none     | Force OAuth only — surface refresh failures loudly instead of silently degrading      |
+| `oauth-first`   | OAuth   | api-key  | **Default.** Prefer OAuth (richer scopes), fall back to api-key on failure            |
+
+The `*-first` modes wire fallback when the secondary credential is configured;
+the no-suffix modes never wire fallback. **Default**: when neither flag, env,
+nor config sets a preference, the effective mode is `oauth-first` —
+preserving the pre-`#523` behavior.
+
+### Resolution precedence
+
+Highest priority wins:
+
+1. `--auth <mode>` CLI flag (Commander `.choices()` validates at parse time —
+   misspellings fail loudly: `qontoctl ... --auth oauth-only` →
+   `error: option '--auth <mode>' argument 'oauth-only' is invalid. Allowed choices are api-key, api-key-first, oauth, oauth-first.`)
+2. `QONTOCTL_AUTH` env var (or its profile-scoped variant `QONTOCTL_<PROFILE>_AUTH`).
+   Invalid values are silently dropped — use the flag for validated input.
+3. `auth.preference` config field (file-level — invalid values produce a
+   `VALIDATION` error from `resolveConfig` because checked-in files deserve
+   strict checking).
+4. Built-in default `oauth-first`.
+
+### Both fallback paths
+
+When the resolved mode wires a fallback, the chain advances on **two** failure
+classes:
+
+- **HTTP 401/403** with auth-related error code from the primary credential
+  (existing behavior — preserved). Non-auth 401s (e.g., `vop_proof_token_missing`
+  on a write) propagate directly without falling back, so legitimate
+  per-endpoint authorization failures are not masked.
+- **Auth-flow failure** during header construction — most commonly an OAuth
+  refresh-token returning `invalid_grant` because the token has expired or
+  been revoked. The HTTP client recognizes the typed `OAuthRefreshError` and
+  advances to the fallback before the request is dispatched. Pre-`#523`
+  builds had no catch for this class — that gap is what `#523` fixes.
+
+### Examples
+
+```yaml
+# .qontoctl.yaml — pin api-key for CI determinism
+api-key:
+    organization-slug: acme
+    secret-key: ...
+auth:
+    preference: api-key
+```
+
+```sh
+# Override per-invocation: try OAuth first this run
+qontoctl --auth oauth-first transaction list
+```
+
+```sh
+# Pin via env var in CI (matches the api-key-only env CI provides)
+export QONTOCTL_AUTH=api-key
+qontoctl account list
+```
+
+### Degraded selection (warning)
+
+When the resolved mode requests a credential that is not configured, the chain
+degrades to whatever IS configured and emits a stderr warning:
+
+```text
+Warning: auth preference "oauth" set but no OAuth credentials configured; using api-key instead
+```
+
+The degrade is **not** a hard error — workflows that share a config across
+machines (one of which lacks OAuth setup) keep working. The warning surfaces
+the divergence so the operator can fix the config when convenient. Set the
+no-fallback modes (`api-key` / `oauth`) to force a single auth path with
+no degrade.
 
 ## `QONTOCTL_CONFIG_FILE` — quick reference
 

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -291,8 +291,221 @@ describe("createClient", () => {
     onFallback("GET", "/v2/organizations");
 
     expect(stderrSpy).toHaveBeenCalledWith(
-      "Warning: OAuth authentication failed, falling back to API key for GET /v2/organizations\n",
+      "Warning: primary authentication failed, falling back to api-key for GET /v2/organizations\n",
     );
+  });
+
+  describe("auth preference selection (4 modes × 4 credential states)", () => {
+    const apiKeyCreds = { organizationSlug: "org", secretKey: "key" } as const;
+    const oauthCreds = {
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      accessToken: "access-token",
+      accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    } as const;
+    const oauthAuthFn = vi.fn().mockResolvedValue("Bearer at");
+
+    type AuthMode = "api-key" | "api-key-first" | "oauth" | "oauth-first";
+    type Setup = "both" | "api-key-only" | "oauth-only" | "none";
+
+    interface Case {
+      mode: AuthMode;
+      setup: Setup;
+      expect:
+        | { kind: "throw" }
+        | {
+            kind: "ok";
+            primary: "api-key" | "oauth";
+            fallback: "api-key" | "oauth" | undefined;
+            warning?: string;
+          };
+    }
+
+    const cases: readonly Case[] = [
+      // api-key mode (no fallback)
+      { mode: "api-key", setup: "both", expect: { kind: "ok", primary: "api-key", fallback: undefined } },
+      { mode: "api-key", setup: "api-key-only", expect: { kind: "ok", primary: "api-key", fallback: undefined } },
+      {
+        mode: "api-key",
+        setup: "oauth-only",
+        expect: { kind: "ok", primary: "oauth", fallback: undefined, warning: "no api-key" },
+      },
+      { mode: "api-key", setup: "none", expect: { kind: "throw" } },
+      // api-key-first mode
+      { mode: "api-key-first", setup: "both", expect: { kind: "ok", primary: "api-key", fallback: "oauth" } },
+      {
+        mode: "api-key-first",
+        setup: "api-key-only",
+        expect: { kind: "ok", primary: "api-key", fallback: undefined },
+      },
+      {
+        mode: "api-key-first",
+        setup: "oauth-only",
+        expect: { kind: "ok", primary: "oauth", fallback: undefined, warning: "no api-key" },
+      },
+      { mode: "api-key-first", setup: "none", expect: { kind: "throw" } },
+      // oauth mode (no fallback)
+      { mode: "oauth", setup: "both", expect: { kind: "ok", primary: "oauth", fallback: undefined } },
+      {
+        mode: "oauth",
+        setup: "api-key-only",
+        expect: { kind: "ok", primary: "api-key", fallback: undefined, warning: "no OAuth" },
+      },
+      { mode: "oauth", setup: "oauth-only", expect: { kind: "ok", primary: "oauth", fallback: undefined } },
+      { mode: "oauth", setup: "none", expect: { kind: "throw" } },
+      // oauth-first mode (default)
+      { mode: "oauth-first", setup: "both", expect: { kind: "ok", primary: "oauth", fallback: "api-key" } },
+      {
+        mode: "oauth-first",
+        setup: "api-key-only",
+        expect: { kind: "ok", primary: "api-key", fallback: undefined, warning: "no OAuth" },
+      },
+      {
+        mode: "oauth-first",
+        setup: "oauth-only",
+        expect: { kind: "ok", primary: "oauth", fallback: undefined },
+      },
+      { mode: "oauth-first", setup: "none", expect: { kind: "throw" } },
+    ];
+
+    for (const c of cases) {
+      it(`mode=${c.mode} setup=${c.setup} -> ${c.expect.kind === "throw" ? "throws" : `primary=${c.expect.primary} fallback=${String(c.expect.fallback)}`}`, async () => {
+        createOAuthAuthorizationMock.mockReturnValue(oauthAuthFn);
+        resolveConfigMock.mockResolvedValue({
+          config: {
+            ...(c.setup === "both" || c.setup === "api-key-only" ? { apiKey: apiKeyCreds } : {}),
+            ...(c.setup === "both" || c.setup === "oauth-only" ? { oauth: oauthCreds } : {}),
+          },
+          endpoint: "https://thirdparty.qonto.com",
+          warnings: [],
+          oauthAccessTokenFromEnv: false,
+        });
+
+        const options: GlobalOptions = { output: "table", auth: c.mode };
+
+        if (c.expect.kind === "throw") {
+          await expect(createClient(options)).rejects.toThrow("No credentials found in configuration");
+          return;
+        }
+
+        await createClient(options);
+
+        const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+
+        // Primary authorization assertion
+        if (c.expect.primary === "oauth") {
+          // OAuth primary: authorization is the mock function returned by createOAuthAuthorization
+          expect(ctorArgs?.authorization).toBe(oauthAuthFn);
+        } else {
+          // api-key primary: authorization is a string of form `org:key`
+          expect(ctorArgs?.authorization).toBe("org:key");
+        }
+
+        // Fallback authorization assertion
+        if (c.expect.fallback === "oauth") {
+          expect(ctorArgs?.fallbackAuthorization).toBe(oauthAuthFn);
+        } else if (c.expect.fallback === "api-key") {
+          expect(ctorArgs?.fallbackAuthorization).toBe("org:key");
+        } else {
+          expect(ctorArgs?.fallbackAuthorization).toBeUndefined();
+        }
+
+        // Warning assertion (degrade cases) — match the specific substring from
+        // the fixture (`"no api-key"` / `"no OAuth"`), not just any warning,
+        // so each case verifies the *correct* degrade message reaches stderr.
+        if (c.expect.warning !== undefined) {
+          const expectedWarning = c.expect.warning;
+          const warningCalls = stderrSpy.mock.calls.map((call: [string]) => call[0]) as string[];
+          const sawWarning = warningCalls.some((msg) => msg.startsWith("Warning:") && msg.includes(expectedWarning));
+          expect(sawWarning).toBe(true);
+        }
+      });
+    }
+  });
+
+  describe("auth preference precedence", () => {
+    it("--auth flag overrides config.auth.preference", async () => {
+      const oauthAuthFn = vi.fn().mockResolvedValue("Bearer at");
+      createOAuthAuthorizationMock.mockReturnValue(oauthAuthFn);
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            accessToken: "access-token",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+          apiKey: { organizationSlug: "org", secretKey: "key" },
+          auth: { preference: "oauth-first" },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        oauthAccessTokenFromEnv: false,
+      });
+
+      // Flag picks api-key, overriding config's oauth-first
+      const options: GlobalOptions = { output: "table", auth: "api-key" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.authorization).toBe("org:key");
+      expect(ctorArgs?.fallbackAuthorization).toBeUndefined();
+    });
+
+    it("config.auth.preference is honored when no flag is set", async () => {
+      const oauthAuthFn = vi.fn().mockResolvedValue("Bearer at");
+      createOAuthAuthorizationMock.mockReturnValue(oauthAuthFn);
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            accessToken: "access-token",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+          apiKey: { organizationSlug: "org", secretKey: "key" },
+          auth: { preference: "api-key" },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        oauthAccessTokenFromEnv: false,
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.authorization).toBe("org:key");
+      expect(ctorArgs?.fallbackAuthorization).toBeUndefined();
+    });
+
+    it("default mode (no flag, no config) is oauth-first when both creds present", async () => {
+      // This covers AC: "Default behavior unchanged: when both creds present and
+      // no preference set, effective mode is oauth-first"
+      const oauthAuthFn = vi.fn().mockResolvedValue("Bearer at");
+      createOAuthAuthorizationMock.mockReturnValue(oauthAuthFn);
+      resolveConfigMock.mockResolvedValue({
+        config: {
+          oauth: {
+            clientId: "client-id",
+            clientSecret: "client-secret",
+            accessToken: "access-token",
+            accessTokenExpiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          },
+          apiKey: { organizationSlug: "org", secretKey: "key" },
+        },
+        endpoint: "https://thirdparty.qonto.com",
+        warnings: [],
+        oauthAccessTokenFromEnv: false,
+      });
+
+      const options: GlobalOptions = { output: "table" };
+      await createClient(options);
+
+      const ctorArgs = HttpClientMock.mock.calls[0]?.[0] as HttpClientOptions | undefined;
+      expect(ctorArgs?.authorization).toBe(oauthAuthFn);
+      expect(ctorArgs?.fallbackAuthorization).toBe("org:key");
+    });
   });
 
   describe("scaMethod plumbing", () => {

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -3,10 +3,14 @@
 
 import {
   type Authorization,
+  type AuthSlot,
   type HttpClientLogger,
+  type QontoctlConfig,
   HttpClient,
   resolveConfig,
   resolveScaMethod,
+  resolveAuthPreference,
+  selectAuthChain,
   buildApiKeyAuthorization,
   createOAuthAuthorization,
   OAUTH_TOKEN_URL,
@@ -19,10 +23,20 @@ import type { GlobalOptions } from "./options.js";
  * Create an authenticated HttpClient from global CLI options.
  *
  * Resolves configuration (`--config` > `QONTOCTL_CONFIG_FILE` env >
- * `--profile` derived path > home default), builds the authorization
- * header, and uses the resolved endpoint.
+ * `--profile` derived path > home default), resolves the auth precedence
+ * preference (`--auth` flag > `QONTOCTL_AUTH` env > config > built-in default
+ * `oauth-first`), builds the authorization chain accordingly, and uses the
+ * resolved endpoint.
  *
- * Auth precedence: OAuth (with auto-refresh) > API key.
+ * Auth precedence is governed by the resolved {@link import("@qontoctl/core").AuthPreference}:
+ * - `api-key` — api-key only, no fallback
+ * - `api-key-first` — api-key primary, OAuth fallback when api-key fails
+ * - `oauth` — OAuth only, no fallback
+ * - `oauth-first` (default) — OAuth primary, api-key fallback when OAuth fails
+ *
+ * Both fallback paths trigger on HTTP 401/403 (when the auth header was built
+ * successfully but the API rejected it) AND on auth-flow failures (e.g. OAuth
+ * refresh-token expiry — see {@link import("@qontoctl/core").OAuthRefreshError}).
  */
 export async function createClient(options: GlobalOptions): Promise<HttpClient> {
   const { config, endpoint, warnings, path, oauthAccessTokenFromEnv } = await resolveConfig(
@@ -33,27 +47,55 @@ export async function createClient(options: GlobalOptions): Promise<HttpClient> 
     process.stderr.write(`Warning: ${warning}\n`);
   }
 
-  let authorization: Authorization;
-  let fallbackAuthorization: Authorization | undefined;
+  const preference = resolveAuthPreference(config, options.auth);
+  const selection = selectAuthChain(preference, {
+    apiKey: config.apiKey !== undefined,
+    oauth: config.oauth !== undefined,
+  });
 
-  if (config.oauth !== undefined && config.oauth.clientId !== "" && config.oauth.accessToken !== undefined) {
-    authorization = createOAuthAuthorization({
+  if (selection.noCredentials) {
+    throw new Error("No credentials found in configuration");
+  }
+
+  if (selection.warning !== undefined) {
+    process.stderr.write(`Warning: ${selection.warning}\n`);
+  }
+
+  const oauthFactory = (): Authorization => {
+    if (config.oauth === undefined) {
+      // selectAuthChain only emits the "oauth" slot when oauth creds are
+      // present, so this is unreachable. Kept as a defensive check rather
+      // than a non-null assertion to preserve auditability.
+      throw new Error("Internal error: OAuth slot selected but no OAuth credentials available");
+    }
+    return createOAuthAuthorization({
       oauth: config.oauth,
       tokenUrl: config.oauth.stagingToken !== undefined ? OAUTH_TOKEN_SANDBOX_URL : OAUTH_TOKEN_URL,
       ...(path !== undefined ? { path } : {}),
       ...(options.profile !== undefined ? { profile: options.profile } : {}),
       readOnly: oauthAccessTokenFromEnv,
     });
+  };
 
-    // When OAuth is primary, fall back to API key if available
-    if (config.apiKey !== undefined) {
-      fallbackAuthorization = buildApiKeyAuthorization(config.apiKey);
+  const apiKeyFactory = (): Authorization => {
+    if (config.apiKey === undefined) {
+      throw new Error("Internal error: api-key slot selected but no api-key credentials available");
     }
-  } else if (config.apiKey !== undefined) {
-    authorization = buildApiKeyAuthorization(config.apiKey);
-  } else {
-    throw new Error("No credentials found in configuration");
+    return buildApiKeyAuthorization(config.apiKey);
+  };
+
+  const buildSlot = (slot: AuthSlot): Authorization | undefined => {
+    if (slot === "oauth") return oauthFactory();
+    if (slot === "api-key") return apiKeyFactory();
+    return undefined;
+  };
+
+  const authorization = buildSlot(selection.primary);
+  if (authorization === undefined) {
+    // selectAuthChain guarantees primary !== null when noCredentials === false.
+    throw new Error("Internal error: auth chain has no primary credential");
   }
+  const fallbackAuthorization = buildSlot(selection.fallback);
 
   let logger: HttpClientLogger | undefined;
   if (options.debug === true) {
@@ -78,11 +120,32 @@ export async function createClient(options: GlobalOptions): Promise<HttpClient> 
     baseUrl: endpoint,
     authorization,
     fallbackAuthorization,
-    onFallback: (method, path) => {
-      process.stderr.write(`Warning: OAuth authentication failed, falling back to API key for ${method} ${path}\n`);
+    onFallback: (method, p) => {
+      process.stderr.write(
+        `Warning: primary authentication failed, falling back to ${describeSlot(selection.fallback)} for ${method} ${p}\n`,
+      );
     },
     logger,
-    stagingToken: config.oauth?.stagingToken,
+    stagingToken: getStagingToken(config),
     ...(scaMethod !== undefined ? { scaMethod } : {}),
   });
+}
+
+/**
+ * Read the staging token off the resolved config when present. Extracted so
+ * the call site stays free of `?.` chains (the token may live under `oauth`
+ * but is logically a transport-layer setting and must be applied to whatever
+ * authorization mode is in effect).
+ */
+function getStagingToken(config: QontoctlConfig): string | undefined {
+  return config.oauth?.stagingToken;
+}
+
+/**
+ * Friendly label for a slot value (used in stderr warnings).
+ */
+function describeSlot(slot: AuthSlot): string {
+  if (slot === "oauth") return "OAuth";
+  if (slot === "api-key") return "api-key";
+  return "(none)";
 }

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -5,11 +5,13 @@ import { homedir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import { Option } from "commander";
+import { AUTH_PREFERENCES } from "@qontoctl/core";
 import type { GlobalOptions } from "./options.js";
 
 /**
- * Adds inheritable global options (--config, --profile, --verbose, --debug) to a command.
- * These mirror the program-level options so users can specify them after the subcommand.
+ * Adds inheritable global options to a command — currently `--config`, `--profile`,
+ * `--verbose`, `--debug`, `--sca-method` (hidden), and `--auth`. These mirror the
+ * program-level options so users can specify them after the subcommand.
  */
 export function addInheritableOptions(cmd: Command): Command {
   return cmd
@@ -19,7 +21,13 @@ export function addInheritableOptions(cmd: Command): Command {
     .addOption(new Option("-p, --profile <name>", "configuration profile to use"))
     .addOption(new Option("--verbose", "enable verbose output"))
     .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
-    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp());
+    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
+    .addOption(
+      new Option(
+        "--auth <mode>",
+        "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
+      ).choices([...AUTH_PREFERENCES]),
+    );
 }
 
 /**

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import type { AuthPreference } from "@qontoctl/core";
+
 /**
  * Supported output formats for CLI commands.
  */
@@ -35,6 +37,14 @@ export interface GlobalOptions {
    * default. See `docs/sandbox-testing.md`.
    */
   readonly scaMethod?: string | undefined;
+  /**
+   * Auth precedence preference (`--auth` flag), one of `api-key`,
+   * `api-key-first`, `oauth`, `oauth-first`. Highest-priority preference input —
+   * overrides `QONTOCTL_AUTH` env var and `auth.preference` config field. When
+   * unset, falls back to env > config > built-in default (`oauth-first`).
+   * See [#523](https://github.com/alexey-pelykh/qontoctl/issues/523).
+   */
+  readonly auth?: AuthPreference | undefined;
 }
 
 /**

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,6 +3,7 @@
 
 import { createRequire } from "node:module";
 import { Command, Option } from "commander";
+import { AUTH_PREFERENCES } from "@qontoctl/core";
 import { registerCompletionCommand } from "./completions/index.js";
 import { registerBeneficiaryCommands } from "./commands/beneficiary/index.js";
 import { registerCardCommands } from "./commands/card/index.js";
@@ -45,7 +46,13 @@ export function createProgram(): Command {
     .addOption(new Option("--page <number>", "fetch a specific page of results").argParser(parsePositiveInt))
     .addOption(new Option("--per-page <number>", "number of results per page").argParser(parsePositiveInt))
     .addOption(new Option("--no-paginate", "disable auto-pagination"))
-    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp());
+    .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
+    .addOption(
+      new Option(
+        "--auth <mode>",
+        "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
+      ).choices([...AUTH_PREFERENCES]),
+    );
 
   registerCompletionCommand(program);
   registerBeneficiaryCommands(program);

--- a/packages/core/src/auth/index.ts
+++ b/packages/core/src/auth/index.ts
@@ -6,5 +6,7 @@ export { buildOAuthAuthorization } from "./oauth.js";
 export { createOAuthAuthorization } from "./oauth-authorization-factory.js";
 export type { CreateOAuthAuthorizationOptions } from "./oauth-authorization-factory.js";
 export { generateCodeVerifier, generateCodeChallenge } from "./pkce.js";
-export { exchangeCode, refreshAccessToken, revokeToken } from "./oauth-service.js";
+export { exchangeCode, refreshAccessToken, revokeToken, OAuthRefreshError } from "./oauth-service.js";
 export type { OAuthTokens } from "./oauth-service.js";
+export { isAuthPreference, resolveAuthPreference, selectAuthChain } from "./preference.js";
+export type { AuthChainSelection, AuthSlot } from "./preference.js";

--- a/packages/core/src/auth/oauth-service.test.ts
+++ b/packages/core/src/auth/oauth-service.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { exchangeCode, refreshAccessToken, revokeToken } from "./oauth-service.js";
+import { exchangeCode, refreshAccessToken, revokeToken, OAuthRefreshError } from "./oauth-service.js";
 import { AuthError } from "./api-key.js";
 
 function jsonResponse(data: unknown, status = 200): Response {
@@ -173,6 +173,41 @@ describe("refreshAccessToken", () => {
     await expect(
       refreshAccessToken("https://oauth.example.com/token", "client-id", "client-secret", "bad-refresh"),
     ).rejects.toThrow(AuthError);
+  });
+
+  it("throws OAuthRefreshError (typed marker) on failure so HttpClient can advance to fallback", async () => {
+    vi.mocked(fetch).mockResolvedValue(textResponse("invalid_grant", 400));
+
+    await expect(
+      refreshAccessToken("https://oauth.example.com/token", "client-id", "client-secret", "bad-refresh"),
+    ).rejects.toThrow(OAuthRefreshError);
+  });
+
+  it("preserves the original cause on the OAuthRefreshError", async () => {
+    vi.mocked(fetch).mockResolvedValue(textResponse("invalid_grant", 400));
+
+    try {
+      await refreshAccessToken("https://oauth.example.com/token", "client-id", "client-secret", "bad-refresh");
+      expect.fail("expected refreshAccessToken to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OAuthRefreshError);
+      expect(err).toBeInstanceOf(AuthError);
+      const refreshErr = err as OAuthRefreshError;
+      expect(refreshErr.cause).toBeInstanceOf(AuthError);
+      expect(refreshErr.message).toContain("OAuth token refresh failed");
+    }
+  });
+
+  it("wraps non-AuthError causes (e.g. network errors) into OAuthRefreshError", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("network unreachable"));
+
+    try {
+      await refreshAccessToken("https://oauth.example.com/token", "client-id", "client-secret", "ref");
+      expect.fail("expected refreshAccessToken to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OAuthRefreshError);
+      expect((err as OAuthRefreshError).message).toContain("network unreachable");
+    }
   });
 });
 

--- a/packages/core/src/auth/oauth-service.ts
+++ b/packages/core/src/auth/oauth-service.ts
@@ -7,6 +7,43 @@ import { parseResponse } from "../response.js";
 import { AuthError } from "./api-key.js";
 
 /**
+ * Error thrown when the OAuth refresh-token flow fails (e.g. the refresh
+ * token has expired or been revoked, returning `invalid_grant` from the
+ * authorization server, or a network error during the refresh request).
+ *
+ * Distinct from {@link AuthError} so the HTTP client can recognize this
+ * specific failure class — pre-flight, before any API call is dispatched —
+ * and advance to a fallback authorization (e.g., api-key) when the auth
+ * chain configuration permits. Without a typed marker, the HTTP client
+ * could not distinguish a refresh failure from any other `AuthError`
+ * surfacing during header construction.
+ *
+ * Inherits from {@link AuthError} so existing `instanceof AuthError`
+ * checks (and the broader `name === "AuthError"` lookups some callers
+ * use) continue to match.
+ *
+ * See [#523](https://github.com/alexey-pelykh/qontoctl/issues/523) for the
+ * incident this addresses: refresh-token expiry that previously caused
+ * the CLI to fail entirely instead of falling back to api-key auth even
+ * when api-key creds were configured.
+ */
+export class OAuthRefreshError extends AuthError {
+  /**
+   * Underlying error that caused the refresh failure (e.g. the original
+   * `AuthError` from the token-endpoint response, or a network error). Useful
+   * for surfacing actionable messages to the user without losing the original
+   * cause chain.
+   */
+  readonly cause: unknown;
+
+  constructor(message: string, cause: unknown) {
+    super(message);
+    this.name = "OAuthRefreshError";
+    this.cause = cause;
+  }
+}
+
+/**
  * Tokens returned from a successful OAuth token exchange or refresh.
  */
 export interface OAuthTokens {
@@ -57,6 +94,12 @@ export async function exchangeCode(
  * @param clientId - The OAuth client ID
  * @param clientSecret - The OAuth client secret
  * @param refreshToken - The refresh token
+ *
+ * @throws {OAuthRefreshError} when the token endpoint rejects the refresh
+ *   request (e.g. `invalid_grant`) or the request fails for any other reason
+ *   (network error, parse failure). The original cause is preserved on the
+ *   thrown error so the HTTP client can advance to a fallback authorization
+ *   without losing diagnostic information.
  */
 export async function refreshAccessToken(
   tokenUrl: string,
@@ -72,7 +115,12 @@ export async function refreshAccessToken(
     refresh_token: refreshToken,
   });
 
-  return requestTokens(tokenUrl, body, stagingToken);
+  try {
+    return await requestTokens(tokenUrl, body, stagingToken);
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    throw new OAuthRefreshError(`OAuth token refresh failed: ${detail}`, cause);
+  }
 }
 
 /**

--- a/packages/core/src/auth/preference.test.ts
+++ b/packages/core/src/auth/preference.test.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import type { AuthPreference, QontoctlConfig } from "../config/types.js";
+import { isAuthPreference, resolveAuthPreference, selectAuthChain } from "./preference.js";
+
+describe("isAuthPreference", () => {
+  it.each([
+    ["api-key", true],
+    ["api-key-first", true],
+    ["oauth", true],
+    ["oauth-first", true],
+    ["api-key-only", false], // common typo
+    ["api_key", false],
+    ["", false],
+    ["OAuth", false], // case-sensitive
+  ])("isAuthPreference(%s) === %s", (value, expected) => {
+    expect(isAuthPreference(value)).toBe(expected);
+  });
+
+  it("returns false for non-string inputs", () => {
+    expect(isAuthPreference(undefined)).toBe(false);
+    expect(isAuthPreference(null)).toBe(false);
+    expect(isAuthPreference(42)).toBe(false);
+    expect(isAuthPreference({ preference: "oauth" })).toBe(false);
+  });
+});
+
+describe("resolveAuthPreference", () => {
+  it("returns the override when supplied", () => {
+    const config: QontoctlConfig = { auth: { preference: "oauth" } };
+    expect(resolveAuthPreference(config, "api-key")).toBe("api-key");
+  });
+
+  it("returns config.auth.preference when no override", () => {
+    const config: QontoctlConfig = { auth: { preference: "api-key-first" } };
+    expect(resolveAuthPreference(config)).toBe("api-key-first");
+  });
+
+  it("returns the default (oauth-first) when neither override nor config sets it", () => {
+    const config: QontoctlConfig = {};
+    expect(resolveAuthPreference(config)).toBe("oauth-first");
+  });
+
+  it("returns the default when config.auth is present but preference is undefined", () => {
+    const config: QontoctlConfig = { auth: {} };
+    expect(resolveAuthPreference(config)).toBe("oauth-first");
+  });
+
+  it("override takes precedence even when config and override agree", () => {
+    // Smoke check: the explicit-input branch fires first, regardless of config.
+    const config: QontoctlConfig = { auth: { preference: "oauth-first" } };
+    expect(resolveAuthPreference(config, "oauth-first")).toBe("oauth-first");
+  });
+});
+
+describe("selectAuthChain — 4 modes × 4 credential states (16 cases)", () => {
+  // Decision matrix from the helper's doc-comment, exhaustively asserted.
+  type Setup = "both" | "api-key-only" | "oauth-only" | "none";
+  const setupToAvailable: Record<Setup, { apiKey: boolean; oauth: boolean }> = {
+    both: { apiKey: true, oauth: true },
+    "api-key-only": { apiKey: true, oauth: false },
+    "oauth-only": { apiKey: false, oauth: true },
+    none: { apiKey: false, oauth: false },
+  };
+
+  interface Expected {
+    primary: "api-key" | "oauth" | null;
+    fallback: "api-key" | "oauth" | null;
+    warning: boolean;
+    noCredentials: boolean;
+  }
+
+  const cases: ReadonlyArray<{ mode: AuthPreference; setup: Setup; expect: Expected }> = [
+    // api-key (no fallback)
+    {
+      mode: "api-key",
+      setup: "both",
+      expect: { primary: "api-key", fallback: null, warning: false, noCredentials: false },
+    },
+    {
+      mode: "api-key",
+      setup: "api-key-only",
+      expect: { primary: "api-key", fallback: null, warning: false, noCredentials: false },
+    },
+    {
+      mode: "api-key",
+      setup: "oauth-only",
+      expect: { primary: "oauth", fallback: null, warning: true, noCredentials: false },
+    },
+    { mode: "api-key", setup: "none", expect: { primary: null, fallback: null, warning: false, noCredentials: true } },
+    // api-key-first
+    {
+      mode: "api-key-first",
+      setup: "both",
+      expect: { primary: "api-key", fallback: "oauth", warning: false, noCredentials: false },
+    },
+    {
+      mode: "api-key-first",
+      setup: "api-key-only",
+      expect: { primary: "api-key", fallback: null, warning: false, noCredentials: false },
+    },
+    {
+      mode: "api-key-first",
+      setup: "oauth-only",
+      expect: { primary: "oauth", fallback: null, warning: true, noCredentials: false },
+    },
+    {
+      mode: "api-key-first",
+      setup: "none",
+      expect: { primary: null, fallback: null, warning: false, noCredentials: true },
+    },
+    // oauth (no fallback)
+    {
+      mode: "oauth",
+      setup: "both",
+      expect: { primary: "oauth", fallback: null, warning: false, noCredentials: false },
+    },
+    {
+      mode: "oauth",
+      setup: "api-key-only",
+      expect: { primary: "api-key", fallback: null, warning: true, noCredentials: false },
+    },
+    {
+      mode: "oauth",
+      setup: "oauth-only",
+      expect: { primary: "oauth", fallback: null, warning: false, noCredentials: false },
+    },
+    { mode: "oauth", setup: "none", expect: { primary: null, fallback: null, warning: false, noCredentials: true } },
+    // oauth-first (default)
+    {
+      mode: "oauth-first",
+      setup: "both",
+      expect: { primary: "oauth", fallback: "api-key", warning: false, noCredentials: false },
+    },
+    {
+      mode: "oauth-first",
+      setup: "api-key-only",
+      expect: { primary: "api-key", fallback: null, warning: true, noCredentials: false },
+    },
+    {
+      mode: "oauth-first",
+      setup: "oauth-only",
+      expect: { primary: "oauth", fallback: null, warning: false, noCredentials: false },
+    },
+    {
+      mode: "oauth-first",
+      setup: "none",
+      expect: { primary: null, fallback: null, warning: false, noCredentials: true },
+    },
+  ];
+
+  for (const c of cases) {
+    it(`mode=${c.mode} setup=${c.setup} -> primary=${c.expect.primary} fallback=${c.expect.fallback} warning=${c.expect.warning} noCreds=${c.expect.noCredentials}`, () => {
+      const selection = selectAuthChain(c.mode, setupToAvailable[c.setup]);
+
+      expect(selection.primary).toBe(c.expect.primary);
+      expect(selection.fallback).toBe(c.expect.fallback);
+      expect(selection.noCredentials).toBe(c.expect.noCredentials);
+
+      if (c.expect.warning) {
+        expect(selection.warning).toBeDefined();
+        expect(typeof selection.warning).toBe("string");
+        // Warning must mention the requested preference so the user can find it
+        // in the codebase / docs without ambiguity.
+        expect(selection.warning).toContain(c.mode);
+      } else {
+        expect(selection.warning).toBeUndefined();
+      }
+    });
+  }
+});

--- a/packages/core/src/auth/preference.ts
+++ b/packages/core/src/auth/preference.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { AuthPreference, QontoctlConfig } from "../config/types.js";
+import { AUTH_PREFERENCES, DEFAULT_AUTH_PREFERENCE } from "../config/types.js";
+
+/**
+ * Type guard: `true` when `value` is a valid {@link AuthPreference} string.
+ *
+ * Used by the CLI flag's Commander `.choices()` validation, the env-overlay
+ * filter, and any other input-boundary check. Centralizing the test means a
+ * future addition to {@link AUTH_PREFERENCES} (e.g., a fifth mode) lights up
+ * every input path uniformly.
+ */
+export function isAuthPreference(value: unknown): value is AuthPreference {
+  return typeof value === "string" && (AUTH_PREFERENCES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the effective {@link AuthPreference} for a CLI/MCP invocation.
+ *
+ * Precedence (highest first), per #523:
+ *
+ * 1. `override` — caller-supplied value (typically the CLI's `--auth` flag).
+ *    The Commander layer validates this against {@link AUTH_PREFERENCES}, so
+ *    by the time it reaches here it is already a valid mode (or `undefined`).
+ * 2. `config.auth.preference` — already-resolved value carrying the file-or-env
+ *    tier. The `applyEnvOverlay` step writes the env value (`QONTOCTL_AUTH`)
+ *    onto this field, which means env > file (per the standard env-overlay
+ *    rule). When neither env nor file supplies a value, this field is `undefined`
+ *    and the default takes over.
+ * 3. {@link DEFAULT_AUTH_PREFERENCE} — `oauth-first`, preserving pre-#523
+ *    behavior when both credentials are present.
+ *
+ * The CLI passes its `--auth` flag verbatim; the MCP server has no flag and
+ * always passes `undefined`, so MCP effectively resolves to env > file > default.
+ *
+ * @param config Resolved config (env-overlaid).
+ * @param override Optional explicit preference (CLI flag value).
+ */
+export function resolveAuthPreference(config: QontoctlConfig, override?: AuthPreference): AuthPreference {
+  if (override !== undefined) {
+    return override;
+  }
+  if (config.auth?.preference !== undefined) {
+    return config.auth.preference;
+  }
+  return DEFAULT_AUTH_PREFERENCE;
+}
+
+/**
+ * Authorization slot in the resolved chain — names the credential that should
+ * fill the `authorization` (primary) or `fallbackAuthorization` (secondary)
+ * position of the {@link import("../http-client.js").HttpClient}.
+ *
+ * `null` represents an empty slot (no credential bound here).
+ */
+export type AuthSlot = "api-key" | "oauth" | null;
+
+/**
+ * Result of {@link selectAuthChain}: which credentials fill the primary and
+ * fallback slots, plus a non-fatal warning describing any degrade.
+ *
+ * Shape decisions:
+ *
+ * - Returns NAMES of credentials, not built `Authorization` objects, so this
+ *   helper can stay package-agnostic. The callers (CLI / MCP) build the actual
+ *   {@link import("../http-client.js").Authorization} objects from the slot
+ *   names — only they have the per-package context (`path`, `profile`,
+ *   `readOnly`, `tokenUrl`) needed for {@link import("./oauth-authorization-factory.js").createOAuthAuthorization}.
+ * - `warning` is informational, not a hard error: when a `*-first` preference
+ *   has only one credential available, the chain degrades to that single
+ *   credential and `warning` describes what happened. Callers print to stderr.
+ * - `noCredentials` is `true` when neither api-key nor OAuth is configured —
+ *   the caller MUST surface this as a fatal error (no chain can be built).
+ */
+export interface AuthChainSelection {
+  primary: AuthSlot;
+  fallback: AuthSlot;
+  warning?: string;
+  noCredentials: boolean;
+}
+
+/**
+ * Select which credentials fill the auth chain given a resolved preference and
+ * the credentials actually available in config.
+ *
+ * Decision matrix (16 cases — 4 modes × 4 credential states):
+ *
+ * | Mode             | both       | api-key only | oauth only      | none |
+ * |------------------|------------|--------------|-----------------|------|
+ * | `api-key`        | api-key    | api-key      | degrade→oauth*  | NONE |
+ * | `api-key-first`  | api-key→oa | api-key      | degrade→oauth*  | NONE |
+ * | `oauth`          | oauth      | degrade→ak*  | oauth           | NONE |
+ * | `oauth-first`    | oauth→ak   | degrade→ak*  | oauth           | NONE |
+ *
+ * `*` = warning emitted because the requested mode lacks the matching credential.
+ *
+ * The "degrade" rule (rather than "fail loud") reflects the AC's pragmatic stance:
+ * a workflow that has only api-key creds shouldn't break just because the user
+ * pinned `oauth` in a profile shared with another machine. The warning surfaces
+ * the divergence so the operator can fix the config when convenient.
+ */
+export function selectAuthChain(
+  preference: AuthPreference,
+  available: { apiKey: boolean; oauth: boolean },
+): AuthChainSelection {
+  const { apiKey, oauth } = available;
+
+  if (!apiKey && !oauth) {
+    return { primary: null, fallback: null, noCredentials: true };
+  }
+
+  switch (preference) {
+    case "api-key": {
+      if (apiKey) {
+        return { primary: "api-key", fallback: null, noCredentials: false };
+      }
+      // Requested api-key only, but only OAuth available — degrade with warning.
+      return {
+        primary: "oauth",
+        fallback: null,
+        warning: 'auth preference "api-key" set but no api-key credentials configured; using OAuth instead',
+        noCredentials: false,
+      };
+    }
+    case "api-key-first": {
+      if (apiKey && oauth) {
+        return { primary: "api-key", fallback: "oauth", noCredentials: false };
+      }
+      if (apiKey) {
+        return { primary: "api-key", fallback: null, noCredentials: false };
+      }
+      // Only OAuth available, but api-key was requested as primary — degrade.
+      return {
+        primary: "oauth",
+        fallback: null,
+        warning: 'auth preference "api-key-first" set but no api-key credentials configured; using OAuth instead',
+        noCredentials: false,
+      };
+    }
+    case "oauth": {
+      if (oauth) {
+        return { primary: "oauth", fallback: null, noCredentials: false };
+      }
+      // Requested oauth only, but only api-key available — degrade with warning.
+      return {
+        primary: "api-key",
+        fallback: null,
+        warning: 'auth preference "oauth" set but no OAuth credentials configured; using api-key instead',
+        noCredentials: false,
+      };
+    }
+    case "oauth-first": {
+      if (oauth && apiKey) {
+        return { primary: "oauth", fallback: "api-key", noCredentials: false };
+      }
+      if (oauth) {
+        return { primary: "oauth", fallback: null, noCredentials: false };
+      }
+      // Only api-key available, but OAuth was requested as primary — degrade.
+      return {
+        primary: "api-key",
+        fallback: null,
+        warning: 'auth preference "oauth-first" set but no OAuth credentials configured; using api-key instead',
+        noCredentials: false,
+      };
+    }
+  }
+}

--- a/packages/core/src/config/env.test.ts
+++ b/packages/core/src/config/env.test.ts
@@ -419,4 +419,65 @@ describe("applyEnvOverlay", () => {
     );
     expect(accessTokenFromEnv).toBe(false);
   });
+
+  describe("QONTOCTL_AUTH", () => {
+    it.each(["api-key", "api-key-first", "oauth", "oauth-first"] as const)(
+      "overlays valid value %s from bare env var",
+      (value) => {
+        const { config: result } = applyEnvOverlay({}, { env: { QONTOCTL_AUTH: value } });
+        expect(result.auth?.preference).toBe(value);
+      },
+    );
+
+    it("env preference overrides file preference", () => {
+      const { config: result } = applyEnvOverlay(
+        { auth: { preference: "oauth-first" } },
+        { env: { QONTOCTL_AUTH: "api-key" } },
+      );
+      expect(result.auth?.preference).toBe("api-key");
+    });
+
+    it("silently drops invalid env value (CLI flag's choices() catches typos at parse time)", () => {
+      const { config: result } = applyEnvOverlay(
+        {},
+        { env: { QONTOCTL_AUTH: "api-key-only" } }, // common typo
+      );
+      // Falls through with no auth preference set; resolveAuthPreference's
+      // default (`oauth-first`) will kick in downstream.
+      expect(result.auth).toBeUndefined();
+    });
+
+    it("overlays profile-scoped variant", () => {
+      const { config: result } = applyEnvOverlay(
+        {},
+        {
+          profile: "staging",
+          env: { QONTOCTL_STAGING_AUTH: "oauth" },
+        },
+      );
+      expect(result.auth?.preference).toBe("oauth");
+    });
+
+    it("ignores bare QONTOCTL_AUTH when profile is specified", () => {
+      const { config: result } = applyEnvOverlay(
+        {},
+        {
+          profile: "staging",
+          env: { QONTOCTL_AUTH: "api-key" },
+        },
+      );
+      expect(result.auth).toBeUndefined();
+    });
+
+    it("preserves existing auth fields when only some are env-supplied", () => {
+      // Today there is only `preference` under auth, so this just verifies the
+      // spread doesn't drop the field. When the auth namespace grows, the
+      // pattern is already in place.
+      const { config: result } = applyEnvOverlay(
+        { auth: { preference: "api-key" } },
+        { env: { QONTOCTL_AUTH: "oauth" } },
+      );
+      expect(result.auth?.preference).toBe("oauth");
+    });
+  });
 });

--- a/packages/core/src/config/env.ts
+++ b/packages/core/src/config/env.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import type { ApiKeyCredentials, OAuthCredentials, ScaConfig } from "./types.js";
+import type { ApiKeyCredentials, AuthConfig, AuthPreference, OAuthCredentials, ScaConfig } from "./types.js";
+import { AUTH_PREFERENCES } from "./types.js";
 
 const ENV_PREFIX = "QONTOCTL";
 const ORG_SLUG_SUFFIX = "ORGANIZATION_SLUG";
@@ -12,6 +13,13 @@ const CLIENT_SECRET_SUFFIX = "CLIENT_SECRET";
 const ACCESS_TOKEN_SUFFIX = "ACCESS_TOKEN";
 const STAGING_TOKEN_SUFFIX = "STAGING_TOKEN";
 const SCA_METHOD_SUFFIX = "SCA_METHOD";
+// `QONTOCTL_AUTH` (no `_PREFERENCE` suffix) mirrors the user-facing `--auth`
+// CLI flag — the dominant interaction surface — rather than the YAML structure
+// `auth.preference`. Trade-off accepted: the YAML/file path is more verbose,
+// the env var is leaner. If the `auth` section grows additional fields they
+// will use `QONTOCTL_AUTH_<FIELD>` (e.g. `QONTOCTL_AUTH_TIMEOUT`); preference
+// keeps the canonical short form because it is the section's primary control.
+const AUTH_SUFFIX = "AUTH";
 
 /**
  * Subset of {@link OAuthCredentials} that env vars are permitted to set.
@@ -46,6 +54,7 @@ export interface EnvOverlayConfig {
   oauth?: StaticOAuthFields;
   endpoint?: string;
   sca?: ScaConfig;
+  auth?: AuthConfig;
 }
 
 /**
@@ -77,6 +86,9 @@ export interface EnvOverlayResult {
  * - `QONTOCTL_STAGING_TOKEN` (sandbox routing)
  * - `QONTOCTL_ENDPOINT` (override)
  * - `QONTOCTL_SCA_METHOD` (preference)
+ * - `QONTOCTL_AUTH` (auth precedence — `api-key` / `api-key-first` / `oauth`
+ *   / `oauth-first`; invalid values are silently dropped here, the `--auth`
+ *   flag's `choices()` validation catches misspellings at parse time)
  *
  * Runtime-mutable fields (`refreshToken`, `accessTokenExpiresAt`, `scopes`)
  * are **never** read from env. They belong to file state the tool both reads
@@ -107,6 +119,7 @@ export function applyEnvOverlay(
   const accessToken = env[`${prefix}_${ACCESS_TOKEN_SUFFIX}`];
   const stagingToken = env[`${prefix}_${STAGING_TOKEN_SUFFIX}`];
   const scaMethod = env[`${prefix}_${SCA_METHOD_SUFFIX}`];
+  const authPreference = env[`${prefix}_${AUTH_SUFFIX}`];
 
   let result: EnvOverlayConfig = config;
 
@@ -184,6 +197,13 @@ export function applyEnvOverlay(
 
   if (scaMethod !== undefined) {
     result = { ...result, sca: { ...result.sca, method: scaMethod } };
+  }
+
+  if (authPreference !== undefined && (AUTH_PREFERENCES as readonly string[]).includes(authPreference)) {
+    // Silently ignore invalid env values — env-overlay is forgiving by design
+    // (the hard validation lives in the CLI's `--auth` choices() check).
+    // This mirrors the SCA method behavior where free-form values pass through.
+    result = { ...result, auth: { ...result.auth, preference: authPreference as AuthPreference } };
   }
 
   return { config: result, accessTokenFromEnv: accessToken !== undefined };

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -3,12 +3,15 @@
 
 export type {
   ApiKeyCredentials,
+  AuthConfig,
+  AuthPreference,
   OAuthCredentials,
   QontoctlConfig,
   ConfigResult,
   ResolveOptions,
   ScaConfig,
 } from "./types.js";
+export { AUTH_PREFERENCES, DEFAULT_AUTH_PREFERENCE } from "./types.js";
 export { resolveConfig, resolveConfigPath, resolveScaMethod, ConfigError } from "./resolve.js";
 export type { ConfigErrorCode } from "./resolve.js";
 export { loadConfigFile, resolveConfigFilePath } from "./loader.js";

--- a/packages/core/src/config/resolve.ts
+++ b/packages/core/src/config/resolve.ts
@@ -189,6 +189,9 @@ function pickStaticFields(config: QontoctlConfig): EnvOverlayConfig {
   if (config.sca !== undefined) {
     result.sca = config.sca;
   }
+  if (config.auth !== undefined) {
+    result.auth = config.auth;
+  }
   return result;
 }
 
@@ -203,6 +206,7 @@ function mergeRuntimeFields(staticPortion: EnvOverlayConfig, source: QontoctlCon
     ...(staticPortion.apiKey !== undefined ? { apiKey: staticPortion.apiKey } : {}),
     ...(staticPortion.endpoint !== undefined ? { endpoint: staticPortion.endpoint } : {}),
     ...(staticPortion.sca !== undefined ? { sca: staticPortion.sca } : {}),
+    ...(staticPortion.auth !== undefined ? { auth: staticPortion.auth } : {}),
   };
 
   if (staticPortion.oauth !== undefined) {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -39,6 +39,69 @@ export interface ScaConfig {
 }
 
 /**
+ * Explicit authentication preference modes for {@link AuthConfig.preference}.
+ *
+ * Replaces the legacy presence-based selection (`oauth.accessToken
+ * !== undefined ⇒ OAuth primary, api-key fallback`) with explicit user control
+ * over which credential is primary AND whether the other is a fallback.
+ *
+ * - `api-key` — api-key only, **no fallback**. Use when api-key auth must be
+ *   forced and OAuth must NEVER be attempted (e.g., CI where OAuth is
+ *   undesirable, or pinned-credential workflows).
+ * - `api-key-first` — api-key primary, OAuth fallback when api-key fails.
+ * - `oauth` — OAuth only, **no fallback**. Use to force-pin OAuth and surface
+ *   refresh failures loudly (vs silently degrading to api-key).
+ * - `oauth-first` — OAuth primary, api-key fallback when OAuth fails. **Default**
+ *   when both credentials are present and no preference is set; preserves
+ *   the pre-#523 behavior.
+ *
+ * The `*-first` modes wire fallback when the secondary credential is available;
+ * non-`-first` modes never wire fallback.
+ *
+ * Industry precedent: AWS SDK credential provider chain, gcloud Application
+ * Default Credentials, kubectl context picker (no-fallback model).
+ */
+export type AuthPreference = "api-key" | "api-key-first" | "oauth" | "oauth-first";
+
+/**
+ * All valid {@link AuthPreference} values, used for runtime validation
+ * (env-var parsing, Commander `.choices()`, schema validation).
+ */
+export const AUTH_PREFERENCES: readonly AuthPreference[] = [
+  "api-key",
+  "api-key-first",
+  "oauth",
+  "oauth-first",
+] as const;
+
+/**
+ * Default preference applied when neither flag, env var, nor config sets one.
+ *
+ * Chosen to preserve pre-#523 behavior: OAuth primary (when both creds
+ * present), api-key as silent fallback. Flipping the default direction is a
+ * separate major-release decision gated on telemetry.
+ */
+export const DEFAULT_AUTH_PREFERENCE: AuthPreference = "oauth-first";
+
+/**
+ * Authentication-related configuration.
+ *
+ * Currently exposes the {@link preference} field. Lives at top-level (not
+ * under `oauth` or `api-key`) because the preference governs the chain
+ * across both credential types — placing it under either would imply
+ * subordination that the field does not have.
+ */
+export interface AuthConfig {
+  /**
+   * Explicit auth preference mode. See {@link AuthPreference}.
+   *
+   * Precedence (highest first): `--auth` CLI flag > `QONTOCTL_AUTH` env var
+   * > `auth.preference` config field > {@link DEFAULT_AUTH_PREFERENCE}.
+   */
+  preference?: AuthPreference;
+}
+
+/**
  * Parsed configuration from a `.qontoctl.yaml` file.
  */
 export interface QontoctlConfig {
@@ -46,6 +109,7 @@ export interface QontoctlConfig {
   oauth?: OAuthCredentials;
   endpoint?: string;
   sca?: ScaConfig;
+  auth?: AuthConfig;
 }
 
 /**

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -326,6 +326,49 @@ describe("validateConfig", () => {
     const result = validateConfig({ sca: { method: "mock" } });
     expect(result.warnings).toEqual([]);
   });
+
+  describe("auth section", () => {
+    it.each(["api-key", "api-key-first", "oauth", "oauth-first"])("accepts valid auth.preference value %s", (value) => {
+      const result = validateConfig({ auth: { preference: value } });
+      expect(result.errors).toEqual([]);
+      expect(result.config.auth).toEqual({ preference: value });
+    });
+
+    it("ignores empty auth section", () => {
+      const result = validateConfig({ auth: null });
+      expect(result.config.auth).toBeUndefined();
+      expect(result.errors).toEqual([]);
+    });
+
+    it("errors when auth section is not a mapping", () => {
+      const result = validateConfig({ auth: "api-key" });
+      expect(result.errors).toContain('"auth" must be a mapping');
+    });
+
+    it("errors on invalid auth.preference value (typo not silently dropped)", () => {
+      // File-level validation is strict (unlike env-overlay) — config files are
+      // edited carefully and a typo in a checked-in file deserves a clear failure.
+      const result = validateConfig({ auth: { preference: "api-key-only" } });
+      expect(result.errors.some((e) => e.includes('"auth.preference"'))).toBe(true);
+      expect(result.errors.some((e) => e.includes("api-key-only"))).toBe(true);
+    });
+
+    it("errors when auth.preference is not a string", () => {
+      const result = validateConfig({ auth: { preference: 42 } });
+      expect(result.errors).toContain('"auth.preference" must be a string');
+    });
+
+    it("warns on unknown keys inside auth", () => {
+      const result = validateConfig({ auth: { preference: "oauth", future: "value" } });
+      expect(result.warnings).toContain('Unknown key in "auth": "future"');
+      expect(result.config.auth).toEqual({ preference: "oauth" });
+    });
+
+    it("does not warn on auth as a known top-level key", () => {
+      const result = validateConfig({ auth: { preference: "oauth-first" } });
+      expect(result.warnings).toEqual([]);
+    });
+  });
 });
 
 describe("isValidProfileName", () => {
@@ -376,6 +419,8 @@ describe("isValidProfileName", () => {
     expect(isValidProfileName("organization-slug")).toBe(false);
     expect(isValidProfileName("secret-key")).toBe(false);
     expect(isValidProfileName("sca-method")).toBe(false);
+    expect(isValidProfileName("auth")).toBe(false);
+    expect(isValidProfileName("AUTH")).toBe(false);
     expect(isValidProfileName("config-file")).toBe(false);
     // Underscore form too (the post-normalization shape)
     expect(isValidProfileName("client_id")).toBe(false);

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import type { QontoctlConfig } from "./types.js";
+import type { AuthPreference, QontoctlConfig } from "./types.js";
+import { AUTH_PREFERENCES } from "./types.js";
 
 /**
  * Profile names that would shadow no-profile env-var suffixes.
@@ -27,6 +28,7 @@ const RESERVED_PROFILE_SUFFIXES = new Set([
   "SCOPES",
   "STAGING_TOKEN",
   "SCA_METHOD",
+  "AUTH",
   "CONFIG_FILE",
 ]);
 
@@ -52,7 +54,7 @@ export function isValidProfileName(name: string): boolean {
   return true;
 }
 
-const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key", "oauth", "endpoint", "sca"]);
+const KNOWN_TOP_LEVEL_KEYS = new Set(["api-key", "oauth", "endpoint", "sca", "auth"]);
 const KNOWN_API_KEY_KEYS = new Set(["organization-slug", "secret-key"]);
 const KNOWN_OAUTH_KEYS = new Set([
   "client-id",
@@ -65,6 +67,7 @@ const KNOWN_OAUTH_KEYS = new Set([
   "staging-token",
 ]);
 const KNOWN_SCA_KEYS = new Set(["method"]);
+const KNOWN_AUTH_KEYS = new Set(["preference"]);
 
 export interface ValidationResult {
   config: QontoctlConfig;
@@ -244,6 +247,39 @@ export function validateConfig(raw: unknown): ValidationResult {
 
       if (typeof method === "string") {
         config.sca = { method };
+      }
+    }
+  }
+
+  if ("auth" in doc) {
+    const authSection = doc["auth"];
+
+    if (authSection === null || authSection === undefined) {
+      // auth section present but empty — not an error
+    } else if (typeof authSection !== "object" || Array.isArray(authSection)) {
+      errors.push('"auth" must be a mapping');
+    } else {
+      const auth = authSection as Record<string, unknown>;
+
+      for (const key of Object.keys(auth)) {
+        if (!KNOWN_AUTH_KEYS.has(key)) {
+          warnings.push(`Unknown key in "auth": "${key}"`);
+        }
+      }
+
+      const preference = auth["preference"];
+
+      if (preference !== undefined) {
+        if (typeof preference !== "string") {
+          errors.push('"auth.preference" must be a string');
+        } else if (!(AUTH_PREFERENCES as readonly string[]).includes(preference)) {
+          // Hard error here — unlike env vars, file values can be edited carefully,
+          // so a typo (`api-key-only` instead of `api-key`) deserves a clear failure
+          // rather than a silent fallback to the default direction.
+          errors.push(`"auth.preference" must be one of: ${AUTH_PREFERENCES.join(", ")} (got "${preference}")`);
+        } else {
+          config.auth = { preference: preference as AuthPreference };
+        }
       }
     }
   }

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -10,6 +10,8 @@ import {
   QontoScaNotEnrolledError,
   QontoScaRequiredError,
 } from "./http-client.js";
+import { OAuthRefreshError } from "./auth/oauth-service.js";
+import { AuthError } from "./auth/api-key.js";
 import { binaryResponse } from "./testing/binary-response.js";
 import { jsonResponse } from "./testing/json-response.js";
 
@@ -1576,6 +1578,128 @@ describe("HttpClient", () => {
       expect((error as QontoApiError).status).toBe(403);
       expect((error as QontoApiError).errors[0]?.code).toBe("insufficient_funds");
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // ---------------------------------------------------------------------
+    // Auth-flow fallback (OAuthRefreshError) — closes the gap from #523:
+    // before this branch, an OAuth refresh failure (e.g., refresh-token
+    // `invalid_grant`) propagated out of the request entirely, never
+    // advancing to the fallback authorization. Now the typed
+    // `OAuthRefreshError` is caught pre-fetch and the request is dispatched
+    // with the fallback credential, mirroring the HTTP-401 fallback shape.
+    // ---------------------------------------------------------------------
+
+    it("falls back to api-key when OAuth auth callback throws OAuthRefreshError pre-fetch", async () => {
+      const oauthAuth = vi.fn(() => {
+        throw new OAuthRefreshError("OAuth token refresh failed: invalid_grant", new Error("invalid_grant"));
+      });
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+
+      const onFallback = vi.fn();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: oauthAuth,
+        fallbackAuthorization: "slug:key",
+        onFallback,
+      });
+
+      const result = await client.get("/v2/organizations");
+
+      expect(result).toEqual({ data: "ok" });
+      // Critical: the request was dispatched ONCE — directly with fallback —
+      // not (failed primary then fallback retry). The OAuth attempt never
+      // reached the network because the auth callback threw.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect((init.headers as Record<string, string>)["Authorization"]).toBe("slug:key");
+      expect(onFallback).toHaveBeenCalledWith("GET", "/v2/organizations");
+    });
+
+    it("propagates OAuthRefreshError when no fallback is configured", async () => {
+      const oauthAuth = vi.fn(() => {
+        throw new OAuthRefreshError("OAuth token refresh failed: invalid_grant", new Error("invalid_grant"));
+      });
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: oauthAuth,
+        // No fallbackAuthorization — chain has nowhere to advance.
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(OAuthRefreshError);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("propagates non-OAuthRefreshError AuthError without falling back (do not mask config bugs)", async () => {
+      // A non-typed AuthError (e.g., misconfigured api-key with empty secret)
+      // is a configuration problem, NOT a refresh-flow failure. Falling back
+      // would silently mask it. Verify we propagate.
+      const auth = vi.fn(() => {
+        throw new AuthError("Missing secret key in API key credentials");
+      });
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: auth,
+        fallbackAuthorization: "slug:key",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(AuthError);
+      expect(error).not.toBeInstanceOf(OAuthRefreshError);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT trigger HTTP 401 fallback when already on fallback after OAuthRefreshError", async () => {
+      // Edge case: OAuthRefreshError pre-fetch → fallback dispatched → API
+      // returns 401 (e.g., the api-key creds are also invalid). The 401
+      // fallback path must NOT re-trigger (which would dispatch the same
+      // fallback creds a third time and confuse the error class). The test
+      // asserts: fetch called ONCE with fallback, then 401 propagates as
+      // QontoApiError (not retried, not fallback-of-fallback'd).
+      const oauthAuth = vi.fn(() => {
+        throw new OAuthRefreshError("OAuth token refresh failed: invalid_grant", new Error("invalid_grant"));
+      });
+      fetchSpy.mockReturnValue(
+        jsonResponse({ errors: [{ code: "unauthorized", detail: "Unauthorized" }] }, { status: 401 }),
+      );
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: oauthAuth,
+        fallbackAuthorization: "slug:bad-key",
+      });
+
+      const error = await client.get("/v2/organizations").catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(QontoApiError);
+      expect((error as QontoApiError).status).toBe(401);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves idempotency key on auth-flow fallback for write requests", async () => {
+      const oauthAuth = vi.fn(() => {
+        throw new OAuthRefreshError("OAuth token refresh failed: invalid_grant", new Error("invalid_grant"));
+      });
+      fetchSpy.mockReturnValue(jsonResponse({ id: "123" }, { status: 201 }));
+
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: oauthAuth,
+        fallbackAuthorization: "slug:key",
+      });
+
+      await client.post("/v2/transfers", { amount: 100 });
+
+      const [, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      const headers = init.headers as Record<string, string>;
+      // Idempotency key was generated up-front in fetchWithRetry and applied
+      // to the (single) fallback request — without this, the fallback would
+      // miss the safety net for retried writes.
+      expect(headers["X-Qonto-Idempotency-Key"]).toBeDefined();
     });
   });
 

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -4,6 +4,8 @@
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 
+import { OAuthRefreshError } from "./auth/oauth-service.js";
+
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version: string };
 
@@ -426,7 +428,47 @@ export class HttpClient {
     const idempotencyKey = isWrite ? (options?.idempotencyKey ?? randomUUID()) : undefined;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const headers = await this.buildHeaders(!isFormData && options?.body !== undefined, options?.accept);
+      // Track whether we already advanced to the fallback authorization for THIS
+      // attempt. Two paths feed it:
+      //   1. Auth-flow failure (e.g. OAuth refresh `invalid_grant`): caught
+      //      pre-fetch and retried by re-building headers with the fallback.
+      //   2. HTTP-level 401/403 fallback (existing behavior, gated below by
+      //      `!usingFallback`).
+      //
+      // The flag exists so the 401/403 path does not re-trigger after we have
+      // already used the fallback for this attempt — that would call api-key
+      // a second time on a path-level rejection and swallow the legitimate
+      // error class.
+      let usingFallback = false;
+      let headers: Record<string, string>;
+
+      try {
+        headers = await this.buildHeaders(!isFormData && options?.body !== undefined, options?.accept);
+      } catch (err) {
+        // Auth-flow failures (OAuth refresh-token expiry, network failure during
+        // refresh) are recognized via the typed `OAuthRefreshError` so they can
+        // advance to the fallback authorization the same way an HTTP 401 would.
+        // Without this branch, a refresh failure would short-circuit out of the
+        // request entirely — the bug class #523 was opened to fix.
+        //
+        // Critical: we ONLY catch the typed error class here. A generic
+        // `AuthError` or any other throw still propagates so we never silently
+        // mask a misconfigured api-key (e.g. empty `secret-key` raises
+        // `AuthError` from `buildApiKeyAuthorization` — that is a configuration
+        // problem the user must see, not a fallback trigger).
+        if (err instanceof OAuthRefreshError && this.fallbackAuthorization !== undefined) {
+          this.logVerbose(`OAuth refresh failed (${err.message}); advancing to fallback authorization`);
+          this.onFallback?.(method, path);
+          usingFallback = true;
+          headers = await this.buildHeaders(
+            !isFormData && options?.body !== undefined,
+            options?.accept,
+            this.fallbackAuthorization,
+          );
+        } else {
+          throw err;
+        }
+      }
 
       if (idempotencyKey !== undefined) {
         headers[IDEMPOTENCY_KEY_HEADER] = idempotencyKey;
@@ -440,7 +482,9 @@ export class HttpClient {
         headers[SCA_SESSION_TOKEN_HEADER] = options.scaSessionToken;
       }
 
-      this.logVerbose(`${method} ${url.toString()}${attempt > 0 ? ` (retry ${attempt})` : ""}`);
+      this.logVerbose(
+        `${method} ${url.toString()}${attempt > 0 ? ` (retry ${attempt})` : ""}${usingFallback ? " (fallback)" : ""}`,
+      );
       if (body !== undefined) {
         this.logDebug(isFormData ? "Request body: [FormData]" : `Request body: ${body as string}`);
       }
@@ -472,7 +516,11 @@ export class HttpClient {
         throw this.build428Error(errorBody);
       }
 
-      if ((response.status === 401 || response.status === 403) && this.fallbackAuthorization !== undefined) {
+      if (
+        (response.status === 401 || response.status === 403) &&
+        this.fallbackAuthorization !== undefined &&
+        !usingFallback
+      ) {
         const primaryErrorBody = await this.safeReadJson(response);
         const primaryErrors = this.extractErrors(primaryErrorBody);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,8 @@ export {
 
 export type {
   ApiKeyCredentials,
+  AuthConfig,
+  AuthPreference,
   ConfigErrorCode,
   OAuthCredentials,
   QontoctlConfig,
@@ -51,6 +53,8 @@ export type {
   StaticOAuthFields,
 } from "./config/index.js";
 
+export { AUTH_PREFERENCES, DEFAULT_AUTH_PREFERENCE } from "./config/index.js";
+
 export {
   AuthError,
   buildApiKeyAuthorization,
@@ -61,9 +65,13 @@ export {
   exchangeCode,
   refreshAccessToken,
   revokeToken,
+  OAuthRefreshError,
+  isAuthPreference,
+  resolveAuthPreference,
+  selectAuthChain,
 } from "./auth/index.js";
 
-export type { CreateOAuthAuthorizationOptions, OAuthTokens } from "./auth/index.js";
+export type { AuthChainSelection, AuthSlot, CreateOAuthAuthorizationOptions, OAuthTokens } from "./auth/index.js";
 
 export {
   API_BASE_URL,

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -8,7 +8,7 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -50,6 +50,8 @@ interface BulkTransferRecord {
 }
 
 describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("bulk-transfer list", () => {
     it("lists bulk transfers with default output", () => {
       const output = cli("bulk-transfer", "list", "--no-paginate");

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -41,6 +41,8 @@ interface BulkTransferListResponse {
 }
 
 describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
   let stderrBuffer: string;

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { CardSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli, cliJson } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface CardItem {
   readonly id: string;
@@ -16,6 +16,8 @@ interface CardItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("card list", () => {
     it("lists cards with default output", () => {
       const output = cli("card", "list");

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { CardListResponseSchema, CardSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface CardItem {
   readonly id: string;
@@ -24,6 +24,8 @@ interface CardListResponse {
 }
 
 describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
@@ -6,7 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { PaymentLinkListResponseSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 /**
  * Best-effort detection of "feature unavailable" errors surfaced by MCP
@@ -26,6 +26,8 @@ function isFeatureUnavailable(result: { isError?: boolean | undefined; content: 
 }
 
 describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/commands/payment-link.e2e.test.ts
+++ b/packages/e2e/src/commands/payment-link.e2e.test.ts
@@ -4,9 +4,11 @@
 import { PaymentLinkSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cliJson, SKIP, skipIfNotFound } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("payment-link list", () => {
     it("lists payment links", () => {
       // `payment-link` requires the Qonto Payment Links subscription to be

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -18,6 +18,8 @@ function cli(args: string[]): string {
 }
 
 describe.skipIf(!hasOAuthCredentials())("e-invoicing CLI (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   it("einvoicing settings displays settings in table format", () => {
     const output = cli(["einvoicing", "settings"]);
     expect(output).toContain("sending_status");

--- a/packages/e2e/src/einvoicing/mcp.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/mcp.e2e.test.ts
@@ -6,11 +6,13 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 describe.skipIf(!hasOAuthCredentials())("e-invoicing MCP (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -4,9 +4,11 @@
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("insurance CRUD lifecycle", () => {
     let createdId: string | undefined;
 

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -6,9 +6,11 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { InsuranceContractSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -30,6 +30,8 @@ interface IntlCurrencyItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("international CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("intl eligibility", () => {
     it("returns eligibility status with default output", () => {
       const output = cli("intl", "eligibility");

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,6 +19,8 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
 }
 
 describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { IntlBeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -39,6 +39,8 @@ interface IntlBeneficiaryItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("intl beneficiary list", () => {
     it("lists international beneficiaries with default output", () => {
       const result = cliMaybe("intl", "beneficiary", "list", "--currency", "USD");

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,6 +19,8 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
 }
 
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -23,6 +23,8 @@ function cliJson<T>(...args: string[]): T {
 }
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("intl-transfer requirements", () => {
     it("returns requirements for a beneficiary", () => {
       // First list intl beneficiaries to get an ID

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -19,6 +19,8 @@ function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
 }
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/quotes/cli.e2e.test.ts
+++ b/packages/e2e/src/quotes/cli.e2e.test.ts
@@ -4,9 +4,11 @@
 import { QuoteSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("quote commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("quote list", () => {
     it("lists quotes", () => {
       const output = cli("quote", "list");

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -6,9 +6,11 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { QuoteListResponseSchema, QuoteSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -129,6 +129,8 @@ interface RecurringTransferItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("recurring-transfer list", () => {
     it("lists recurring transfers with default output", () => {
       const output = cli("recurring-transfer", "list", "--no-paginate");

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -41,6 +41,8 @@ interface RecurringTransferListResponse {
 }
 
 describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
   let stderrBuffer: string;

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse as parseYaml } from "yaml";
+import { afterAll, beforeAll } from "vitest";
+import type { AuthPreference } from "@qontoctl/core";
 
 const REPO_ROOT_CONFIG_PATH = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", ".qontoctl.yaml");
 
@@ -183,20 +185,86 @@ export function getCredentials(): ConfigCredentials {
 /**
  * Build an environment for spawning CLI child processes.
  *
- * Injects `QONTOCTL_CONFIG_FILE=<repo-root>/.qontoctl.yaml` so the CLI
- * loads the repo's config file without relying on CWD inspection (which
- * the resolver no longer performs, post #479). Existing env values for
- * the variable are preserved — tests that explicitly set
- * `QONTOCTL_CONFIG_FILE` keep their override.
+ * Injects:
+ *
+ * 1. `QONTOCTL_CONFIG_FILE=<repo-root>/.qontoctl.yaml` so the CLI loads the
+ *    repo's config file without relying on CWD inspection (which the resolver
+ *    no longer performs, post #479).
+ * 2. `QONTOCTL_AUTH` — defaults to **`"api-key"`** so api-key-only
+ *    suites stay deterministic between local (where OAuth is also configured)
+ *    and CI (which has only api-key creds). Without this pin, a local run with
+ *    OAuth in `.qontoctl.yaml` would default to `oauth-first` and exercise a
+ *    different code path than CI's api-key-only run — the exact determinism
+ *    gap that bit during #463 (see #523 for context).
+ *
+ *    OAuth-required suites (those gated on `hasOAuthCredentials()`) MUST opt
+ *    out via `cliEnv({ authPreference: "oauth-first" })` so their endpoints
+ *    actually authenticate against OAuth. The default is api-key because
+ *    most suites are api-key-compatible; only the OAuth-required minority
+ *    explicitly overrides.
+ *
+ * Existing env values for these variables are preserved — tests that
+ * explicitly set `QONTOCTL_CONFIG_FILE` or `QONTOCTL_AUTH` (e.g. via
+ * the spawning shell) keep their override.
  *
  * Existing api-key / oauth env vars (`QONTOCTL_ORGANIZATION_SLUG`, etc.)
  * also continue to take precedence over file values via the env-overlay,
  * so suites that rely on env-only credentials are unaffected.
+ *
+ * @param options.authPreference Override the default `api-key` pin. Pass
+ *   `"oauth-first"` (or another valid `AuthPreference`) for OAuth-required
+ *   suites; pass `undefined` (or omit `options`) to accept the api-key default.
  */
-export function cliEnv(): Record<string, string> {
+export function cliEnv(options: { authPreference?: AuthPreference } = {}): Record<string, string> {
   const env = { ...(process.env as Record<string, string>) };
   if (env["QONTOCTL_CONFIG_FILE"] === undefined || env["QONTOCTL_CONFIG_FILE"] === "") {
     env["QONTOCTL_CONFIG_FILE"] = cliConfigPath();
   }
+  if (env["QONTOCTL_AUTH"] === undefined || env["QONTOCTL_AUTH"] === "") {
+    env["QONTOCTL_AUTH"] = options.authPreference ?? "api-key";
+  }
   return env;
+}
+
+/**
+ * Register `beforeAll`/`afterAll` hooks that pin `QONTOCTL_AUTH` for the
+ * enclosing describe block by mutating `process.env`.
+ *
+ * Why this exists: {@link cliEnv} pins api-key by default for CI determinism
+ * (per #523). OAuth-required suites — those gated on `hasOAuthCredentials()`
+ * — must opt out so their endpoints (cards, quotes, intl-transfers, …)
+ * actually authenticate against OAuth. Mutating `process.env` propagates
+ * through both the direct `cliEnv()` callers (which read it via
+ * `{ ...process.env }`) AND the `cli` / `cliRaw` / `cliJson` helpers in
+ * `helpers.ts` (which call `cliEnv()` internally) — so a single hook
+ * registration covers every CLI spawn in the describe block, regardless of
+ * which helper the test uses.
+ *
+ * Sequential execution (`pnpm test:e2e --concurrency=1`) ensures the
+ * `process.env` mutation does not leak between describe blocks.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { pinAuthPreference } from "../sandbox.js";
+ *
+ * describe.skipIf(!hasOAuthCredentials())("OAuth-required suite", () => {
+ *   pinAuthPreference("oauth-first");
+ *   // ...
+ * });
+ * ```
+ */
+export function pinAuthPreference(pref: AuthPreference): void {
+  let previous: string | undefined;
+  beforeAll(() => {
+    previous = process.env["QONTOCTL_AUTH"];
+    process.env["QONTOCTL_AUTH"] = pref;
+  });
+  afterAll(() => {
+    if (previous === undefined) {
+      delete process.env["QONTOCTL_AUTH"];
+    } else {
+      process.env["QONTOCTL_AUTH"] = previous;
+    }
+  });
 }

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -7,7 +7,7 @@ import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
@@ -55,6 +55,8 @@ function cliJson<T>(...args: string[]): T {
 }
 
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation CLI (e2e, sandbox)", () => {
+  pinAuthPreference("oauth-first");
+
   let beneficiaryId: string;
   let bankAccountId: string;
   let vopProofToken: string;

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -8,7 +8,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, hasStagingToken } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
@@ -60,6 +60,8 @@ function firstText(content: unknown): string {
 }
 
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation MCP (e2e, sandbox)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
   let stderrBuffer: string;

--- a/packages/e2e/src/teams/cli.e2e.test.ts
+++ b/packages/e2e/src/teams/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { TeamSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli, cliJson } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface TeamItem {
   readonly id: string;
@@ -12,6 +12,8 @@ interface TeamItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("team CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("team list", () => {
     it("lists teams with default output", () => {
       const output = cli("team", "list");

--- a/packages/e2e/src/teams/mcp.e2e.test.ts
+++ b/packages/e2e/src/teams/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { TeamListResponseSchema, TeamSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface TeamItem {
   readonly id: string;
@@ -23,6 +23,8 @@ interface TeamListResponse {
 }
 
 describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { WebhookSubscriptionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli, cliJson } from "../helpers.js";
-import { hasOAuthCredentials } from "../sandbox.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface WebhookItem {
   readonly id: string;
@@ -13,6 +13,8 @@ interface WebhookItem {
 }
 
 describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   describe("webhook list", () => {
     it("lists webhooks with default output", () => {
       const output = cli("webhook", "list");

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface WebhookItem {
   readonly id: string;
@@ -24,6 +24,8 @@ interface WebhookListResponse {
 }
 
 describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
+  pinAuthPreference("oauth-first");
+
   let client: Client;
   let transport: StdioClientTransport;
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,9 +8,12 @@ import {
   createOAuthAuthorization,
   resolveConfig,
   resolveScaMethod,
+  resolveAuthPreference,
+  selectAuthChain,
   OAUTH_TOKEN_URL,
   OAUTH_TOKEN_SANDBOX_URL,
   type Authorization,
+  type AuthSlot,
 } from "@qontoctl/core";
 import { buildMcpResolveOptions } from "./config.js";
 import { runStdioServer } from "./stdio.js";
@@ -26,26 +29,52 @@ await runStdioServer({
   getClient: async () => {
     const { config, endpoint, path, oauthAccessTokenFromEnv } = await resolveConfig(mcpResolveOptions);
 
-    let authorization: Authorization;
-    let fallbackAuthorization: Authorization | undefined;
+    // No CLI flag in MCP — auth preference comes from env > config > default.
+    // resolveAuthPreference handles the env-overlaid config field.
+    const preference = resolveAuthPreference(config);
+    const selection = selectAuthChain(preference, {
+      apiKey: config.apiKey !== undefined,
+      oauth: config.oauth !== undefined,
+    });
 
-    if (config.oauth !== undefined && config.oauth.clientId !== "") {
-      authorization = createOAuthAuthorization({
+    if (selection.noCredentials) {
+      throw new Error("No credentials found in configuration");
+    }
+
+    if (selection.warning !== undefined) {
+      process.stderr.write(`Warning: ${selection.warning}\n`);
+    }
+
+    const oauthFactory = (): Authorization => {
+      if (config.oauth === undefined) {
+        throw new Error("Internal error: OAuth slot selected but no OAuth credentials available");
+      }
+      return createOAuthAuthorization({
         oauth: config.oauth,
         tokenUrl: config.oauth.stagingToken !== undefined ? OAUTH_TOKEN_SANDBOX_URL : OAUTH_TOKEN_URL,
         ...(path !== undefined ? { path } : {}),
         readOnly: oauthAccessTokenFromEnv,
       });
+    };
 
-      // When OAuth is primary, fall back to API key if available
-      if (config.apiKey !== undefined) {
-        fallbackAuthorization = buildApiKeyAuthorization(config.apiKey);
+    const apiKeyFactory = (): Authorization => {
+      if (config.apiKey === undefined) {
+        throw new Error("Internal error: api-key slot selected but no api-key credentials available");
       }
-    } else if (config.apiKey !== undefined) {
-      authorization = buildApiKeyAuthorization(config.apiKey);
-    } else {
-      throw new Error("No credentials found in configuration");
+      return buildApiKeyAuthorization(config.apiKey);
+    };
+
+    const buildSlot = (slot: AuthSlot): Authorization | undefined => {
+      if (slot === "oauth") return oauthFactory();
+      if (slot === "api-key") return apiKeyFactory();
+      return undefined;
+    };
+
+    const authorization = buildSlot(selection.primary);
+    if (authorization === undefined) {
+      throw new Error("Internal error: auth chain has no primary credential");
     }
+    const fallbackAuthorization = buildSlot(selection.fallback);
 
     // SCA method is resolved from env/config only — never as a tool input —
     // so an LLM client cannot pick the SCA method, only an operator can.
@@ -55,8 +84,9 @@ await runStdioServer({
       baseUrl: endpoint,
       authorization,
       fallbackAuthorization,
-      onFallback: (method, path) => {
-        process.stderr.write(`Warning: OAuth authentication failed, falling back to API key for ${method} ${path}\n`);
+      onFallback: (method, p) => {
+        const label = selection.fallback === "oauth" ? "OAuth" : "api-key";
+        process.stderr.write(`Warning: primary authentication failed, falling back to ${label} for ${method} ${p}\n`);
       },
       stagingToken: config.oauth?.stagingToken,
       ...(scaMethod !== undefined ? { scaMethod } : {}),


### PR DESCRIPTION
## Summary

Implements [#523](https://github.com/alexey-pelykh/qontoctl/issues/523):

- **Explicit 4-mode auth preference** (`api-key` / `api-key-first` / `oauth` / `oauth-first`) replaces presence-based OAuth/api-key selection. Configurable via `auth.preference` config field, `QONTOCTL_AUTH` env var, or `--auth <mode>` CLI flag (Commander `.choices(...)` validation). Default `oauth-first` preserves existing behavior when both creds are present.
- **Typed `OAuthRefreshError`** (extends `AuthError`) — `refreshAccessToken` now throws this on `invalid_grant` etc., and `HttpClient.fetchWithRetry` catches it to advance to `fallbackAuthorization` instead of failing the entire request. Closes the all-or-nothing failure mode that broke #463-style runs when an OAuth refresh token expired.
- **E2E sandbox CI determinism**: `cliEnv()` defaults `QONTOCTL_AUTH` to `api-key`; OAuth-required suites opt in via the new `pinAuthPreference("oauth-first")` hook helper.
- **Docs**: `docs/configuration.md` § Authentication precedence; `CLAUDE.md` link.

## Test plan

- [x] Unit: `pnpm test` — 1769 passed (cli 739 + core 1030)
- [x] Lint: `pnpm lint` — clean
- [x] Build: `pnpm build` — clean
- [x] E2E: `pnpm test:e2e` — 8 pre-existing failures (cards/clients/profile/sca-continuation, all in sandbox state — verified identical on `origin/main` baseline, none caused by this PR)
- [x] Adversarial validation (fresh subprocess): 15/15 AC verified
- [x] Polish (fresh subprocess): CLEAN, 6 fixes (comment accuracy, doc references, test fixture strength)

🤖 Generated with [Claude Code](https://claude.com/claude-code)