### PR TITLE
(test) recurring-transfer: cover real 204 cancel + remaining VoP warning branches (#501)

### DIFF
--- a/packages/cli/src/commands/recurring-transfer/create.test.ts
+++ b/packages/cli/src/commands/recurring-transfer/create.test.ts
@@ -401,4 +401,87 @@ describe("recurring-transfer create command", () => {
     );
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("no match"));
   });
+
+  it("auto-resolves vop_proof_token on not_possible result with warning", async () => {
+    getBeneficiaryMock.mockResolvedValue(sampleBeneficiary);
+    verifyPayeeMock.mockResolvedValue({
+      match_result: "MATCH_RESULT_NOT_POSSIBLE",
+      matched_name: null,
+      proof_token: { token: "tok_auto_not_possible" },
+    });
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "100",
+        "--reference",
+        "Test",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "monthly",
+      ],
+      { from: "user" },
+    );
+
+    expect(createRecurringTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_auto_not_possible" }),
+      expect.anything(),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("not possible"));
+  });
+
+  it("auto-resolves vop_proof_token on close_match result with warning including matched name", async () => {
+    getBeneficiaryMock.mockResolvedValue(sampleBeneficiary);
+    verifyPayeeMock.mockResolvedValue({
+      match_result: "MATCH_RESULT_CLOSE_MATCH",
+      matched_name: "Acme Corporation",
+      proof_token: { token: "tok_auto_close_match" },
+    });
+    createRecurringTransferMock.mockResolvedValue(sampleRecurringTransfer);
+
+    const program = new Command();
+    program.option("-o, --output <format>", "", "table");
+    registerRecurringTransferCommands(program);
+
+    await program.parseAsync(
+      [
+        "recurring-transfer",
+        "create",
+        "--beneficiary",
+        "ben-1",
+        "--debit-account",
+        "acc-1",
+        "--amount",
+        "100",
+        "--reference",
+        "Test",
+        "--start-date",
+        "2026-04-01",
+        "--schedule",
+        "monthly",
+      ],
+      { from: "user" },
+    );
+
+    expect(createRecurringTransferMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ vop_proof_token: "tok_auto_close_match" }),
+      expect.anything(),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("close match"));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("matched name: Acme Corporation"));
+  });
 });

--- a/packages/core/src/recurring-transfers/service.test.ts
+++ b/packages/core/src/recurring-transfers/service.test.ts
@@ -186,6 +186,21 @@ describe("cancelRecurringTransfer", () => {
     const [url] = fetchSpy.mock.calls[0] as [URL];
     expect(url.pathname).toBe("/v2/sepa/recurring_transfers/a%2Fb/cancel");
   });
+
+  // Regression lock for #498: the cancel endpoint returns a true 204 No Content.
+  // The other tests in this block use jsonResponse({}) which would have ALSO
+  // passed under the old buggy client.post path (response.json() succeeds on
+  // "{}"). Only an empty-body 204 exercises the regression path that requires
+  // requestVoid (which never reads the body).
+  it("succeeds on a real 204 No Content response", async () => {
+    fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+    await expect(cancelRecurringTransfer(client, "rt-1")).resolves.toBeUndefined();
+
+    const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/sepa/recurring_transfers/rt-1/cancel");
+    expect(init.method).toBe("POST");
+  });
 });
 
 describe("getRecurringTransfer", () => {


### PR DESCRIPTION
## Summary

Closes #501. Two non-blocking test-coverage gaps surfaced by post-submit review of #498.

- **`packages/core/src/recurring-transfers/service.test.ts`** — `cancelRecurringTransfer` now has a test that mocks a true `204 No Content` response (`new Response(null, { status: 204 })`), so the regression fix to use `requestVoid` is actually exercised. The previous `jsonResponse({})` mock would have ALSO passed under the old buggy `client.post` path because `response.json()` succeeds on `"{}"`. Only an empty-body 204 locks in the regression path.

- **`packages/cli/src/commands/recurring-transfer/create.test.ts`** — added unit tests for the `MATCH_RESULT_NOT_POSSIBLE` and `MATCH_RESULT_CLOSE_MATCH` warning branches (only `NO_MATCH` was previously tested). The `CLOSE_MATCH` test additionally asserts the `(matched name: ...)` suffix produced when `matched_name` is non-null. Mirrors the existing MCP coverage at `packages/mcp/src/tools/recurring-transfer.test.ts` which already exercised all three branches.

## Acceptance criteria from #501

- [x] Unit test for `cancelRecurringTransfer` mocks a true 204 No Content response (no JSON body)
- [x] Unit tests for `recurring-transfer create` CLI cover `MATCH_RESULT_NOT_POSSIBLE` and `MATCH_RESULT_CLOSE_MATCH` warning branches
- [x] All existing tests still pass (core 910, cli 741)

## Test plan

- [x] `pnpm format:check` — clean on changed files
- [x] `pnpm build` — 5/5 packages
- [x] `pnpm typecheck` — 8/8 packages
- [x] `pnpm lint` — 8/8 packages
- [x] `pnpm license-check` — 100 prod deps
- [x] `pnpm publish-check` — 4 packages verified
- [x] `pnpm test` — full suite green; `recurring-transfers/service.test.ts` 11 → 12, `recurring-transfer/create.test.ts` 8 → 10
- [ ] CI gate: pending (this PR)

## Scope

Test-only change. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)