### PR TITLE
(test) E2E: apply shared helpers to remaining 12 domains (#515)

### DIFF
--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFile, execFileSync, spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { promisify } from "node:util";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
+import { CLI_PATH, cli, cliJson } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
 
 /**
@@ -20,19 +20,6 @@ const execFileAsync = promisify(execFile);
  * (`/v2/mocked_sca_sessions/{token}`) — the core picks per `client.isSandbox`.
  */
 const SCA_POLL_URL_RE = /\/v2\/(?:sca\/sessions|mocked_sca_sessions)\/([A-Za-z0-9_-]+)(?=\s|$|\/)/;
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
 
 // Local response-shape interface. Named distinctly from the core export
 // `BulkTransferRecord`, which describes a single transfer item within a bulk

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import type { Readable } from "node:stream";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 /**
  * Pattern matching the SCA session polling URL the core HTTP client logs at
@@ -105,16 +103,14 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
         name: "beneficiary_list",
         arguments: { per_page: 1 },
       });
-      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
-      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+      const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
       if (beneficiaryParsed.beneficiaries.length === 0) return;
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
-      const accountText = accountResult.content[0] as { type: string; text: string };
-      const accountParsed = JSON.parse(accountText.text) as { id: string }[];
+      const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
       if (accountParsed.length === 0) return;
       const bankAccountId = (accountParsed[0] as { id: string }).id;
 
@@ -142,12 +138,11 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
 
       expect(result.isError).not.toBe(true);
 
-      const textContent = result.content[0] as { type: string; text: string };
-      expect(textContent.type).toBe("text");
+      const text = firstTextFromMcpResult(result);
       // Must be a successful bulk transfer (JSON), NOT an SCA-pending text response.
-      expect(textContent.text).not.toMatch(/^SCA required/);
+      expect(text).not.toMatch(/^SCA required/);
 
-      const bt = JSON.parse(textContent.text) as BulkTransferRecord;
+      const bt = JSON.parse(text) as BulkTransferRecord;
       BulkTransferSchema.parse(bt);
       expect(bt).toHaveProperty("id");
       expect(bt).toHaveProperty("total_count");
@@ -163,16 +158,8 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
       });
 
       expect(result.isError).not.toBe(true);
-      expect(result.content).toBeDefined();
-      expect(Array.isArray(result.content)).toBe(true);
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const parsed = JSON.parse(textContent.text) as BulkTransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as BulkTransferListResponse;
       BulkTransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("bulk_transfers");
       expect(parsed).toHaveProperty("meta");
@@ -187,11 +174,7 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
 
       expect(result.isError).not.toBe(true);
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as BulkTransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as BulkTransferListResponse;
       expect(parsed.bulk_transfers.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
@@ -205,11 +188,7 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
       });
       if (listResult.isError === true) return;
 
-      const listText = listResult.content[0] as {
-        type: string;
-        text: string;
-      };
-      const listParsed = JSON.parse(listText.text) as BulkTransferListResponse;
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as BulkTransferListResponse;
       const first = listParsed.bulk_transfers[0];
       if (first === undefined) return;
 
@@ -218,14 +197,7 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
         arguments: { id: first.id },
       });
 
-      expect(result.content).toBeDefined();
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const bt = JSON.parse(textContent.text) as BulkTransferRecord;
+      const bt = JSON.parse(firstTextFromMcpResult(result)) as BulkTransferRecord;
       BulkTransferSchema.parse(bt);
       expect(bt.id).toBe(first.id);
       expect(bt).toHaveProperty("total_count");

--- a/packages/e2e/src/einvoicing/cli.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/cli.e2e.test.ts
@@ -1,33 +1,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
+import { cli } from "../helpers.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("e-invoicing CLI (e2e)", () => {
   pinAuthPreference("oauth-first");
 
   it("einvoicing settings displays settings in table format", () => {
-    const output = cli(["einvoicing", "settings"]);
+    const output = cli("einvoicing", "settings");
     expect(output).toContain("sending_status");
     expect(output).toContain("receiving_status");
   });
 
   it("einvoicing settings --output json produces valid JSON with expected fields", () => {
-    const output = cli(["einvoicing", "settings", "--output", "json"]);
+    const output = cli("einvoicing", "settings", "--output", "json");
     const settings = JSON.parse(output) as Record<string, unknown>;
     EInvoicingSettingsSchema.parse(settings);
     expect(settings).toHaveProperty("sending_status");

--- a/packages/e2e/src/einvoicing/mcp.e2e.test.ts
+++ b/packages/e2e/src/einvoicing/mcp.e2e.test.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { EInvoicingSettingsSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 describe.skipIf(!hasOAuthCredentials())("e-invoicing MCP (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -38,13 +36,8 @@ describe.skipIf(!hasOAuthCredentials())("e-invoicing MCP (e2e)", () => {
       arguments: {},
     });
     expect(result.isError).not.toBe(true);
-    expect(result.content).toBeDefined();
 
-    const content = result.content as { type: string; text: string }[];
-    expect(content).toHaveLength(1);
-    expect((content[0] as { type: string }).type).toBe("text");
-
-    const settings = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    const settings = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
     EInvoicingSettingsSchema.parse(settings);
     expect(settings).toHaveProperty("sending_status");
     expect(settings).toHaveProperty("receiving_status");

--- a/packages/e2e/src/international/cli.e2e.test.ts
+++ b/packages/e2e/src/international/cli.e2e.test.ts
@@ -1,27 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
-import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
+import { IntlCurrencySchema, IntlEligibilitySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-    timeout: 30_000,
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
+import { cli, cliJson } from "../helpers.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface IntlCurrencyItem {
   readonly country_code: string;

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { IntlEligibilitySchema, IntlCurrencySchema } from "@qontoctl/core";
+import { IntlCurrencySchema, IntlEligibilitySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = result.content as { type: string; text: string }[];
-  expect(content).toHaveLength(1);
-  const entry = content[0] as { type: string; text: string };
-  expect(entry.type).toBe("text");
-  return entry.text;
-}
 
 describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -49,7 +39,7 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
 
       if (result.isError === true) return;
 
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       IntlEligibilitySchema.parse(parsed);
       expect(parsed).toHaveProperty("status");
     });
@@ -64,7 +54,7 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
 
       if (result.isError === true) return;
 
-      const parsed = JSON.parse(firstText(result)) as unknown[];
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
       const first = parsed[0];
       if (first !== undefined) {
@@ -80,7 +70,7 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
 
       if (result.isError === true) return;
 
-      const parsed = JSON.parse(firstText(result)) as { currency_code: string; country_code: string }[];
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as { currency_code: string; country_code: string }[];
       expect(Array.isArray(parsed)).toBe(true);
       for (const c of parsed) {
         const match = c.currency_code.toLowerCase().includes("eur") || c.country_code.toLowerCase().includes("eur");

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -1,35 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { IntlBeneficiarySchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-/**
- * The Qonto sandbox gates `/v2/international/beneficiaries` on the org's
- * eligibility status: an `STATUS_INELIGIBLE` org returns HTTP 403 with a
- * `forbidden: failed to list beneficiaries: forbidden` body. That surfaces
- * to the CLI as a non-zero exit. We swallow such failures here so the suite
- * remains useful both on eligibility-cleared and ineligible sandbox accounts;
- * the tests still assert response shape when the call succeeds.
- */
-function cliMaybe(...args: string[]): { stdout: string; ok: boolean } {
-  try {
-    const stdout = execFileSync("node", [CLI_PATH, ...args], {
-      encoding: "utf-8",
-      env: cliEnv(),
-      timeout: 30_000,
-      stdio: ["pipe", "pipe", "ignore"],
-    });
-    return { stdout, ok: true };
-  } catch {
-    return { stdout: "", ok: false };
-  }
-}
+import { cliRaw } from "../helpers.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface IntlBeneficiaryItem {
   readonly id: string;
@@ -38,19 +13,27 @@ interface IntlBeneficiaryItem {
   readonly country: string;
 }
 
+/**
+ * The Qonto sandbox gates `/v2/international/beneficiaries` on the org's
+ * eligibility status: an `STATUS_INELIGIBLE` org returns HTTP 403 with a
+ * `forbidden: failed to list beneficiaries: forbidden` body. That surfaces
+ * to the CLI as a non-zero exit. We use `cliRaw` here so the suite
+ * remains useful both on eligibility-cleared and ineligible sandbox accounts;
+ * the tests still assert response shape when the call succeeds.
+ */
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
 
   describe("intl beneficiary list", () => {
     it("lists international beneficiaries with default output", () => {
-      const result = cliMaybe("intl", "beneficiary", "list", "--currency", "USD");
+      const result = cliRaw(["intl", "beneficiary", "list", "--currency", "USD"]);
       if (result.ok) {
         expect(result.stdout).toBeDefined();
       }
     });
 
     it("produces valid JSON with --output json", () => {
-      const result = cliMaybe("intl", "beneficiary", "list", "--currency", "USD", "--output", "json");
+      const result = cliRaw(["intl", "beneficiary", "list", "--currency", "USD", "--output", "json"]);
       if (!result.ok) return;
       const parsed = JSON.parse(result.stdout) as IntlBeneficiaryItem[];
       expect(Array.isArray(parsed)).toBe(true);
@@ -63,7 +46,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", (
     });
 
     it("supports pagination", () => {
-      const result = cliMaybe(
+      const result = cliRaw([
         "intl",
         "beneficiary",
         "list",
@@ -75,7 +58,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", (
         "1",
         "--output",
         "json",
-      );
+      ]);
       if (!result.ok) return;
       const parsed = JSON.parse(result.stdout) as IntlBeneficiaryItem[];
       expect(Array.isArray(parsed)).toBe(true);
@@ -83,7 +66,17 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", (
     });
 
     it("outputs CSV format", () => {
-      const result = cliMaybe("intl", "beneficiary", "list", "--currency", "USD", "--output", "csv", "--per-page", "5");
+      const result = cliRaw([
+        "intl",
+        "beneficiary",
+        "list",
+        "--currency",
+        "USD",
+        "--output",
+        "csv",
+        "--per-page",
+        "5",
+      ]);
       if (!result.ok) return;
       const lines = result.stdout.trim().split("\n");
       expect(lines.length).toBeGreaterThanOrEqual(1);

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -66,17 +66,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", (
     });
 
     it("outputs CSV format", () => {
-      const result = cliRaw([
-        "intl",
-        "beneficiary",
-        "list",
-        "--currency",
-        "USD",
-        "--output",
-        "csv",
-        "--per-page",
-        "5",
-      ]);
+      const result = cliRaw(["intl", "beneficiary", "list", "--currency", "USD", "--output", "csv", "--per-page", "5"]);
       if (!result.ok) return;
       const lines = result.stdout.trim().split("\n");
       expect(lines.length).toBeGreaterThanOrEqual(1);

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = result.content as { type: string; text: string }[];
-  expect(content).toHaveLength(1);
-  const entry = content[0] as { type: string; text: string };
-  expect(entry.type).toBe("text");
-  return entry.text;
-}
 
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -49,7 +39,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
 
       if (result.isError === true) return;
 
-      const parsed = JSON.parse(firstText(result)) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         international_beneficiaries: unknown[];
         meta: Record<string, unknown>;
       };
@@ -67,7 +57,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
 
       if (result.isError === true) return;
 
-      const parsed = JSON.parse(firstText(result)) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         international_beneficiaries: unknown[];
         meta: { current_page: number };
       };
@@ -84,7 +74,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
       });
       if (listResult.isError === true) return;
 
-      const listParsed = JSON.parse(firstText(listResult)) as {
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         international_beneficiaries: { id: string }[];
       };
       if (listParsed.international_beneficiaries.length === 0) return;
@@ -97,7 +87,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
       });
 
       expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("requirements");
     });
   });

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -1,26 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-    timeout: 30_000,
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
+import { cli, cliJson } from "../helpers.js";
+import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = result.content as { type: string; text: string }[];
-  expect(content).toHaveLength(1);
-  const entry = content[0] as { type: string; text: string };
-  expect(entry.type).toBe("text");
-  return entry.text;
-}
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -49,7 +39,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
       });
       if (listResult.isError === true) return;
 
-      const listParsed = JSON.parse(firstText(listResult)) as {
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         international_beneficiaries: { id: string }[];
       };
       if (listParsed.international_beneficiaries.length === 0) return;
@@ -62,7 +52,7 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
       });
 
       expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       IntlTransferRequirementsResponseSchema.parse(parsed);
     });
   });

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -3,13 +3,12 @@
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 const EXPECTED_TOOLS = [
   "org_show",

--- a/packages/e2e/src/org-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/cli.e2e.test.ts
@@ -1,31 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { SKIP, skipIfQontoErrorContains } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
+import { cli, SKIP, skipIfQontoErrorContains } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
 
 describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", () => {
   let knownAccountId: string;
 
   beforeAll(() => {
     // Discover an account ID from the sandbox for use in `account show`
-    const json = cli(["account", "list", "--output", "json"]);
+    const json = cli("account", "list", "--output", "json");
     const accounts = JSON.parse(json) as { id: string }[];
     expect(accounts.length).toBeGreaterThan(0);
     knownAccountId = (accounts[0] as { id: string }).id;
@@ -34,14 +23,14 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   // ── org show ────────────────────────────────────────────────────
 
   it("org show displays organization details in table format", () => {
-    const output = cli(["org", "show"]);
+    const output = cli("org", "show");
     expect(output).toContain("slug");
     expect(output).toContain("legal_name");
     expect(output).toContain("bank_accounts");
   });
 
   it("org show --output json produces valid JSON with expected fields", () => {
-    const output = cli(["org", "show", "--output", "json"]);
+    const output = cli("org", "show", "--output", "json");
     const org = JSON.parse(output) as Record<string, unknown>;
     OrganizationSchema.parse(org);
     expect(org).toHaveProperty("slug");
@@ -55,7 +44,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   // ── account list ───────────────────────────────────────────────
 
   it("account list displays accounts in table format", () => {
-    const output = cli(["account", "list"]);
+    const output = cli("account", "list");
     expect(output).toContain("id");
     expect(output).toContain("name");
     expect(output).toContain("iban");
@@ -64,7 +53,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   });
 
   it("account list --output json produces valid JSON array", () => {
-    const output = cli(["account", "list", "--output", "json"]);
+    const output = cli("account", "list", "--output", "json");
     const accounts = JSON.parse(output) as Record<string, unknown>[];
     expect(Array.isArray(accounts)).toBe(true);
     expect(accounts.length).toBeGreaterThan(0);
@@ -81,7 +70,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   // ── account show ───────────────────────────────────────────────
 
   it("account show displays account details in table format", () => {
-    const output = cli(["account", "show", knownAccountId]);
+    const output = cli("account", "show", knownAccountId);
     expect(output).toContain(knownAccountId);
     expect(output).toContain("iban");
     expect(output).toContain("balance");
@@ -89,7 +78,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts CLI (e2e)", ()
   });
 
   it("account show --output json produces valid JSON object", () => {
-    const output = cli(["account", "show", knownAccountId, "--output", "json"]);
+    const output = cli("account", "show", knownAccountId, "--output", "json");
     const account = JSON.parse(output) as Record<string, unknown>;
     BankAccountSchema.parse(account);
     expect(account).toHaveProperty("id", knownAccountId);

--- a/packages/e2e/src/org-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/org-accounts/mcp.e2e.test.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BankAccountSchema, OrganizationSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", () => {
   let client: Client;
@@ -40,11 +38,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
     expect(result.isError).not.toBe(true);
     expect(result.content).toBeDefined();
 
-    const content = result.content as { type: string; text: string }[];
-    expect(content).toHaveLength(1);
-    expect((content[0] as { type: string }).type).toBe("text");
-
-    const org = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    const org = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
     OrganizationSchema.parse(org);
     expect(org).toHaveProperty("slug");
     expect(org).toHaveProperty("legal_name");
@@ -63,11 +57,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
     });
     expect(result.isError).not.toBe(true);
 
-    const content = result.content as { type: string; text: string }[];
-    expect(content).toHaveLength(1);
-    expect((content[0] as { type: string }).type).toBe("text");
-
-    const accounts = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>[];
+    const accounts = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>[];
     expect(Array.isArray(accounts)).toBe(true);
     expect(accounts.length).toBeGreaterThan(0);
 
@@ -88,11 +78,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
       name: "account_list",
       arguments: {},
     });
-    const listContent = listResult.content as {
-      type: string;
-      text: string;
-    }[];
-    const accounts = JSON.parse((listContent[0] as { text: string }).text) as { id: string }[];
+    const accounts = JSON.parse(firstTextFromMcpResult(listResult)) as { id: string }[];
     const accountId = (accounts[0] as { id: string }).id;
 
     const result = await client.callTool({
@@ -101,11 +87,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
     });
     expect(result.isError).not.toBe(true);
 
-    const content = result.content as { type: string; text: string }[];
-    expect(content).toHaveLength(1);
-    expect((content[0] as { type: string }).type).toBe("text");
-
-    const account = JSON.parse((content[0] as { text: string }).text) as Record<string, unknown>;
+    const account = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
     BankAccountSchema.parse(account);
     expect(account).toHaveProperty("id", accountId);
     expect(account).toHaveProperty("name");
@@ -125,11 +107,7 @@ describe.skipIf(!hasApiKeyCredentials())("organization & accounts MCP (e2e)", ()
       name: "account_list",
       arguments: {},
     });
-    const listContent = listResult.content as {
-      type: string;
-      text: string;
-    }[];
-    const accounts = JSON.parse((listContent[0] as { text: string }).text) as { id: string }[];
+    const accounts = JSON.parse(firstTextFromMcpResult(listResult)) as { id: string }[];
     const accountId = (accounts[0] as { id: string }).id;
 
     const result = await client.callTool({

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFile, execFileSync, spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
+import { CLI_PATH, cli, cliJson } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
 
 /**
@@ -18,19 +17,6 @@ const execFileAsync = promisify(execFile);
  * (`/v2/mocked_sca_sessions/{token}`) — the core picks per `client.isSandbox`.
  */
 const SCA_POLL_URL_RE = /\/v2\/(?:sca\/sessions|mocked_sca_sessions)\/([A-Za-z0-9_-]+)(?=\s|$|\/)/;
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
 
 interface SpawnWithScaResult {
   readonly exitCode: number;

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import type { Readable } from "node:stream";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 /**
  * Pattern matching the SCA session polling URL the core HTTP client logs at
@@ -107,16 +105,14 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         name: "beneficiary_list",
         arguments: { per_page: 1 },
       });
-      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
-      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+      const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
       if (beneficiaryParsed.beneficiaries.length === 0) return;
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
-      const accountText = accountResult.content[0] as { type: string; text: string };
-      const accountParsed = JSON.parse(accountText.text) as { id: string }[];
+      const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
       if (accountParsed.length === 0) return;
       const accountId = (accountParsed[0] as { id: string }).id;
 
@@ -151,12 +147,11 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
 
       expect(result.isError).not.toBe(true);
 
-      const textContent = result.content[0] as { type: string; text: string };
-      expect(textContent.type).toBe("text");
+      const text = firstTextFromMcpResult(result);
       // Must be a successful recurring transfer (JSON), NOT an SCA-pending text response.
-      expect(textContent.text).not.toMatch(/^SCA required/);
+      expect(text).not.toMatch(/^SCA required/);
 
-      const rt = JSON.parse(textContent.text) as RecurringTransferItem;
+      const rt = JSON.parse(text) as RecurringTransferItem;
       RecurringTransferSchema.parse(rt);
       expect(rt).toHaveProperty("id");
       expect(rt.frequency).toBe("monthly");
@@ -179,16 +174,14 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         name: "beneficiary_list",
         arguments: { per_page: 1 },
       });
-      const beneficiaryText = beneficiaryResult.content[0] as { type: string; text: string };
-      const beneficiaryParsed = JSON.parse(beneficiaryText.text) as {
+      const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
       if (beneficiaryParsed.beneficiaries.length === 0) return;
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
-      const accountText = accountResult.content[0] as { type: string; text: string };
-      const accountParsed = JSON.parse(accountText.text) as { id: string }[];
+      const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
       if (accountParsed.length === 0) return;
       const accountId = (accountParsed[0] as { id: string }).id;
 
@@ -219,9 +212,9 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       const [createResult] = await Promise.all([createCallPromise, createApprovalPromise]);
 
       expect(createResult.isError).not.toBe(true);
-      const createText = createResult.content[0] as { type: string; text: string };
-      expect(createText.text).not.toMatch(/^SCA required/);
-      const created = JSON.parse(createText.text) as RecurringTransferItem;
+      const createText = firstTextFromMcpResult(createResult);
+      expect(createText).not.toMatch(/^SCA required/);
+      const created = JSON.parse(createText) as RecurringTransferItem;
       expect(created).toHaveProperty("id");
 
       // --- Step 2: cancel (no inline SCA orchestration available). ---
@@ -231,9 +224,9 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       });
 
       expect(cancelResult.isError).not.toBe(true);
-      const cancelText = cancelResult.content[0] as { type: string; text: string };
-      expect(cancelText.text).not.toMatch(/^SCA required/);
-      const canceled = JSON.parse(cancelText.text) as { canceled: boolean; id: string };
+      const cancelText = firstTextFromMcpResult(cancelResult);
+      expect(cancelText).not.toMatch(/^SCA required/);
+      const canceled = JSON.parse(cancelText) as { canceled: boolean; id: string };
       expect(canceled.canceled).toBe(true);
       expect(canceled.id).toBe(created.id);
     });
@@ -246,16 +239,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         arguments: {},
       });
 
-      expect(result.content).toBeDefined();
-      expect(Array.isArray(result.content)).toBe(true);
-
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const parsed = JSON.parse(textContent.text) as RecurringTransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as RecurringTransferListResponse;
       RecurringTransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("recurring_transfers");
       expect(parsed).toHaveProperty("meta");
@@ -268,11 +252,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         arguments: { per_page: 2, page: 1 },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as RecurringTransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as RecurringTransferListResponse;
       expect(parsed.recurring_transfers.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
@@ -284,11 +264,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         name: "recurring_transfer_list",
         arguments: { per_page: 1 },
       });
-      const listText = listResult.content[0] as {
-        type: string;
-        text: string;
-      };
-      const listParsed = JSON.parse(listText.text) as RecurringTransferListResponse;
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as RecurringTransferListResponse;
       const first = listParsed.recurring_transfers[0];
       if (first === undefined) return;
 
@@ -297,14 +273,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
         arguments: { id: first.id },
       });
 
-      expect(result.content).toBeDefined();
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const rt = JSON.parse(textContent.text) as RecurringTransferItem;
+      const rt = JSON.parse(firstTextFromMcpResult(result)) as RecurringTransferItem;
       RecurringTransferSchema.parse(rt);
       expect(rt.id).toBe(first.id);
       expect(rt).toHaveProperty("amount");

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFile, execFileSync, spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { resolve } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, cliJson } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 const execFileAsync = promisify(execFile);
 
 /**
@@ -36,22 +35,6 @@ interface BankAccountItem {
 
 interface VopProofToken {
   readonly proof_token: { readonly token: string };
-}
-
-/**
- * Run the CLI synchronously for setup and approval helpers.
- */
-function cliSync(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-    timeout: 25_000,
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  return JSON.parse(cliSync("--output", "json", ...args)) as T;
 }
 
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation CLI (e2e, sandbox)", () => {

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -2,15 +2,13 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { randomUUID } from "node:crypto";
-import { resolve } from "node:path";
 import type { Readable } from "node:stream";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 /**
  * Pattern matching the SCA session polling URL the core HTTP client logs at
@@ -43,20 +41,6 @@ interface BankAccountItem {
 
 interface VopProofToken {
   readonly proof_token: { readonly token: string };
-}
-
-interface ToolTextContent {
-  readonly type: string;
-  readonly text: string;
-}
-
-function firstText(content: unknown): string {
-  const arr = content as ToolTextContent[] | undefined;
-  const first = arr?.[0];
-  if (first === undefined) {
-    throw new Error("Tool returned no content");
-  }
-  return first.text;
 }
 
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation MCP (e2e, sandbox)", () => {
@@ -98,7 +82,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       name: "beneficiary_list",
       arguments: {},
     });
-    const beneficiaryList = JSON.parse(firstText(beneficiaryListResult.content)) as {
+    const beneficiaryList = JSON.parse(firstTextFromMcpResult(beneficiaryListResult)) as {
       beneficiaries: BeneficiaryItem[];
     };
     // PSD2 Article 13(b): transfers to "trusted" beneficiaries are exempt from
@@ -130,7 +114,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       name: "account_list",
       arguments: {},
     });
-    const accounts = JSON.parse(firstText(accountListResult.content)) as BankAccountItem[];
+    const accounts = JSON.parse(firstTextFromMcpResult(accountListResult)) as BankAccountItem[];
     const firstAccount = accounts[0];
     if (firstAccount === undefined) {
       throw new Error("E2E setup: no bank accounts available in sandbox");
@@ -141,7 +125,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       name: "transfer_verify_payee",
       arguments: { iban: beneficiaryIban, name: beneficiaryName },
     });
-    const vop = JSON.parse(firstText(vopResult.content)) as VopProofToken;
+    const vop = JSON.parse(firstTextFromMcpResult(vopResult)) as VopProofToken;
     vopProofToken = vop.proof_token.token;
   });
 
@@ -210,7 +194,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     const [callResult] = await Promise.all([callPromise, approvalPromise]);
 
     expect(callResult.isError).not.toBe(true);
-    const text = firstText(callResult.content);
+    const text = firstTextFromMcpResult(callResult);
     // Must be a successful transfer (JSON), NOT an SCA-pending text response.
     expect(text).not.toMatch(/^SCA required/);
     const transfer = JSON.parse(text) as Record<string, unknown>;
@@ -226,7 +210,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     // First call: poll for 5s with no decision → SCA-pending response.
     const pendingResult = await client.callTool({ name: "transfer_create", arguments: args });
     expect(pendingResult.isError).not.toBe(true);
-    const pendingText = firstText(pendingResult.content);
+    const pendingText = firstTextFromMcpResult(pendingResult);
     expect(pendingText).toMatch(/^SCA required/);
     expect(pendingText).toContain("sca_session_show");
     expect(pendingText).toContain("sca_session_token");
@@ -249,7 +233,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       arguments: { ...args, sca_session_token: token },
     });
     expect(retryResult.isError).not.toBe(true);
-    const retryText = firstText(retryResult.content);
+    const retryText = firstTextFromMcpResult(retryResult);
     expect(retryText).not.toMatch(/^SCA required/);
     const transfer = JSON.parse(retryText) as Record<string, unknown>;
     TransferSchema.parse(transfer);
@@ -269,7 +253,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     expect(pendingResult.isError).not.toBe(true);
     expect(elapsedMs).toBeLessThan(2_000);
 
-    const pendingText = firstText(pendingResult.content);
+    const pendingText = firstTextFromMcpResult(pendingResult);
     expect(pendingText).toMatch(/^SCA required/);
     expect(pendingText).toContain("sca_session_show");
     expect(pendingText).toContain("sca_session_token");
@@ -290,7 +274,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       arguments: { ...args, sca_session_token: token },
     });
     expect(retryResult.isError).not.toBe(true);
-    const retryText = firstText(retryResult.content);
+    const retryText = firstTextFromMcpResult(retryResult);
     expect(retryText).not.toMatch(/^SCA required/);
     const transfer = JSON.parse(retryText) as Record<string, unknown>;
     TransferSchema.parse(transfer);

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -4,19 +4,13 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, cli, cliJson } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
 function listStatements(): Record<string, unknown>[] {
-  const output = execFileSync("node", [CLI_PATH, "statement", "list", "--no-paginate", "-o", "json"], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-  return JSON.parse(output) as Record<string, unknown>[];
+  return cliJson<Record<string, unknown>[]>("statement", "list", "--no-paginate");
 }
 
 describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
@@ -45,12 +39,13 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
 
       const bankAccountId = (allRows[0] as Record<string, unknown>)["bank_account_id"] as string;
 
-      const filteredOutput = execFileSync(
-        "node",
-        [CLI_PATH, "statement", "list", "--bank-account", bankAccountId, "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv(), stdio: "pipe" },
+      const filteredRows = cliJson<Record<string, unknown>[]>(
+        "statement",
+        "list",
+        "--bank-account",
+        bankAccountId,
+        "--no-paginate",
       );
-      const filteredRows = JSON.parse(filteredOutput) as Record<string, unknown>[];
 
       for (const row of filteredRows) {
         expect(row["bank_account_id"]).toBe(bankAccountId);
@@ -58,14 +53,8 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
     });
 
     it("filters by period range", () => {
-      const output = execFileSync(
-        "node",
-        [CLI_PATH, "statement", "list", "--from", "01-2025", "--to", "12-2025", "--no-paginate", "-o", "json"],
-        { encoding: "utf-8", env: cliEnv(), stdio: "pipe" },
-      );
-
       // The command should succeed; results may be empty if no statements in range
-      const rows = JSON.parse(output) as unknown[];
+      const rows = cliJson<unknown[]>("statement", "list", "--from", "01-2025", "--to", "12-2025", "--no-paginate");
       expect(Array.isArray(rows)).toBe(true);
     });
   });
@@ -79,12 +68,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
 
       const statementId = (allRows[0] as Record<string, unknown>)["id"] as string;
 
-      const showOutput = execFileSync("node", [CLI_PATH, "statement", "show", statementId, "-o", "json"], {
-        encoding: "utf-8",
-        env: cliEnv(),
-        stdio: "pipe",
-      });
-      const showRows = JSON.parse(showOutput) as Record<string, unknown>[];
+      const showRows = cliJson<Record<string, unknown>[]>("statement", "show", statementId);
       expect(showRows).toHaveLength(1);
 
       const row = showRows[0] as Record<string, unknown>;
@@ -119,6 +103,10 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const expectedFileName = firstRow["file_name"] as string;
 
       const downloadDir = mkdtempSync(join(tempDir, "cwd-"));
+      // Inline execFileSync here because the test exercises the CLI's
+      // current-working-directory behavior (downloads to cwd when no
+      // --output-dir is given). The shared `cli()` helper does not expose
+      // a `cwd` option, and adding one is out of scope for this refactor.
       execFileSync("node", [CLI_PATH, "statement", "download", statementId], {
         encoding: "utf-8",
         env: cliEnv(),
@@ -139,11 +127,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       const expectedFileName = firstRow["file_name"] as string;
 
       const outputDir = mkdtempSync(join(tempDir, "outdir-"));
-      execFileSync("node", [CLI_PATH, "statement", "download", statementId, "--output-dir", outputDir], {
-        encoding: "utf-8",
-        env: cliEnv(),
-        stdio: "pipe",
-      });
+      cli("statement", "download", statementId, "--output-dir", outputDir);
 
       const downloadedFile = join(outputDir, expectedFileName);
       expect(existsSync(downloadedFile)).toBe(true);

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StatementListResponseSchema, StatementSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
   let client: Client;
@@ -37,12 +35,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
       // Sandbox may not have statements — skip gracefully on tool error
       if (result.isError === true) return;
 
-      expect(result.content).toHaveLength(1);
-
-      const textContent = result.content[0] as { type: string; text: string };
-      expect(textContent.type).toBe("text");
-
-      const parsed = JSON.parse(textContent.text) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         statements: Record<string, unknown>[];
         meta: Record<string, unknown>;
       };
@@ -69,8 +62,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
 
       expect(result.isError).not.toBe(true);
 
-      const textContent = result.content[0] as { type: string; text: string };
-      const parsed = JSON.parse(textContent.text) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         statements: unknown[];
         meta: unknown;
       };
@@ -87,8 +79,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
       });
       if (listResult.isError === true) return;
 
-      const listText = (listResult.content[0] as { type: string; text: string }).text;
-      const listParsed = JSON.parse(listText) as {
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         statements: Record<string, unknown>[];
       };
       if (listParsed.statements.length === 0) return;
@@ -103,8 +94,7 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
 
       expect(showResult.isError).not.toBe(true);
 
-      const showText = (showResult.content[0] as { type: string; text: string }).text;
-      const showParsed = JSON.parse(showText) as Record<string, unknown>;
+      const showParsed = JSON.parse(firstTextFromMcpResult(showResult)) as Record<string, unknown>;
       StatementSchema.parse(showParsed);
       expect(showParsed["id"]).toBe(statementId);
       expect(showParsed).toHaveProperty("bank_account_id");

--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -1,22 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { SupplierInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-    timeout: 15_000,
-  });
-}
+import { cli } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
 
 describe.skipIf(!hasApiKeyCredentials())("supplier-invoice commands (e2e)", () => {
   describe("supplier-invoice list", () => {

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SupplierInvoiceListResponseSchema, SupplierInvoiceSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function firstText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = result.content as { type: string; text: string }[];
-  expect(content).toHaveLength(1);
-  const entry = content[0] as { type: string; text: string };
-  expect(entry.type).toBe("text");
-  return entry.text;
-}
 
 describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () => {
   let client: Client;
@@ -45,7 +35,7 @@ describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () 
         arguments: {},
       });
 
-      const parsed = JSON.parse(firstText(result)) as {
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         supplier_invoices: unknown[];
         meta: Record<string, unknown>;
       };
@@ -68,7 +58,7 @@ describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () 
         name: "supplier_invoice_list",
         arguments: {},
       });
-      const listParsed = JSON.parse(firstText(listResult)) as {
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         supplier_invoices: { id: string }[];
       };
       if (listParsed.supplier_invoices.length === 0) {
@@ -84,7 +74,7 @@ describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () 
         arguments: { id: invoiceId },
       });
 
-      const parsed = JSON.parse(firstText(result)) as Record<string, unknown>;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       SupplierInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -1,26 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { TransactionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
+import { cli, cliJson } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
 
 interface TransactionItem {
   readonly id: string;

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransactionListResponseSchema, TransactionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 interface TransactionItem {
   readonly id: string;
@@ -61,16 +59,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: {},
       });
 
-      expect(result.content).toBeDefined();
-      expect(Array.isArray(result.content)).toBe(true);
-
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       TransactionListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("transactions");
       expect(parsed).toHaveProperty("meta");
@@ -83,11 +72,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: { per_page: 2, page: 1 },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       expect(parsed.transactions.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
@@ -98,11 +83,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: { status: "completed" },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       for (const txn of parsed.transactions) {
         expect(txn.status).toBe("completed");
       }
@@ -114,11 +95,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: { side: "debit" },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       for (const txn of parsed.transactions) {
         expect(txn.side).toBe("debit");
       }
@@ -133,11 +110,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       expect(parsed).toHaveProperty("transactions");
       expect(Array.isArray(parsed.transactions)).toBe(true);
     });
@@ -148,11 +121,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         name: "transaction_list",
         arguments: { per_page: 1 },
       });
-      const listText = listResult.content[0] as {
-        type: string;
-        text: string;
-      };
-      const listParsed = JSON.parse(listText.text) as TransactionListResponse;
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransactionListResponse;
       const firstTxn = listParsed.transactions[0];
       if (firstTxn === undefined) return;
 
@@ -162,11 +131,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: { bank_account_id: bankAccountId },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransactionListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransactionListResponse;
       for (const txn of parsed.transactions) {
         expect(txn.bank_account_id).toBe(bankAccountId);
       }
@@ -180,11 +145,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         name: "transaction_list",
         arguments: { per_page: 1 },
       });
-      const listText = listResult.content[0] as {
-        type: string;
-        text: string;
-      };
-      const listParsed = JSON.parse(listText.text) as TransactionListResponse;
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransactionListResponse;
       const firstTxn = listParsed.transactions[0];
       if (firstTxn === undefined) return;
 
@@ -194,14 +155,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
         arguments: { id: txnId },
       });
 
-      expect(result.content).toBeDefined();
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const transaction = JSON.parse(textContent.text) as TransactionItem;
+      const transaction = JSON.parse(firstTextFromMcpResult(result)) as TransactionItem;
       TransactionSchema.parse(transaction);
       expect(transaction.id).toBe(txnId);
       expect(transaction).toHaveProperty("amount");

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -1,26 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFileSync } from "node:child_process";
-import { resolve } from "node:path";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
-
-function cli(...args: string[]): string {
-  return execFileSync("node", [CLI_PATH, ...args], {
-    encoding: "utf-8",
-    env: cliEnv(),
-    stdio: "pipe",
-  });
-}
-
-function cliJson<T>(...args: string[]): T {
-  const output = cli(...args, "--output", "json");
-  return JSON.parse(output) as T;
-}
+import { cli, cliJson } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
 
 interface TransferItem {
   readonly id: string;

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
-
-const CLI_PATH = resolve(import.meta.dirname, "../../../qontoctl/dist/cli.js");
 
 interface TransferItem {
   readonly id: string;
@@ -60,16 +58,7 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
         arguments: {},
       });
 
-      expect(result.content).toBeDefined();
-      expect(Array.isArray(result.content)).toBe(true);
-
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const parsed = JSON.parse(textContent.text) as TransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransferListResponse;
       TransferListResponseSchema.parse(parsed);
       expect(parsed).toHaveProperty("transfers");
       expect(parsed).toHaveProperty("meta");
@@ -82,11 +71,7 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
         arguments: { per_page: 2, page: 1 },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransferListResponse;
       expect(parsed.transfers.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
@@ -97,11 +82,7 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
         arguments: { status: "settled" },
       });
 
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      const parsed = JSON.parse(textContent.text) as TransferListResponse;
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as TransferListResponse;
       for (const t of parsed.transfers) {
         expect(t.status).toBe("settled");
       }
@@ -114,11 +95,7 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
         name: "transfer_list",
         arguments: { per_page: 1 },
       });
-      const listText = listResult.content[0] as {
-        type: string;
-        text: string;
-      };
-      const listParsed = JSON.parse(listText.text) as TransferListResponse;
+      const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransferListResponse;
       const firstTransfer = listParsed.transfers[0];
       if (firstTransfer === undefined) return;
 
@@ -128,14 +105,7 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
         arguments: { id: transferId },
       });
 
-      expect(result.content).toBeDefined();
-      const textContent = result.content[0] as {
-        type: string;
-        text: string;
-      };
-      expect(textContent.type).toBe("text");
-
-      const transfer = JSON.parse(textContent.text) as TransferItem;
+      const transfer = JSON.parse(firstTextFromMcpResult(result)) as TransferItem;
       TransferSchema.parse(transfer);
       expect(transfer.id).toBe(transferId);
       expect(transfer).toHaveProperty("amount");


### PR DESCRIPTION
## Description

Completes the helpers.ts refactor started in #490 / #522. All 12 deferred domains now import `cli`, `cliJson`, `cliRaw`, `CLI_PATH`, and `firstTextFromMcpResult` from `packages/e2e/src/helpers.ts` instead of redeclaring them.

**Domains refactored** (CLI + MCP each, except where noted):

- bulk-transfers
- einvoicing
- international
- intl-beneficiaries
- intl-transfers
- org-accounts
- recurring-transfers
- sca-continuation
- statements
- supplier-invoices
- transactions
- transfers

Also cleans up `packages/e2e/src/mcp/server.e2e.test.ts` which was still inlining `CLI_PATH`.

**Net diff**: -398 lines (556 deletions, 158 insertions) across 25 files.

### Two intentional inline retentions

- `statements/cli.e2e.test.ts` `"downloads a statement PDF to the current directory"` keeps an inline `execFileSync` because that test exercises the CLI's `cwd` behavior and the shared `cli()` helper does not expose a `cwd` option. Adding one is out of scope for this refactor.
- `intl-beneficiaries/cli.e2e.test.ts` previously had a custom `cliMaybe(...)` returning `{ stdout, ok }`. Replaced with the canonical `cliRaw(args)` from helpers (returns `CliResult` discriminated union — same skip-on-failure semantics).

## Related Issue

Closes #515.

## Testing

- `pnpm build` — green (turbo cache hit + cold build of `@qontoctl/e2e`)
- `pnpm lint` — green (FULL TURBO)
- `pnpm test` — green (739/739 unit tests pass)
- `pnpm test:e2e` — same 8 failures as `origin/main` (verified via stash + re-run); all are environmental: insufficient sandbox funds for SCA write tests (`sca-continuation/*`), pre-existing profile/auth issue, cards CSV/YAML and clients `client_show` data state — none touch this PR's scope.

## CLA Acknowledgment

- [x] I agree to the [Contributor License Agreement](https://github.com/alexey-pelykh/qontoctl/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)

🤖 Generated with [Claude Code](https://claude.com/claude-code)