### PR TITLE
(refactor) wrap MCP transfer_cancel + recurring_transfer_cancel in executeWithMcpSca (#500)

### DIFF
--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -160,14 +160,11 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
   });
 
   // Cancel exercises both create (write) and cancel (write). Create requires
-  // SCA approval against the sandbox; cancel goes through the MCP tool which
-  // does not currently orchestrate SCA polling (no `executeWithMcpSca`
-  // wrapper, no `wait`/`sca_session_token` schema fields), so a second SCA
-  // mock-decision flow cannot be hooked from the test side without modifying
-  // the MCP tool. If the API requires SCA on cancel, `withClient` formats the
-  // 428 as a structured "SCA required" pending response — the assertion
-  // `cancelText.text !~ /^SCA required/` surfaces that as a separate bug
-  // rather than masking it as a timeout.
+  // SCA approval against the sandbox; cancel now also orchestrates inline SCA
+  // polling via the same `executeWithMcpSca` wrapper (#500), so the test runs
+  // a second mock-decision flow tolerantly: if the sandbox cancel actually
+  // triggers SCA, we approve it; if it doesn't, the token-capture times out
+  // harmlessly while the cancel call resolves successfully on the happy path.
   describe.skipIf(!hasStagingToken())("recurring_transfer_cancel (sandbox SCA)", () => {
     it("creates a recurring transfer with SCA approval and then cancels it", async () => {
       const beneficiaryResult = await client.callTool({
@@ -217,11 +214,37 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       const created = JSON.parse(createText) as RecurringTransferItem;
       expect(created).toHaveProperty("id");
 
-      // --- Step 2: cancel (no inline SCA orchestration available). ---
-      const cancelResult = await client.callTool({
+      // --- Step 2: cancel with inline SCA orchestration (#500). ---
+      // Tolerant approval: cancel may or may not require SCA against the
+      // sandbox. If it does, the token appears in stderr and we approve it;
+      // if it doesn't, the timeout is swallowed and the cancel call resolves
+      // on the happy path. Either way, the assertion below requires success.
+      const cancelCallPromise = client.callTool({
         name: "recurring_transfer_cancel",
-        arguments: { id: created.id },
+        arguments: { id: created.id, wait: 10 },
       });
+      const cancelApprovalPromise = (async () => {
+        // Narrow the swallow to the stderr-capture timeout (happy path: no SCA
+        // challenge was raised). Errors from `sca_session_mock_decision` —
+        // e.g. genuine MCP/HTTP failures — are NOT caught and will fail the
+        // test. Matching by error-message prefix keeps the catch tied to the
+        // specific shape produced by `captureScaTokenFromStderr`.
+        let token: string;
+        try {
+          token = await captureScaTokenFromStderr(8_000);
+        } catch (error) {
+          if (error instanceof Error && error.message.startsWith("Timed out")) {
+            return;
+          }
+          throw error;
+        }
+        await new Promise((r) => setTimeout(r, 2_000));
+        await client.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token, decision: "allow" },
+        });
+      })();
+      const [cancelResult] = await Promise.all([cancelCallPromise, cancelApprovalPromise]);
 
       expect(cancelResult.isError).not.toBe(true);
       const cancelText = firstTextFromMcpResult(cancelResult);

--- a/packages/mcp/src/tools/recurring-transfer.test.ts
+++ b/packages/mcp/src/tools/recurring-transfer.test.ts
@@ -378,6 +378,150 @@ describe("recurring-transfer MCP tools", () => {
       expect(content).toHaveLength(1);
       expect((content[0] as { type: string; text: string }).text).toContain("rt-1");
     });
+
+    describe("SCA continuation", () => {
+      const SCA_TOKEN = "sca-tok-mcp-recurring-transfer-cancel";
+
+      it("returns structured pending response on 428 with wait=0 (pure two-step)", async () => {
+        let postCount = 0;
+        let scaPollCount = 0;
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/recurring_transfers/rt-1/cancel" && init.method === "POST") {
+            postCount++;
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            scaPollCount++;
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "recurring_transfer_cancel",
+          arguments: { id: "rt-1", wait: 0 },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain("SCA required");
+        expect(text).toContain(SCA_TOKEN);
+        expect(text).toContain("sca_session_show");
+        expect(text).toContain("sca_session_token");
+        // The dead-end formatter is NOT used.
+        expect(text).not.toContain("Poll GET");
+        expect(text).not.toContain("/v2/sca/sessions/");
+        // Pure two-step: cancel POST hit once, no SCA polling, no retry.
+        expect(postCount).toBe(1);
+        expect(scaPollCount).toBe(0);
+      });
+
+      it("retries the operation with the supplied sca_session_token (no polling)", async () => {
+        let postCount = 0;
+        let scaPollCount = 0;
+        const observedScaTokens: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/recurring_transfers/rt-1/cancel" && init.method === "POST") {
+            const headers = init.headers as Record<string, string> | undefined;
+            observedScaTokens.push(headers?.["X-Qonto-Sca-Session-Token"] ?? null);
+            postCount++;
+            return new Response(null, { status: 204 });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            scaPollCount++;
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "recurring_transfer_cancel",
+          arguments: { id: "rt-1", sca_session_token: SCA_TOKEN },
+        });
+
+        expect(postCount).toBe(1);
+        // Caller supplied the SCA token directly: no polling round-trip.
+        expect(scaPollCount).toBe(0);
+        expect(observedScaTokens[0]).toBe(SCA_TOKEN);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { canceled: boolean; id: string };
+        expect(parsed.canceled).toBe(true);
+        expect(parsed.id).toBe("rt-1");
+      });
+
+      it("preserves a stable idempotency key across the initial 428 + post-poll retry", async () => {
+        let postCount = 0;
+        const observedIdempotencyKeys: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          const headers = init.headers as Record<string, string> | undefined;
+
+          if (input.pathname === "/v2/sepa/recurring_transfers/rt-1/cancel" && init.method === "POST") {
+            postCount++;
+            observedIdempotencyKeys.push(headers?.["X-Qonto-Idempotency-Key"] ?? null);
+            if (postCount === 1) {
+              // First attempt: 428 SCA required. Real Qonto API returns top-level fields,
+              // not an `errors[]` array — see docs/security/sca-token-binding.md.
+              return new Response(
+                JSON.stringify({
+                  action_type: "transfer.recurring.cancel",
+                  code: "sca_required",
+                  message: "SCA required",
+                  sca_session_token: SCA_TOKEN,
+                }),
+                {
+                  status: 428,
+                  headers: { "content-type": "application/json", "X-Qonto-Sca-Session-Token": SCA_TOKEN },
+                },
+              );
+            }
+            return new Response(null, { status: 204 });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            return jsonResponse({ sca_session: { status: "allow" } });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "recurring_transfer_cancel",
+          arguments: { id: "rt-1", wait: 5 },
+        });
+
+        expect(postCount).toBe(2);
+        expect(observedIdempotencyKeys[0]).toBeTruthy();
+        expect(observedIdempotencyKeys[0]).toBe(observedIdempotencyKeys[1]);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { canceled: boolean; id: string };
+        expect(parsed.canceled).toBe(true);
+        expect(parsed.id).toBe("rt-1");
+      });
+
+      it("accepts wait=false in the input schema (pure two-step)", async () => {
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/recurring_transfers/rt-1/cancel" && init.method === "POST") {
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "recurring_transfer_cancel",
+          arguments: { id: "rt-1", wait: false },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain(SCA_TOKEN);
+      });
+    });
   });
 
   describe("recurring_transfer_show", () => {

--- a/packages/mcp/src/tools/recurring-transfer.ts
+++ b/packages/mcp/src/tools/recurring-transfer.ts
@@ -142,18 +142,24 @@ export function registerRecurringTransferTools(server: McpServer, getClient: () 
   server.registerTool(
     "recurring_transfer_cancel",
     {
-      description: "Cancel a recurring transfer",
+      description:
+        "Cancel a recurring transfer. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Recurring transfer UUID"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        await cancelRecurringTransfer(client, id);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ canceled: true, id }, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) => cancelRecurringTransfer(client, args.id, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ canceled: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(

--- a/packages/mcp/src/tools/transfer.test.ts
+++ b/packages/mcp/src/tools/transfer.test.ts
@@ -750,6 +750,150 @@ describe("transfer MCP tools", () => {
       expect(url.pathname).toBe("/v2/sepa/transfers/txfr-cancel-1/cancel");
       expect(init.method).toBe("POST");
     });
+
+    describe("SCA continuation", () => {
+      const SCA_TOKEN = "sca-tok-mcp-transfer-cancel";
+
+      it("returns structured pending response on 428 with wait=0 (pure two-step)", async () => {
+        let postCount = 0;
+        let scaPollCount = 0;
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers/txfr-cancel-1/cancel" && init.method === "POST") {
+            postCount++;
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            scaPollCount++;
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_cancel",
+          arguments: { id: "txfr-cancel-1", wait: 0 },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain("SCA required");
+        expect(text).toContain(SCA_TOKEN);
+        expect(text).toContain("sca_session_show");
+        expect(text).toContain("sca_session_token");
+        // The dead-end formatter is NOT used.
+        expect(text).not.toContain("Poll GET");
+        expect(text).not.toContain("/v2/sca/sessions/");
+        // Pure two-step: cancel POST hit once, no SCA polling, no retry.
+        expect(postCount).toBe(1);
+        expect(scaPollCount).toBe(0);
+      });
+
+      it("retries the operation with the supplied sca_session_token (no polling)", async () => {
+        let postCount = 0;
+        let scaPollCount = 0;
+        const observedScaTokens: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers/txfr-cancel-1/cancel" && init.method === "POST") {
+            const headers = init.headers as Record<string, string> | undefined;
+            observedScaTokens.push(headers?.["X-Qonto-Sca-Session-Token"] ?? null);
+            postCount++;
+            return new Response(null, { status: 204 });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            scaPollCount++;
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_cancel",
+          arguments: { id: "txfr-cancel-1", sca_session_token: SCA_TOKEN },
+        });
+
+        expect(postCount).toBe(1);
+        // Caller supplied the SCA token directly: no polling round-trip.
+        expect(scaPollCount).toBe(0);
+        expect(observedScaTokens[0]).toBe(SCA_TOKEN);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { canceled: boolean; id: string };
+        expect(parsed.canceled).toBe(true);
+        expect(parsed.id).toBe("txfr-cancel-1");
+      });
+
+      it("preserves a stable idempotency key across the initial 428 + post-poll retry", async () => {
+        let postCount = 0;
+        const observedIdempotencyKeys: (string | null)[] = [];
+
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          const headers = init.headers as Record<string, string> | undefined;
+
+          if (input.pathname === "/v2/sepa/transfers/txfr-cancel-1/cancel" && init.method === "POST") {
+            postCount++;
+            observedIdempotencyKeys.push(headers?.["X-Qonto-Idempotency-Key"] ?? null);
+            if (postCount === 1) {
+              // First attempt: 428 SCA required. Real Qonto API returns top-level fields,
+              // not an `errors[]` array — see docs/security/sca-token-binding.md.
+              return new Response(
+                JSON.stringify({
+                  action_type: "transfer.single.cancel",
+                  code: "sca_required",
+                  message: "SCA required",
+                  sca_session_token: SCA_TOKEN,
+                }),
+                {
+                  status: 428,
+                  headers: { "content-type": "application/json", "X-Qonto-Sca-Session-Token": SCA_TOKEN },
+                },
+              );
+            }
+            return new Response(null, { status: 204 });
+          }
+          if (input.pathname.startsWith("/v2/sca/sessions/")) {
+            return jsonResponse({ sca_session: { status: "allow" } });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_cancel",
+          arguments: { id: "txfr-cancel-1", wait: 5 },
+        });
+
+        expect(postCount).toBe(2);
+        expect(observedIdempotencyKeys[0]).toBeTruthy();
+        expect(observedIdempotencyKeys[0]).toBe(observedIdempotencyKeys[1]);
+
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        const parsed = JSON.parse(text) as { canceled: boolean; id: string };
+        expect(parsed.canceled).toBe(true);
+        expect(parsed.id).toBe("txfr-cancel-1");
+      });
+
+      it("accepts wait=false in the input schema (pure two-step)", async () => {
+        fetchSpy.mockImplementation((input: URL, init: RequestInit) => {
+          if (input.pathname === "/v2/sepa/transfers/txfr-cancel-1/cancel" && init.method === "POST") {
+            return new Response(JSON.stringify({ sca_session_token: SCA_TOKEN }), {
+              status: 428,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return jsonResponse({});
+        });
+
+        const result = await mcpClient.callTool({
+          name: "transfer_cancel",
+          arguments: { id: "txfr-cancel-1", wait: false },
+        });
+
+        expect(result.isError).toBe(false);
+        const text = (result.content as { type: string; text: string }[])[0]?.text ?? "";
+        expect(text).toContain(SCA_TOKEN);
+      });
+    });
   });
 
   describe("transfer_proof", () => {

--- a/packages/mcp/src/tools/transfer.ts
+++ b/packages/mcp/src/tools/transfer.ts
@@ -226,19 +226,24 @@ export function registerTransferTools(server: McpServer, getClient: () => Promis
   server.registerTool(
     "transfer_cancel",
     {
-      description: "Cancel a pending SEPA transfer",
+      description:
+        "Cancel a pending SEPA transfer. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Transfer UUID"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        await cancelTransfer(client, id);
-
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ canceled: true, id }, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) => cancelTransfer(client, args.id, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ canceled: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(


### PR DESCRIPTION
## Summary

Wires the MCP `transfer_cancel` and `recurring_transfer_cancel` tools through the same `executeWithMcpSca` SCA-orchestration pattern the corresponding `*_create` tools already use. Closes #500.

Before this PR, these cancel tools could not orchestrate inline SCA polling — they lacked `scaContinuationSchema` (no `wait` / `sca_session_token` input fields) and didn't wrap the call in `executeWithMcpSca`. On a 428, `withClient` returned a structured pending shape but callers had no way to continue inline.

## Changes per file

- **`packages/mcp/src/tools/transfer.ts`** — `transfer_cancel`: spread `...scaContinuationSchema` into `inputSchema`; wrap `cancelTransfer` in `executeWithMcpSca`; forward `coreOptionsFromContext(context)`; updated description with the canonical SCA paragraph
- **`packages/mcp/src/tools/recurring-transfer.ts`** — `recurring_transfer_cancel`: same pattern
- **`packages/mcp/src/tools/transfer.test.ts`** — added 4 SCA continuation unit tests under existing `transfer_cancel` describe (mirrors `transfer_create`'s SCA continuation block)
- **`packages/mcp/src/tools/recurring-transfer.test.ts`** — same 4 tests for `recurring_transfer_cancel`
- **`packages/e2e/src/recurring-transfers/mcp.e2e.test.ts`** — replaced the obsolete bug-documenting cancel test with one that exercises inline SCA via the new schema, using a tolerant `try/catch` approval pattern that handles either branch (sandbox cancel may or may not require SCA in practice)

## Audit scope (AC-1)

Direct `grep -rn '"[a-z_]*_cancel"' packages/mcp/src/tools/` confirmed only **3** `*_cancel` MCP tools exist in total:

| Tool | Status |
|---|---|
| `transfer_cancel` | **Wired in this PR** |
| `recurring_transfer_cancel` | **Wired in this PR** |
| `client_invoice_cancel` | **Deliberately excluded — see follow-up #528** |

The issue body's "likely (audit needed)" tools (`bulk_transfer_cancel`, `internal_transfer_cancel`, `intl_transfer_cancel`, `request_cancel`) **do not exist** as MCP tool registrations.

### Why `client_invoice_cancel` is excluded

- The CLI counterpart (`packages/cli/src/commands/client-invoice.ts:302`) does NOT wrap `cancelClientInvoice` in `executeWithCliSca` — strong empirical signal the team determined the endpoint does not require SCA
- The core service signature `cancelClientInvoice(client, id): Promise<ClientInvoice>` (`packages/core/src/client-invoices/service.ts:160`) has NO `options` parameter at all — no extension point for `idempotencyKey` / `scaSessionToken`
- Endpoint semantics (`POST /v2/client_invoices/{id}/mark_as_canceled`) are invoice state mutation, not money movement — unlike SEPA transfer cancels
- Wiring SCA here would expand scope from 2 tools to 3 + a core API breaking change

Tracked as **#528** which will (a) verify the SCA-not-required assumption against Qonto API docs / sandbox behavior and (b) wire SCA through if the assumption proves wrong.

## Pattern reference

The wrapping mirrors the canonical `transfer_create` example (`packages/mcp/src/tools/transfer.ts:206-223`):

```ts
async (args) =>
  withClient(getClient, async (client) =>
    executeWithMcpSca(
      client,
      (context) => cancelTransfer(client, args.id, coreOptionsFromContext(context)),
      () => ({
        content: [{ type: "text" as const, text: JSON.stringify({ canceled: true, id: args.id }, null, 2) }],
      }),
      scaOptionsFromArgs(args),
    ),
  ),
```

## Test plan

- [x] Unit: `pnpm test` — cli 741 / 741, mcp 365 / 365 (was 357 — +8 new SCA continuation tests across the two cancel tools), core unchanged
- [x] Lint: `pnpm lint` — clean
- [x] License-check: `pnpm license-check` — 100 prod deps, all allowed
- [x] Build: `pnpm build` — 5 / 5 packages
- [x] E2E recurring-transfers: 11 / 11 pass against sandbox (OAuth + staging-token), including the updated cancel test
- [x] E2E full-suite failures (8) verified pre-existing on `main` baseline via stash round-trip — sandbox `insufficient_funds` on transfer_create paths and the long-known flaky profile test; not regressions from this PR
- [ ] CI gate: pending (this PR)

## BREAKING

None. The new `wait` and `sca_session_token` input schema fields are optional. Existing callers (those passing only `id`) continue to work — they enter the default `wait=30s` polling branch, which short-circuits on a non-SCA `204 No Content` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)