### PR TITLE
(test) E2E: extract triggerSca/approveAndRetry helpers for SCA round-trip

### DIFF
--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -1,25 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, cliJson } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
-
-const execFileAsync = promisify(execFile);
-
-/**
- * Pattern matching the SCA session polling URL the core HTTP client logs at
- * verbose level. Tokens are base64url, so they survive `encodeURIComponent`
- * unchanged and contain only `[A-Za-z0-9_-]`. Matches both the production
- * endpoint (`/v2/sca/sessions/{token}`) and the sandbox-only mocked endpoint
- * (`/v2/mocked_sca_sessions/{token}`) — see
- * `packages/core/src/sca/sca-service.ts#getScaSession` for the routing logic.
- */
-const SCA_POLL_URL_RE = /\/v2\/(?:sca\/sessions|mocked_sca_sessions)\/([A-Za-z0-9_-]+)(?=\s|$|\/)/;
+import { cliJson } from "../helpers.js";
+import { hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { approveAndRetryCli, SCA_POLL_URL_RE, triggerScaCli } from "../sca-helpers.js";
 
 interface BeneficiaryItem {
   readonly id: string;
@@ -31,6 +18,8 @@ interface BeneficiaryItem {
 
 interface BankAccountItem {
   readonly id: string;
+  readonly main: boolean;
+  readonly balance_cents: number;
 }
 
 interface VopProofToken {
@@ -69,11 +58,18 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     beneficiaryId = beneficiary.id;
 
     const accounts = cliJson<BankAccountItem[]>("account", "list");
-    const firstAccount = accounts[0];
-    if (firstAccount === undefined) {
+    // Pick the `main: true` account: in shared sandbox orgs the non-main
+    // accounts are typically scratch / depleted and cause `400 insufficient_funds`
+    // on the post-SCA retry — masking actual SCA-flow regressions as
+    // environmental flakes. Fall back to the highest-balance account if no
+    // main is flagged (defensive against sandbox config changes).
+    const account =
+      accounts.find((a) => a.main) ??
+      [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    if (account === undefined) {
       throw new Error("E2E setup: no bank accounts available in sandbox");
     }
-    bankAccountId = firstAccount.id;
+    bankAccountId = account.id;
 
     // Pre-resolve the VoP proof token so the SCA test does not race against
     // a separate VoP API call inside the per-test 30s budget.
@@ -91,98 +87,46 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
   it("transfer create triggers SCA, mock-decision allow, retry succeeds", async () => {
     const reference = `e2e-sca-${randomUUID().slice(0, 12)}`;
 
-    const child = spawn(
-      "node",
-      [
-        CLI_PATH,
-        "--verbose",
-        "--output",
-        "json",
-        "transfer",
-        "create",
-        "--beneficiary",
-        beneficiaryId,
-        "--debit-account",
-        bankAccountId,
-        "--reference",
-        reference,
-        "--amount",
-        "1.50",
-        "--vop-proof-token",
-        vopProofToken,
-      ],
-      {
-        env: cliEnv(),
-        stdio: ["ignore", "pipe", "pipe"],
-      },
-    );
+    // Round-trip primitives under test (#450):
+    //   triggerScaCli — spawns a CLI write op, captures token mid-poll
+    //   approveAndRetryCli — calls `sca-session mock-decision`, awaits exit
+    const trigger = await triggerScaCli([
+      "--output",
+      "json",
+      "transfer",
+      "create",
+      "--beneficiary",
+      beneficiaryId,
+      "--debit-account",
+      bankAccountId,
+      "--reference",
+      reference,
+      "--amount",
+      "1.50",
+      "--vop-proof-token",
+      vopProofToken,
+    ]);
 
-    let stdout = "";
-    let stderr = "";
-    let stderrBuffer = "";
-    let scaToken: string | undefined;
-    let approvePromise: Promise<unknown> | undefined;
+    // AC #4: assert on the actual `sca_session_token` field, not the
+    // `"unknown"` fallback (which #445 made the parser throw on).
+    expect(trigger.scaSessionToken).not.toBe("unknown");
+    expect(trigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
 
-    child.stdout.setEncoding("utf-8");
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk;
-    });
+    const exit = await approveAndRetryCli(trigger, "allow");
 
-    child.stderr.setEncoding("utf-8");
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk;
-      if (scaToken !== undefined) return;
-
-      stderrBuffer += chunk;
-      let nlIdx: number;
-      while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
-        const line = stderrBuffer.slice(0, nlIdx);
-        stderrBuffer = stderrBuffer.slice(nlIdx + 1);
-
-        if (scaToken !== undefined) continue;
-        const match = line.match(SCA_POLL_URL_RE);
-        if (match !== null && match[1] !== undefined) {
-          scaToken = match[1];
-          // Approve asynchronously so we keep draining stderr from the
-          // primary child (filling the OS pipe buffer would deadlock it).
-          approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
-            env: cliEnv(),
-            timeout: 25_000,
-          });
-          // Attach a no-op error handler to avoid an "unhandled rejection"
-          // warning if approve rejects before the test reaches the explicit
-          // `await approvePromise` below (we still surface the failure there).
-          approvePromise.catch(() => {});
-        }
-      }
-    });
-
-    const exitCode = await new Promise<number>((resolveExit, rejectExit) => {
-      child.on("error", rejectExit);
-      child.on("close", (code) => {
-        resolveExit(code ?? 1);
-      });
-    });
-
-    if (exitCode !== 0) {
+    if (exit.exitCode !== 0) {
       throw new Error(
-        `transfer create exited ${String(exitCode)}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`,
+        `transfer create exited ${String(exit.exitCode)}\n--- stderr ---\n${exit.stderr}\n--- stdout ---\n${exit.stdout}`,
       );
-    }
-
-    expect(scaToken, "expected to capture SCA session token from polling URL").toBeDefined();
-    if (approvePromise !== undefined) {
-      // Surface mock-decision failures (e.g., token expired, sandbox missing).
-      await approvePromise;
     }
 
     // Spinner output is non-deterministic across terminals, so assert on the
     // wire-log lines that prove the SCA continuation actually exercised:
     // initial transfer POST + at least one SCA-session poll.
-    expect(stderr).toMatch(/POST .*\/v2\/sepa\/transfers/);
-    expect(stderr).toMatch(SCA_POLL_URL_RE);
+    expect(exit.stderr).toMatch(/POST .*\/v2\/sepa\/transfers/);
+    expect(exit.stderr).toMatch(SCA_POLL_URL_RE);
 
-    const transfer = JSON.parse(stdout) as Record<string, unknown>;
+    const transfer = JSON.parse(exit.stdout) as Record<string, unknown>;
     TransferSchema.parse(transfer);
     expect(transfer).toHaveProperty("id");
     expect(transfer).toHaveProperty("beneficiary_id", beneficiaryId);

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -63,9 +63,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     // on the post-SCA retry — masking actual SCA-flow regressions as
     // environmental flakes. Fall back to the highest-balance account if no
     // main is flagged (defensive against sandbox config changes).
-    const account =
-      accounts.find((a) => a.main) ??
-      [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    const account = accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
     if (account === undefined) {
       throw new Error("E2E setup: no bank accounts available in sandbox");
     }

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -9,23 +9,7 @@ import { TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
-
-/**
- * Pattern matching the SCA session polling URL the core HTTP client logs at
- * verbose level. Tokens are base64url, so they survive `encodeURIComponent`
- * unchanged and contain only `[A-Za-z0-9_-]`. Matches both production
- * (`/v2/sca/sessions/{token}`) and sandbox-only mocked
- * (`/v2/mocked_sca_sessions/{token}`) endpoints — see
- * `packages/core/src/sca/sca-service.ts#getScaSession`.
- */
-const SCA_POLL_URL_RE = /\/v2\/(?:sca\/sessions|mocked_sca_sessions)\/([A-Za-z0-9_-]+)(?=\s|$|\/)/;
-
-/**
- * Pattern matching the literal `Session token: <token>` line in the
- * structured "SCA pending" MCP response from `formatScaPendingResponse`. See
- * `packages/mcp/src/sca.ts#formatScaPendingResponse`.
- */
-const SCA_PENDING_TOKEN_RE = /Session token: ([A-Za-z0-9_-]+)/;
+import { approveAndRetryMcp, SCA_POLL_URL_RE, triggerScaMcp } from "../sca-helpers.js";
 
 interface BeneficiaryItem {
   readonly id: string;
@@ -37,6 +21,8 @@ interface BeneficiaryItem {
 
 interface BankAccountItem {
   readonly id: string;
+  readonly main: boolean;
+  readonly balance_cents: number;
 }
 
 interface VopProofToken {
@@ -59,7 +45,9 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     transport = new StdioClientTransport({
       // `--verbose` enables wire logging so the SCA polling URL (containing
       // the session token in its path) appears on the server's stderr stream.
-      // Test 2 uses this stream to discover the token mid-poll.
+      // The inline-poll test (`wait: 10`) uses this stream to discover the
+      // token mid-poll; the two-step tests use the SCA-pending response
+      // body via `triggerScaMcp` and don't need the stderr signal.
       command: "node",
       args: [CLI_PATH, "--verbose", "mcp"],
       env: cliEnv(),
@@ -115,11 +103,17 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
       arguments: {},
     });
     const accounts = JSON.parse(firstTextFromMcpResult(accountListResult)) as BankAccountItem[];
-    const firstAccount = accounts[0];
-    if (firstAccount === undefined) {
+    // Pick the `main: true` account: in shared sandbox orgs the non-main
+    // accounts are typically scratch / depleted and cause `400 insufficient_funds`
+    // on the post-SCA retry — masking actual SCA-flow regressions as
+    // environmental flakes. Fall back to the highest-balance account if no
+    // main is flagged (defensive against sandbox config changes).
+    const account =
+      accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    if (account === undefined) {
       throw new Error("E2E setup: no bank accounts available in sandbox");
     }
-    bankAccountId = firstAccount.id;
+    bankAccountId = account.id;
 
     const vopResult = await client.callTool({
       name: "transfer_verify_payee",
@@ -138,20 +132,21 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
    * so each test issues its own SCA session, immune to PSD2 dynamic-linking
    * single-use semantics.
    */
-  function createArgs(extra: Record<string, unknown>): Record<string, unknown> {
+  function createArgs(): Record<string, unknown> {
     return {
       beneficiary_id: beneficiaryId,
       bank_account_id: bankAccountId,
       reference: `e2e-sca-${randomUUID().slice(0, 12)}`,
       amount: 1.5,
       vop_proof_token: vopProofToken,
-      ...extra,
     };
   }
 
   /**
    * Wait for the SCA session polling URL to appear in the MCP server's
-   * stderr, then extract and return the SCA session token.
+   * stderr, then extract and return the SCA session token. Used only by
+   * the inline-poll variant (`wait: 10`) — the two-step tests get the
+   * token from the SCA-pending response body via `triggerScaMcp`.
    */
   async function captureScaTokenFromStderr(timeoutMs: number): Promise<string> {
     const deadline = Date.now() + timeoutMs;
@@ -170,9 +165,12 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
   }
 
   it("transfer_create with wait=10 + mock-decision allow at t=2s returns transfer in single call", async () => {
-    const args = createArgs({ wait: 10 });
+    // Inline-poll variant: the server polls inside the call, so the test
+    // must approve concurrently while the call is in flight. This pattern
+    // is structurally distinct from the two-step round-trip exercised
+    // below — it stays expressed at the raw `client.callTool` layer.
+    const args = { ...createArgs(), wait: 10 };
 
-    // Kick off the tool call (blocks until SCA resolves or wait expires).
     const callStartedAt = Date.now();
     const callPromise = client.callTool({ name: "transfer_create", arguments: args });
 
@@ -182,6 +180,10 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     // poll observes "allow" and the wrapper retries the POST.
     const approvalPromise = (async () => {
       const token = await captureScaTokenFromStderr(8_000);
+      // AC #4 traceability: token must be a real base64url, not "unknown".
+      expect(token).not.toBe("unknown");
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
       const elapsedSinceCall = Date.now() - callStartedAt;
       const remainingUntilT2 = Math.max(0, 2_000 - elapsedSinceCall);
       await new Promise((r) => setTimeout(r, remainingUntilT2));
@@ -205,33 +207,22 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
   });
 
   it("transfer_create with wait=5 returns SCA-pending; second call with sca_session_token after mock allow returns transfer", async () => {
-    const args = createArgs({ wait: 5 });
+    // Two-step round-trip via the bounded-poll variant: server polls 5s,
+    // returns pending after timeout, test approves, retries with token.
+    // Exercises `triggerScaMcp(..., { wait: 5 })` + `approveAndRetryMcp`.
+    const args = createArgs();
 
-    // First call: poll for 5s with no decision → SCA-pending response.
-    const pendingResult = await client.callTool({ name: "transfer_create", arguments: args });
-    expect(pendingResult.isError).not.toBe(true);
-    const pendingText = firstTextFromMcpResult(pendingResult);
-    expect(pendingText).toMatch(/^SCA required/);
-    expect(pendingText).toContain("sca_session_show");
-    expect(pendingText).toContain("sca_session_token");
+    const trigger = await triggerScaMcp(client, "transfer_create", args, { wait: 5 });
 
-    const tokenMatch = pendingText.match(SCA_PENDING_TOKEN_RE);
-    expect(tokenMatch, `expected Session token line in SCA-pending response: ${pendingText}`).not.toBeNull();
-    const token = tokenMatch?.[1] as string;
+    // AC #4: assert on the actual `sca_session_token` field — not the
+    // literal `"unknown"` sentinel that #445 removed from the codebase.
+    expect(trigger.scaSessionToken).not.toBe("unknown");
+    expect(trigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(trigger.pendingText).toContain("sca_session_show");
+    expect(trigger.pendingText).toContain("sca_session_token");
 
-    // Approve via mock-decision.
-    const approveResult = await client.callTool({
-      name: "sca_session_mock_decision",
-      arguments: { token, decision: "allow" },
-    });
-    expect(approveResult.isError).not.toBe(true);
+    const retryResult = await approveAndRetryMcp(trigger, "allow");
 
-    // Second call: identical params (PSD2 dynamic-linking binds the token to
-    // amount + payee) plus the approved sca_session_token → transfer lands.
-    const retryResult = await client.callTool({
-      name: "transfer_create",
-      arguments: { ...args, sca_session_token: token },
-    });
     expect(retryResult.isError).not.toBe(true);
     const retryText = firstTextFromMcpResult(retryResult);
     expect(retryText).not.toMatch(/^SCA required/);
@@ -243,36 +234,25 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
   });
 
   it("transfer_create with wait=false returns SCA-pending in <2s; second call with sca_session_token after mock allow returns transfer", async () => {
-    const args = createArgs({ wait: false });
+    // Pure two-step variant — server returns pending immediately on 428,
+    // no inline polling. This is the canonical pattern Group 6 write
+    // tests will use, so the helper defaults to `wait: false`.
+    const args = createArgs();
 
-    // First call: pure two-step — must return immediately (no inline polling).
     const start = Date.now();
-    const pendingResult = await client.callTool({ name: "transfer_create", arguments: args });
+    const trigger = await triggerScaMcp(client, "transfer_create", args);
     const elapsedMs = Date.now() - start;
 
-    expect(pendingResult.isError).not.toBe(true);
     expect(elapsedMs).toBeLessThan(2_000);
+    // AC #4 traceability.
+    expect(trigger.scaSessionToken).not.toBe("unknown");
+    expect(trigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(trigger.pendingText).toContain("sca_session_show");
+    expect(trigger.pendingText).toContain("sca_session_token");
+    expect(trigger.pendingText).toContain("No inline poll was requested");
 
-    const pendingText = firstTextFromMcpResult(pendingResult);
-    expect(pendingText).toMatch(/^SCA required/);
-    expect(pendingText).toContain("sca_session_show");
-    expect(pendingText).toContain("sca_session_token");
-    expect(pendingText).toContain("No inline poll was requested");
+    const retryResult = await approveAndRetryMcp(trigger, "allow");
 
-    const tokenMatch = pendingText.match(SCA_PENDING_TOKEN_RE);
-    expect(tokenMatch, `expected Session token line in SCA-pending response: ${pendingText}`).not.toBeNull();
-    const token = tokenMatch?.[1] as string;
-
-    const approveResult = await client.callTool({
-      name: "sca_session_mock_decision",
-      arguments: { token, decision: "allow" },
-    });
-    expect(approveResult.isError).not.toBe(true);
-
-    const retryResult = await client.callTool({
-      name: "transfer_create",
-      arguments: { ...args, sca_session_token: token },
-    });
     expect(retryResult.isError).not.toBe(true);
     const retryText = firstTextFromMcpResult(retryResult);
     expect(retryText).not.toMatch(/^SCA required/);

--- a/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/mcp.e2e.test.ts
@@ -108,8 +108,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     // on the post-SCA retry — masking actual SCA-flow regressions as
     // environmental flakes. Fall back to the highest-balance account if no
     // main is flagged (defensive against sandbox config changes).
-    const account =
-      accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    const account = accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
     if (account === undefined) {
       throw new Error("E2E setup: no bank accounts available in sandbox");
     }

--- a/packages/e2e/src/sca-helpers.ts
+++ b/packages/e2e/src/sca-helpers.ts
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { CLI_PATH, firstTextFromMcpResult } from "./helpers.js";
+import { cliEnv } from "./sandbox.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pattern matching the SCA session polling URL the core HTTP client logs at
+ * verbose level. Tokens are base64url, so they survive `encodeURIComponent`
+ * unchanged and contain only `[A-Za-z0-9_-]`. Matches both the production
+ * endpoint (`/v2/sca/sessions/{token}`) and the sandbox-only mocked endpoint
+ * (`/v2/mocked_sca_sessions/{token}`) — see
+ * `packages/core/src/sca/sca-service.ts#getScaSession` for the routing logic.
+ */
+export const SCA_POLL_URL_RE = /\/v2\/(?:sca\/sessions|mocked_sca_sessions)\/([A-Za-z0-9_-]+)(?=\s|$|\/)/;
+
+/**
+ * Pattern matching the literal `Session token: <token>` line emitted by the
+ * MCP server's structured "SCA pending" response — see
+ * `packages/mcp/src/sca.ts#formatScaPendingResponse`.
+ */
+export const SCA_PENDING_TOKEN_RE = /Session token: ([A-Za-z0-9_-]+)/;
+
+// ---------------------------------------------------------------------------
+// CLI helpers
+// ---------------------------------------------------------------------------
+
+export interface CliScaTrigger {
+  /**
+   * SCA session token captured mid-flight from the spawned CLI's verbose
+   * stderr stream. Always a base64url string per
+   * `packages/core/src/http-client.ts#extractScaSessionToken` — never the
+   * literal `"unknown"` (#445 made that path throw).
+   */
+  readonly scaSessionToken: string;
+  /** The spawned CLI child process; still running when this trigger is returned. */
+  readonly child: ChildProcess;
+  /** Resolves once the CLI exits, with collected stdout/stderr and the exit code. */
+  readonly exitPromise: Promise<CliScaExit>;
+}
+
+export interface CliScaExit {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+/**
+ * Spawn a CLI command that is expected to trigger SCA, and capture the SCA
+ * session token mid-flight from the verbose-log stream.
+ *
+ * The CLI continues running and polling the SCA session — call
+ * {@link approveAndRetryCli} to approve the captured token via the sandbox
+ * `mock-decision` subcommand and await the CLI's completion.
+ *
+ * The returned `child` is left running with stdout/stderr drained into in-
+ * memory buffers; the `exitPromise` resolves once the child exits.
+ *
+ * @param args CLI arguments **excluding** the binary path. `--verbose` is
+ *   prepended automatically so the SCA polling URL appears on stderr.
+ * @param options.timeoutMs Max time to wait for the SCA polling URL to
+ *   appear in stderr. Defaults to 10 000 ms — typical sandbox VoP + transfer
+ *   setup is well under 2 s, so 10 s leaves plenty of headroom while still
+ *   failing fast when the SCA path was never engaged (e.g. a trusted-payee
+ *   exemption was unexpectedly hit).
+ */
+export async function triggerScaCli(
+  args: readonly string[],
+  options: { timeoutMs?: number } = {},
+): Promise<CliScaTrigger> {
+  const timeoutMs = options.timeoutMs ?? 10_000;
+
+  const child = spawn("node", [CLI_PATH, "--verbose", ...args], {
+    env: cliEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let stderrBuffer = "";
+  let scaSessionToken: string | undefined;
+  let captureResolve: ((token: string) => void) | undefined;
+  let captureReject: ((err: Error) => void) | undefined;
+  const capturePromise = new Promise<string>((resolve, reject) => {
+    captureResolve = resolve;
+    captureReject = reject;
+  });
+
+  // `stdio: ["ignore", "pipe", "pipe"]` above guarantees both streams exist;
+  // the spawn-overload result type narrows them to non-null Readables.
+  child.stdout.setEncoding("utf-8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+
+  child.stderr.setEncoding("utf-8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+    if (scaSessionToken !== undefined) return;
+
+    stderrBuffer += chunk;
+    let nlIdx: number;
+    while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
+      const line = stderrBuffer.slice(0, nlIdx);
+      stderrBuffer = stderrBuffer.slice(nlIdx + 1);
+      if (scaSessionToken !== undefined) continue;
+
+      const match = line.match(SCA_POLL_URL_RE);
+      if (match !== null && match[1] !== undefined) {
+        scaSessionToken = match[1];
+        captureResolve?.(scaSessionToken);
+      }
+    }
+  });
+
+  const exitPromise = new Promise<CliScaExit>((resolveExit, rejectExit) => {
+    child.on("error", rejectExit);
+    child.on("close", (code) => {
+      resolveExit({ stdout, stderr, exitCode: code ?? 1 });
+    });
+  });
+
+  // Race the token capture against a timeout so a stuck CLI does not
+  // hang the test suite indefinitely.
+  const timer = setTimeout(() => {
+    captureReject?.(
+      new Error(
+        `Timed out (${String(timeoutMs)}ms) waiting for SCA polling URL in CLI stderr.\n--- stderr ---\n${stderr}`,
+      ),
+    );
+  }, timeoutMs);
+
+  let token: string;
+  try {
+    token = await capturePromise;
+  } catch (err) {
+    // Don't leak a child process if we never captured a token.
+    child.kill();
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return { scaSessionToken: token, child, exitPromise };
+}
+
+/**
+ * Approve (or deny) a previously-captured SCA session token via the sandbox
+ * `mock-decision` subcommand, then await the originally-spawned CLI's exit.
+ *
+ * The CLI's internal SCA wrapper polls the session at a fixed interval,
+ * observes the approval, and retries the original operation. This helper
+ * returns once the spawned CLI exits with the retried operation's result.
+ *
+ * @param trigger The trigger returned by {@link triggerScaCli}.
+ * @param decision `"allow"` or `"deny"`. Defaults to `"allow"`.
+ * @param options.timeoutMs Override the default 25 s timeout on the
+ *   `mock-decision` subprocess (the inner CLI's polling timeout is governed
+ *   separately via `executeWithCliSca` defaults).
+ */
+export async function approveAndRetryCli(
+  trigger: CliScaTrigger,
+  decision: "allow" | "deny" = "allow",
+  options: { timeoutMs?: number } = {},
+): Promise<CliScaExit> {
+  await execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", trigger.scaSessionToken, decision], {
+    env: cliEnv(),
+    timeout: options.timeoutMs ?? 25_000,
+  });
+  return trigger.exitPromise;
+}
+
+// ---------------------------------------------------------------------------
+// MCP helpers
+// ---------------------------------------------------------------------------
+
+export interface McpScaTrigger {
+  /**
+   * SCA session token extracted from the structured "SCA required" pending
+   * response. Always a base64url string captured from the literal
+   * `Session token: <token>` line emitted by `formatScaPendingResponse` —
+   * never the literal `"unknown"` (#445 made that path throw before any
+   * pending response is emitted).
+   */
+  readonly scaSessionToken: string;
+  /** Raw text of the SCA-pending response body (for assertion / debug). */
+  readonly pendingText: string;
+  /** MCP client used to issue the trigger and (later) the retry. */
+  readonly client: Client;
+  /** Tool name passed on the trigger call; reused on the retry. */
+  readonly toolName: string;
+  /**
+   * Original tool arguments (without `wait` or `sca_session_token`) — captured
+   * so {@link approveAndRetryMcp} can re-invoke with the same shape and let
+   * PSD2 dynamic-linking succeed.
+   */
+  readonly args: Record<string, unknown>;
+}
+
+/**
+ * Call an MCP write tool in two-step mode (default: `wait: false`) so the
+ * server returns the SCA-pending response without blocking, and extract the
+ * SCA session token from the `Session token: <token>` line.
+ *
+ * Pair with {@link approveAndRetryMcp} to approve the token via
+ * `sca_session_mock_decision` and re-invoke the tool with `sca_session_token`
+ * set so the operation lands.
+ *
+ * @param client MCP client connected to a CLI-spawned server.
+ * @param toolName MCP write tool name (e.g. `"transfer_create"`).
+ * @param args Tool arguments **excluding** `wait` and `sca_session_token` —
+ *   those are managed by the helper. Args are captured into the returned
+ *   trigger so the retry uses the same shape (PSD2 dynamic-linking binds the
+ *   token to amount + payee).
+ * @param options.wait Override the default `false` — pass a positive integer
+ *   (1–120) to exercise the bounded-poll variant where the server polls
+ *   inline for that many seconds before falling back to the pending response.
+ *   Useful for tests that assert on the polling-timeout path specifically.
+ */
+export async function triggerScaMcp(
+  client: Client,
+  toolName: string,
+  args: Record<string, unknown>,
+  options: { wait?: number | false } = {},
+): Promise<McpScaTrigger> {
+  const wait = options.wait ?? false;
+  const result = await client.callTool({
+    name: toolName,
+    arguments: { ...args, wait },
+  });
+
+  if (result.isError === true) {
+    throw new Error(`MCP tool ${toolName} returned isError=true on trigger call:\n${JSON.stringify(result, null, 2)}`);
+  }
+
+  const pendingText = firstTextFromMcpResult(result as { content: unknown });
+  if (!/^SCA required/.test(pendingText)) {
+    throw new Error(`Expected SCA-pending response from ${toolName} (wait=${String(wait)}), got:\n${pendingText}`);
+  }
+
+  const tokenMatch = pendingText.match(SCA_PENDING_TOKEN_RE);
+  if (tokenMatch === null || tokenMatch[1] === undefined) {
+    throw new Error(`No "Session token: ..." line in SCA-pending response:\n${pendingText}`);
+  }
+
+  return {
+    scaSessionToken: tokenMatch[1],
+    pendingText,
+    client,
+    toolName,
+    args,
+  };
+}
+
+/**
+ * Approve (or deny) a captured SCA session token via the
+ * `sca_session_mock_decision` MCP tool, then re-invoke the original tool
+ * with `sca_session_token` set so the operation succeeds (or fails on deny).
+ *
+ * The retry passes the trigger's original args verbatim plus the approved
+ * token — PSD2 dynamic-linking binds the token to amount + payee, so any
+ * shape change (#438 / `docs/security/sca-token-binding.md`) would cause
+ * the retry to be rejected with `422 Not found`.
+ *
+ * Returns the raw `CallToolResult` of the retry so callers can decide whether
+ * to assert success (`!isError && parseable JSON`) or failure (e.g. on deny).
+ */
+export async function approveAndRetryMcp(
+  trigger: McpScaTrigger,
+  decision: "allow" | "deny" = "allow",
+): Promise<CallToolResult> {
+  const approveResult = await trigger.client.callTool({
+    name: "sca_session_mock_decision",
+    arguments: { token: trigger.scaSessionToken, decision },
+  });
+  if (approveResult.isError === true) {
+    throw new Error(`sca_session_mock_decision returned isError=true:\n${JSON.stringify(approveResult, null, 2)}`);
+  }
+
+  return (await trigger.client.callTool({
+    name: trigger.toolName,
+    arguments: { ...trigger.args, sca_session_token: trigger.scaSessionToken },
+  })) as CallToolResult;
+}


### PR DESCRIPTION
## Summary

- Extracts `triggerScaCli` / `approveAndRetryCli` and `triggerScaMcp` / `approveAndRetryMcp` to `packages/e2e/src/sca-helpers.ts` so #449 Group 6 (28 SCA-gated write-path tests) can chain them per domain without duplicating spawn-CLI/capture-stderr/approve/await orchestration.
- Fixes a latent sandbox-account-selection bug: both tests previously picked `accounts[0]` (a depleted scratch account), causing `400 insufficient_funds` on post-SCA retries that masked actual SCA-flow regressions as environmental flakes. Now picks the `main: true` account with a highest-balance fallback.
- Refactors `sca-continuation/{cli,mcp}.e2e.test.ts` to use the helpers. The inline-poll MCP test (`wait: 10` + concurrent approval) keeps its raw `client.callTool` shape — that pattern is structurally distinct from the two-step round-trip the helpers express.
- Adds explicit AC #4 traceability — `expect(scaToken).not.toBe("unknown")` + base64url shape check — so the `extractScaSessionToken` fallback that #445 closed cannot silently re-emerge.

Closes #450.

## AC traceability

| AC | Status |
|----|--------|
| Full SCA round-trip exercised (trigger → mock allow → poll → retry) | ✅ both surfaces, all variants |
| Same for MCP surface | ✅ `triggerScaMcp` + `approveAndRetryMcp` |
| Asserts on real `sca_session_token` field, not `"unknown"` fallback | ✅ explicit `not.toBe("unknown")` + shape regex |
| Reusable helpers (`triggerSca` / `approveAndRetry`) extracted | ✅ `packages/e2e/src/sca-helpers.ts` |
| Test passes in `e2e-sandbox` CI job | ⚠ stale AC — see note below |

### Note on AC: `e2e-sandbox` CI job

Per [`docs/e2e-testing.md`](https://github.com/alexey-pelykh/qontoctl/blob/main/docs/e2e-testing.md), the `e2e-sandbox` CI job was deliberately **removed**: Qonto rotates OAuth refresh tokens on every `oauth/token` exchange, burning the GH-stored secret on every run. SCA-continuation suites are local-only by design, gated on `hasOAuthCredentials() && hasStagingToken()`. This PR does not re-add the removed CI job; raise a follow-up if the architectural decision is to be revisited.

## Test plan

- [x] `pnpm format:check` (only pre-existing untracked `.claude/*` warnings remain)
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm license-check`
- [x] `pnpm publish-check`
- [x] `pnpm test` — 741 unit tests pass
- [x] `pnpm test:e2e` — 4 SCA-continuation tests pass (vs. failing on `main` due to depleted account); 4 unrelated pre-existing failures (`clients/show`, `cards/csv`, `cards/yaml`, `profile/connectivity`) remain unchanged from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)