### PR TITLE
(test+fix) E2E for webhook CRUD round-trip + align schema/surface with Qonto API (#452)

### DIFF
--- a/packages/cli/src/commands/webhook.test.ts
+++ b/packages/cli/src/commands/webhook.test.ts
@@ -6,6 +6,12 @@ import { jsonResponse } from "@qontoctl/core/testing";
 import { createWebhookCommand } from "./webhook.js";
 import type { PaginationMeta } from "../pagination.js";
 
+// Mocks mirror the actual Qonto API contract (empirically verified 2026-05-10
+// via #452): single-resource responses are unwrapped, lists wrap items under
+// `subscriptions` (NOT `webhook_subscriptions`), and `description` is omitted
+// from API responses entirely. Prior fixtures reflected aspirational shapes
+// that hid the drift behind the unit tests.
+
 function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
   return {
     current_page: 1,
@@ -57,8 +63,7 @@ describe("webhook commands", () => {
           organization_id: "org-1",
           membership_id: "mem-1",
           callback_url: "https://example.com/hook1",
-          types: ["transactions.created"],
-          description: null,
+          types: ["v1/transactions"],
           secret: null,
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
@@ -68,7 +73,7 @@ describe("webhook commands", () => {
           organization_id: "org-1",
           membership_id: "mem-1",
           callback_url: "https://example.com/hook2",
-          types: ["transactions.created", "transactions.updated"],
+          types: ["v1/transactions", "v1/cards"],
           description: "Second hook",
           secret: null,
           created_at: "2026-01-02T00:00:00Z",
@@ -77,7 +82,7 @@ describe("webhook commands", () => {
       ];
       fetchSpy.mockImplementation(() =>
         jsonResponse({
-          webhook_subscriptions: webhooks,
+          subscriptions: webhooks,
           meta: makeMeta({ total_count: 2 }),
         }),
       );
@@ -104,8 +109,7 @@ describe("webhook commands", () => {
           organization_id: "org-1",
           membership_id: "mem-1",
           callback_url: "https://example.com/hook",
-          types: ["transactions.created"],
-          description: null,
+          types: ["v1/transactions"],
           secret: null,
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
@@ -113,7 +117,7 @@ describe("webhook commands", () => {
       ];
       fetchSpy.mockImplementation(() =>
         jsonResponse({
-          webhook_subscriptions: webhooks,
+          subscriptions: webhooks,
           meta: makeMeta({ total_count: 1 }),
         }),
       );
@@ -136,8 +140,7 @@ describe("webhook commands", () => {
         organization_id: "org-1",
         membership_id: "mem-1",
         callback_url: "https://example.com/hook",
-        types: ["transactions.created"],
-        description: null,
+        types: ["v1/transactions"],
         secret: null,
         created_at: "2026-01-01T00:00:00Z",
         updated_at: "2026-01-01T00:00:00Z",
@@ -147,7 +150,7 @@ describe("webhook commands", () => {
     it("passes pagination options to API", async () => {
       fetchSpy.mockImplementation(() =>
         jsonResponse({
-          webhook_subscriptions: [],
+          subscriptions: [],
           meta: makeMeta(),
         }),
       );
@@ -167,7 +170,7 @@ describe("webhook commands", () => {
     it("calls the correct API endpoint", async () => {
       fetchSpy.mockImplementation(() =>
         jsonResponse({
-          webhook_subscriptions: [],
+          subscriptions: [],
           meta: makeMeta(),
         }),
       );
@@ -190,15 +193,14 @@ describe("webhook commands", () => {
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created"],
-      description: null,
+      types: ["v1/transactions"],
       secret: null,
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
 
     it("shows webhook details in json format", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(sampleWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -212,11 +214,11 @@ describe("webhook commands", () => {
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", "wh-1");
       expect(parsed).toHaveProperty("callback_url", "https://example.com/hook");
-      expect(parsed).toHaveProperty("types", ["transactions.created"]);
+      expect(parsed).toHaveProperty("types", ["v1/transactions"]);
     });
 
     it("shows webhook details in table format", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(sampleWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -229,11 +231,11 @@ describe("webhook commands", () => {
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("wh-1");
       expect(output).toContain("https://example.com/hook");
-      expect(output).toContain("transactions.created");
+      expect(output).toContain("v1/transactions");
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(sampleWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -253,15 +255,14 @@ describe("webhook commands", () => {
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created", "transactions.updated"],
-      description: null,
+      types: ["v1/transactions", "v1/cards"],
       secret: "generated-secret",
       created_at: "2026-03-01T00:00:00Z",
       updated_at: "2026-03-01T00:00:00Z",
     };
 
     it("creates a webhook in json format", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(createdWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -277,8 +278,8 @@ describe("webhook commands", () => {
           "--url",
           "https://example.com/hook",
           "--events",
-          "transactions.created",
-          "transactions.updated",
+          "v1/transactions",
+          "v1/cards",
         ],
         { from: "user" },
       );
@@ -288,11 +289,11 @@ describe("webhook commands", () => {
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", "wh-new");
       expect(parsed).toHaveProperty("callback_url", "https://example.com/hook");
-      expect(parsed).toHaveProperty("types", ["transactions.created", "transactions.updated"]);
+      expect(parsed).toHaveProperty("types", ["v1/transactions", "v1/cards"]);
     });
 
     it("sends POST to the correct endpoint with body", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(createdWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -300,7 +301,7 @@ describe("webhook commands", () => {
       program.exitOverride();
 
       await program.parseAsync(
-        ["webhook", "create", "--url", "https://example.com/hook", "--events", "transactions.created"],
+        ["webhook", "create", "--url", "https://example.com/hook", "--events", "v1/transactions"],
         { from: "user" },
       );
 
@@ -310,12 +311,12 @@ describe("webhook commands", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         callback_url: "https://example.com/hook",
-        types: ["transactions.created"],
+        types: ["v1/transactions"],
       });
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: createdWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(createdWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -329,7 +330,7 @@ describe("webhook commands", () => {
           "--url",
           "https://example.com/hook",
           "--events",
-          "transactions.created",
+          "v1/transactions",
           "--idempotency-key",
           "key-abc-123",
         ],
@@ -348,15 +349,14 @@ describe("webhook commands", () => {
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/new-hook",
-      types: ["transactions.created"],
-      description: null,
+      types: ["v1/transactions"],
       secret: null,
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-03-01T00:00:00Z",
     };
 
     it("updates a webhook in json format", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(updatedWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -376,7 +376,7 @@ describe("webhook commands", () => {
     });
 
     it("sends PUT to the correct endpoint with body", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ webhook_subscription: updatedWebhook }));
+      fetchSpy.mockImplementation(() => jsonResponse(updatedWebhook));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
@@ -391,8 +391,8 @@ describe("webhook commands", () => {
           "--url",
           "https://example.com/new-hook",
           "--events",
-          "transactions.created",
-          "transactions.updated",
+          "v1/transactions",
+          "v1/cards",
         ],
         { from: "user" },
       );
@@ -403,7 +403,7 @@ describe("webhook commands", () => {
       const body = JSON.parse(opts.body as string) as Record<string, unknown>;
       expect(body).toEqual({
         callback_url: "https://example.com/new-hook",
-        types: ["transactions.created", "transactions.updated"],
+        types: ["v1/transactions", "v1/cards"],
       });
     });
   });

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -31,7 +31,7 @@ export function createWebhookCommand(): Command {
     const result = await fetchPaginated<WebhookSubscription>(
       client,
       "/v2/webhook_subscriptions",
-      "webhook_subscriptions",
+      "subscriptions",
       opts,
     );
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -315,7 +315,6 @@ export {
   updateWebhook,
   deleteWebhook,
   WebhookSubscriptionSchema,
-  WebhookSubscriptionResponseSchema,
   WebhookSubscriptionListResponseSchema,
 } from "./webhooks/index.js";
 

--- a/packages/core/src/types/webhook-subscription.ts
+++ b/packages/core/src/types/webhook-subscription.ts
@@ -3,6 +3,9 @@
 
 /**
  * A webhook subscription — a registered URL that receives event notifications.
+ *
+ * `description` is omitted entirely from API responses (not returned as null);
+ * modeled here as `string | null | undefined` so consumers handle either shape.
  */
 export interface WebhookSubscription {
   readonly id: string;
@@ -10,7 +13,7 @@ export interface WebhookSubscription {
   readonly membership_id: string;
   readonly callback_url: string;
   readonly types: readonly string[];
-  readonly description: string | null;
+  readonly description?: string | null | undefined;
   readonly secret: string | null;
   readonly created_at: string;
   readonly updated_at: string;

--- a/packages/core/src/webhooks/index.ts
+++ b/packages/core/src/webhooks/index.ts
@@ -3,10 +3,6 @@
 
 export { listWebhooks, getWebhook, createWebhook, updateWebhook, deleteWebhook } from "./service.js";
 
-export {
-  WebhookSubscriptionSchema,
-  WebhookSubscriptionResponseSchema,
-  WebhookSubscriptionListResponseSchema,
-} from "./schemas.js";
+export { WebhookSubscriptionSchema, WebhookSubscriptionListResponseSchema } from "./schemas.js";
 
 export type { CreateWebhookParams, UpdateWebhookParams } from "./types.js";

--- a/packages/core/src/webhooks/schemas.test.ts
+++ b/packages/core/src/webhooks/schemas.test.ts
@@ -2,34 +2,43 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect } from "vitest";
-import { WebhookSubscriptionSchema, WebhookSubscriptionResponseSchema } from "./schemas.js";
+import { WebhookSubscriptionSchema, WebhookSubscriptionListResponseSchema } from "./schemas.js";
 
 describe("WebhookSubscriptionSchema", () => {
+  // Mirrors the actual `POST/GET/PUT /v2/webhook_subscriptions[/:id]` response
+  // shape (empirically verified 2026-05-10): `description` is omitted entirely
+  // rather than returned as `null`, and the object is unwrapped (no
+  // `webhook_subscription` envelope).
   const validWebhook = {
     id: "wh-1",
     organization_id: "org-1",
     membership_id: "mem-1",
     callback_url: "https://example.com/webhook",
-    types: ["transfer.created", "transfer.updated"],
-    description: "My webhook",
+    types: ["v1/transactions", "v1/cards"],
     secret: "whsec_abc123",
     created_at: "2025-01-01T00:00:00.000Z",
     updated_at: "2025-01-01T00:00:00.000Z",
   };
 
-  it("accepts a valid webhook subscription", () => {
+  it("accepts a valid webhook subscription with description omitted (real API shape)", () => {
     const result = WebhookSubscriptionSchema.parse(validWebhook);
     expect(result).toEqual(validWebhook);
+    expect(result.description).toBeUndefined();
+  });
+
+  it("accepts an explicit string description", () => {
+    const result = WebhookSubscriptionSchema.parse({ ...validWebhook, description: "My webhook" });
+    expect(result.description).toBe("My webhook");
+  });
+
+  it("accepts null for description (defensive — API currently omits)", () => {
+    const result = WebhookSubscriptionSchema.parse({ ...validWebhook, description: null });
+    expect(result.description).toBeNull();
   });
 
   it("accepts null for secret", () => {
     const result = WebhookSubscriptionSchema.parse({ ...validWebhook, secret: null });
     expect(result.secret).toBeNull();
-  });
-
-  it("accepts null for description", () => {
-    const result = WebhookSubscriptionSchema.parse({ ...validWebhook, description: null });
-    expect(result.description).toBeNull();
   });
 
   it("accepts empty types array", () => {
@@ -47,22 +56,33 @@ describe("WebhookSubscriptionSchema", () => {
   });
 });
 
-describe("WebhookSubscriptionResponseSchema", () => {
-  it("validates response wrapper", () => {
+describe("WebhookSubscriptionListResponseSchema", () => {
+  it("validates the API list response (subscriptions key, NOT webhook_subscriptions)", () => {
     const response = {
-      webhook_subscription: {
-        id: "wh-1",
-        organization_id: "org-1",
-        membership_id: "mem-1",
-        callback_url: "https://example.com/webhook",
-        types: ["transfer.created"],
-        description: null,
-        secret: null,
-        created_at: "2025-01-01T00:00:00.000Z",
-        updated_at: "2025-01-01T00:00:00.000Z",
-      },
+      subscriptions: [
+        {
+          id: "wh-1",
+          organization_id: "org-1",
+          membership_id: "mem-1",
+          callback_url: "https://example.com/webhook",
+          types: ["v1/transactions"],
+          secret: "whsec_abc",
+          created_at: "2025-01-01T00:00:00.000Z",
+          updated_at: "2025-01-01T00:00:00.000Z",
+        },
+      ],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 1, per_page: 25 },
     };
-    const result = WebhookSubscriptionResponseSchema.parse(response);
-    expect(result.webhook_subscription.id).toBe("wh-1");
+    const result = WebhookSubscriptionListResponseSchema.parse(response);
+    expect(result.subscriptions).toHaveLength(1);
+    expect(result.subscriptions[0]?.id).toBe("wh-1");
+  });
+
+  it("rejects responses using the legacy webhook_subscriptions key", () => {
+    const response = {
+      webhook_subscriptions: [],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 0, per_page: 25 },
+    };
+    expect(() => WebhookSubscriptionListResponseSchema.parse(response)).toThrow();
   });
 });

--- a/packages/core/src/webhooks/schemas.ts
+++ b/packages/core/src/webhooks/schemas.ts
@@ -6,6 +6,19 @@ import { z } from "zod";
 import { PaginationMetaSchema } from "../api-types.schema.js";
 import type { WebhookSubscription } from "../types/webhook-subscription.js";
 
+/**
+ * Schema for a webhook subscription returned by `/v2/webhook_subscriptions`.
+ *
+ * Empirical observation (2026-05-10, sandbox + production endpoints): the
+ * Qonto API does NOT wrap single-resource responses (POST/GET/PUT) in a
+ * `{ webhook_subscription: ... }` envelope — the object is returned directly.
+ * The list endpoint wraps under `subscriptions` (NOT `webhook_subscriptions`).
+ * The `description` field is omitted entirely from API responses rather than
+ * returned as `null`. This schema models the actual contract; prior versions
+ * (with response wrappers + required nullable description) were aspirational
+ * and caused both CLI list (silent empty array) and every MCP webhook tool
+ * call to fail. Drift uncovered by #452's real-API CRUD round-trip E2E.
+ */
 export const WebhookSubscriptionSchema = z
   .object({
     id: z.string(),
@@ -13,22 +26,21 @@ export const WebhookSubscriptionSchema = z
     membership_id: z.string(),
     callback_url: z.string(),
     types: z.array(z.string()),
-    description: z.nullable(z.string()),
+    description: z.string().nullish(),
     secret: z.nullable(z.string()),
     created_at: z.string(),
     updated_at: z.string(),
   })
   .strip() satisfies z.ZodType<WebhookSubscription>;
 
-export const WebhookSubscriptionResponseSchema = z
-  .object({
-    webhook_subscription: WebhookSubscriptionSchema,
-  })
-  .strip();
-
+/**
+ * Schema for `GET /v2/webhook_subscriptions` (list response).
+ *
+ * The API wraps the array under `subscriptions` (NOT `webhook_subscriptions`).
+ */
 export const WebhookSubscriptionListResponseSchema = z
   .object({
-    webhook_subscriptions: z.array(WebhookSubscriptionSchema),
+    subscriptions: z.array(WebhookSubscriptionSchema),
     meta: PaginationMetaSchema,
   })
   .strip();

--- a/packages/core/src/webhooks/service.test.ts
+++ b/packages/core/src/webhooks/service.test.ts
@@ -6,6 +6,12 @@ import { HttpClient } from "../http-client.js";
 import { jsonResponse } from "../testing/json-response.js";
 import { listWebhooks, getWebhook, createWebhook, updateWebhook, deleteWebhook } from "./service.js";
 
+// Empirically observed (2026-05-10): the Qonto API returns single webhook
+// objects directly (no `webhook_subscription` envelope) and lists them under
+// `subscriptions`. The `description` field is omitted. Mocks here mirror that
+// shape; #452 added the real-API E2E that drove these tests away from their
+// prior aspirational fixtures.
+
 describe("listWebhooks", () => {
   let fetchSpy: ReturnType<typeof vi.fn>;
   let client: HttpClient;
@@ -25,15 +31,14 @@ describe("listWebhooks", () => {
 
   it("lists webhook subscriptions without params", async () => {
     const body = {
-      webhook_subscriptions: [
+      subscriptions: [
         {
           id: "wh-1",
           organization_id: "org-1",
           membership_id: "mem-1",
           callback_url: "https://example.com/hook",
-          types: ["transactions.created"],
-          description: null,
-          secret: null,
+          types: ["v1/transactions"],
+          secret: "whsec_abc",
           created_at: "2026-01-01T00:00:00Z",
           updated_at: "2026-01-01T00:00:00Z",
         },
@@ -43,7 +48,7 @@ describe("listWebhooks", () => {
     fetchSpy.mockReturnValue(jsonResponse(body));
 
     const result = await listWebhooks(client);
-    expect(result.webhook_subscriptions).toHaveLength(1);
+    expect(result.subscriptions).toHaveLength(1);
     expect(result.meta.current_page).toBe(1);
 
     const [url] = fetchSpy.mock.calls[0] as [URL];
@@ -53,7 +58,7 @@ describe("listWebhooks", () => {
 
   it("passes pagination params as query strings", async () => {
     const body = {
-      webhook_subscriptions: [],
+      subscriptions: [],
       meta: { current_page: 2, next_page: null, prev_page: 1, total_pages: 2, total_count: 30, per_page: 25 },
     };
     fetchSpy.mockReturnValue(jsonResponse(body));
@@ -67,7 +72,7 @@ describe("listWebhooks", () => {
 
   it("omits undefined pagination params", async () => {
     const body = {
-      webhook_subscriptions: [],
+      subscriptions: [],
       meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 0, per_page: 25 },
     };
     fetchSpy.mockReturnValue(jsonResponse(body));
@@ -97,19 +102,18 @@ describe("getWebhook", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches a webhook subscription by ID", async () => {
+  it("fetches a webhook subscription by ID (response object is unwrapped)", async () => {
     const webhook = {
       id: "wh-1",
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created"],
-      description: null,
-      secret: null,
+      types: ["v1/transactions"],
+      secret: "whsec_abc",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: webhook }));
+    fetchSpy.mockReturnValue(jsonResponse(webhook));
 
     const result = await getWebhook(client, "wh-1");
     expect(result).toEqual(webhook);
@@ -124,13 +128,12 @@ describe("getWebhook", () => {
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created"],
-      description: null,
-      secret: null,
+      types: ["v1/transactions"],
+      secret: "whsec_abc",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: webhook }));
+    fetchSpy.mockReturnValue(jsonResponse(webhook));
 
     await getWebhook(client, "a/b");
 
@@ -156,23 +159,22 @@ describe("createWebhook", () => {
     vi.restoreAllMocks();
   });
 
-  it("posts to the correct endpoint and returns webhook", async () => {
+  it("posts to the correct endpoint and returns the created webhook (unwrapped)", async () => {
     const webhook = {
       id: "wh-new",
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created", "transactions.updated"],
-      description: null,
+      types: ["v1/transactions", "v1/cards"],
       secret: "whsec_abc",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: webhook }));
+    fetchSpy.mockReturnValue(jsonResponse(webhook));
 
     const result = await createWebhook(client, {
       callback_url: "https://example.com/hook",
-      types: ["transactions.created", "transactions.updated"],
+      types: ["v1/transactions", "v1/cards"],
     });
     expect(result).toEqual(webhook);
 
@@ -183,7 +185,7 @@ describe("createWebhook", () => {
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body).toEqual({
       callback_url: "https://example.com/hook",
-      types: ["transactions.created", "transactions.updated"],
+      types: ["v1/transactions", "v1/cards"],
     });
   });
 });
@@ -205,19 +207,18 @@ describe("updateWebhook", () => {
     vi.restoreAllMocks();
   });
 
-  it("puts to the correct endpoint and returns updated webhook", async () => {
+  it("puts to the correct endpoint and returns the updated webhook (unwrapped)", async () => {
     const webhook = {
       id: "wh-1",
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/new-hook",
-      types: ["transactions.created"],
-      description: null,
-      secret: null,
+      types: ["v1/transactions"],
+      secret: "whsec_abc",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-02T00:00:00Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: webhook }));
+    fetchSpy.mockReturnValue(jsonResponse(webhook));
 
     const result = await updateWebhook(client, "wh-1", {
       callback_url: "https://example.com/new-hook",
@@ -238,13 +239,12 @@ describe("updateWebhook", () => {
       organization_id: "org-1",
       membership_id: "mem-1",
       callback_url: "https://example.com/hook",
-      types: ["transactions.created"],
-      description: null,
-      secret: null,
+      types: ["v1/transactions"],
+      secret: "whsec_abc",
       created_at: "2026-01-01T00:00:00Z",
       updated_at: "2026-01-01T00:00:00Z",
     };
-    fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: webhook }));
+    fetchSpy.mockReturnValue(jsonResponse(webhook));
 
     await updateWebhook(client, "a/b", { callback_url: "https://example.com" });
 

--- a/packages/core/src/webhooks/service.ts
+++ b/packages/core/src/webhooks/service.ts
@@ -5,16 +5,18 @@ import type { PaginationMeta } from "../api-types.js";
 import type { HttpClient } from "../http-client.js";
 import { parseResponse } from "../response.js";
 import type { WebhookSubscription } from "../types/webhook-subscription.js";
-import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionResponseSchema } from "./schemas.js";
+import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "./schemas.js";
 import type { CreateWebhookParams, UpdateWebhookParams } from "./types.js";
 
 /**
  * List webhook subscriptions with optional pagination.
+ *
+ * The API wraps results under `subscriptions` (NOT `webhook_subscriptions`).
  */
 export async function listWebhooks(
   client: HttpClient,
   params?: { page?: number; per_page?: number },
-): Promise<{ webhook_subscriptions: WebhookSubscription[]; meta: PaginationMeta }> {
+): Promise<{ subscriptions: WebhookSubscription[]; meta: PaginationMeta }> {
   const query: Record<string, string | readonly string[]> = {};
   if (params) {
     if (params.page !== undefined) query["page"] = String(params.page);
@@ -27,15 +29,19 @@ export async function listWebhooks(
 
 /**
  * Fetch a single webhook subscription by ID.
+ *
+ * The API returns the object directly (no `webhook_subscription` envelope).
  */
 export async function getWebhook(client: HttpClient, id: string): Promise<WebhookSubscription> {
   const endpointPath = `/v2/webhook_subscriptions/${encodeURIComponent(id)}`;
   const response = await client.get(endpointPath);
-  return parseResponse(WebhookSubscriptionResponseSchema, response, endpointPath).webhook_subscription;
+  return parseResponse(WebhookSubscriptionSchema, response, endpointPath);
 }
 
 /**
  * Create a new webhook subscription.
+ *
+ * The API returns the object directly (no `webhook_subscription` envelope).
  */
 export async function createWebhook(
   client: HttpClient,
@@ -44,11 +50,17 @@ export async function createWebhook(
 ): Promise<WebhookSubscription> {
   const endpointPath = "/v2/webhook_subscriptions";
   const response = await client.post(endpointPath, params, options);
-  return parseResponse(WebhookSubscriptionResponseSchema, response, endpointPath).webhook_subscription;
+  return parseResponse(WebhookSubscriptionSchema, response, endpointPath);
 }
 
 /**
  * Update an existing webhook subscription.
+ *
+ * The API returns the object directly (no `webhook_subscription` envelope).
+ * Note: the Qonto API treats PUT as a full-resource replacement — `callback_url`
+ * must be re-sent on every update even when unchanged, otherwise the API returns
+ * "HTTP 400: CallbackURL is missing". This service layer mirrors the API contract
+ * directly; callers wanting partial-update ergonomics need to fetch-then-merge.
  */
 export async function updateWebhook(
   client: HttpClient,
@@ -58,7 +70,7 @@ export async function updateWebhook(
 ): Promise<WebhookSubscription> {
   const endpointPath = `/v2/webhook_subscriptions/${encodeURIComponent(id)}`;
   const response = await client.put(endpointPath, params, options);
-  return parseResponse(WebhookSubscriptionResponseSchema, response, endpointPath).webhook_subscription;
+  return parseResponse(WebhookSubscriptionSchema, response, endpointPath);
 }
 
 /**

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -3,7 +3,7 @@
 
 import { WebhookSubscriptionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson } from "../helpers.js";
+import { cli, cliJson, cliRaw, qontoHttpStatus } from "../helpers.js";
 import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface WebhookItem {
@@ -11,6 +11,12 @@ interface WebhookItem {
   readonly callback_url: string;
   readonly types: string[];
 }
+
+// Stable webhook.site URL used purely as an opaque registration target — the
+// test never receives or asserts on delivered events (per #452 AC item 2). The
+// fixed UUID encodes #452 to make stray sandbox webhooks from failed runs easy
+// to spot and clean up manually.
+const TEST_CALLBACK_URL = "https://webhook.site/00000000-0000-0000-0000-000000000452";
 
 describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -54,6 +60,73 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
     });
   });
 
+  // Real CRUD round-trip against the live sandbox — closes the audit gap from
+  // umbrella #449 (Group 3): webhook write paths were fully implemented but
+  // entirely uncovered by E2E. Sequential `it` blocks share `createdWebhookId`
+  // via closure, mirroring the pattern in `packages/e2e/src/clients/cli.e2e.test.ts`.
+  describe("webhook CRUD lifecycle", () => {
+    let createdWebhookId: string | undefined;
+
+    it("creates a webhook subscription", () => {
+      const webhook = cliJson<WebhookItem>(
+        "webhook",
+        "create",
+        "--url",
+        TEST_CALLBACK_URL,
+        "--events",
+        "v1/transactions",
+      );
+      WebhookSubscriptionSchema.parse(webhook);
+      expect(webhook.id).toBeDefined();
+      expect(webhook.callback_url).toBe(TEST_CALLBACK_URL);
+      expect(webhook.types).toContain("v1/transactions");
+      createdWebhookId = webhook.id;
+    });
+
+    it("updates the webhook by widening the event filter", () => {
+      if (createdWebhookId === undefined) return;
+
+      // The Qonto API treats PUT as full-replacement (not partial) — sending
+      // only `types` returns "HTTP 400: CallbackURL is missing", so the URL
+      // has to be re-sent on every update even when unchanged. The CLI
+      // surface mirrors that contract directly; auto-merge would be a UX
+      // improvement but is out of scope for #452.
+      const webhook = cliJson<WebhookItem>(
+        "webhook",
+        "update",
+        createdWebhookId,
+        "--url",
+        TEST_CALLBACK_URL,
+        "--events",
+        "v1/transactions",
+        "v1/cards",
+      );
+      WebhookSubscriptionSchema.parse(webhook);
+      expect(webhook.id).toBe(createdWebhookId);
+      expect(webhook.types).toEqual(expect.arrayContaining(["v1/transactions", "v1/cards"]));
+    });
+
+    it("deletes the webhook via the API", () => {
+      if (createdWebhookId === undefined) return;
+
+      const result = cliJson<{ deleted: boolean; id: string }>("webhook", "delete", createdWebhookId, "--yes");
+      expect(result.deleted).toBe(true);
+      expect(result.id).toBe(createdWebhookId);
+    });
+
+    it("returns 404 when fetching the deleted webhook", () => {
+      if (createdWebhookId === undefined) return;
+
+      const result = cliRaw(["--output", "json", "webhook", "show", createdWebhookId]);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(qontoHttpStatus(result.stderr)).toBe(404);
+    });
+  });
+
+  // The local-only `--yes` confirmation guard is independent of the API
+  // round-trip above — it asserts the CLI exits non-zero before any HTTP call
+  // is made, so it complements (rather than duplicates) the lifecycle tests.
   describe("webhook delete without --yes", () => {
     it("exits with error when --yes is not provided", () => {
       try {

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -15,13 +15,19 @@ interface WebhookItem {
 }
 
 interface WebhookListResponse {
-  readonly webhook_subscriptions: WebhookItem[];
+  readonly subscriptions: WebhookItem[];
   readonly meta: {
     readonly current_page: number;
     readonly total_pages: number;
     readonly total_count: number;
   };
 }
+
+// Stable webhook.site URL used purely as an opaque registration target — the
+// test never receives or asserts on delivered events (per #452 AC item 2). The
+// fixed UUID encodes #452 to make stray sandbox webhooks from failed runs easy
+// to spot and clean up manually.
+const TEST_CALLBACK_URL = "https://webhook.site/00000000-0000-0000-0000-000000000452";
 
 describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -56,9 +62,9 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookListResponse;
       WebhookSubscriptionListResponseSchema.parse(parsed);
-      expect(parsed).toHaveProperty("webhook_subscriptions");
+      expect(parsed).toHaveProperty("subscriptions");
       expect(parsed).toHaveProperty("meta");
-      expect(Array.isArray(parsed.webhook_subscriptions)).toBe(true);
+      expect(Array.isArray(parsed.subscriptions)).toBe(true);
     });
 
     it("supports pagination", async () => {
@@ -70,7 +76,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       if (result.isError === true) return;
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookListResponse;
-      expect(parsed.webhook_subscriptions.length).toBeLessThanOrEqual(2);
+      expect(parsed.subscriptions.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
   });
@@ -84,7 +90,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       if (listResult.isError === true) return;
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as WebhookListResponse;
-      const first = listParsed.webhook_subscriptions[0];
+      const first = listParsed.subscriptions[0];
       if (first === undefined) return;
 
       const result = await client.callTool({
@@ -98,6 +104,86 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       expect(parsed.id).toBe(first.id);
       expect(parsed).toHaveProperty("callback_url");
       expect(parsed).toHaveProperty("types");
+    });
+  });
+
+  // MCP CRUD smoke for `webhook_create` / `webhook_update` / `webhook_delete` —
+  // closes the audit gap from umbrella #449 (Group 3). Mirrors the CLI suite's
+  // round-trip but exercises the operations through callTool so the MCP wrapper
+  // contract is asserted on top of the underlying API contract.
+  describe("webhook CRUD lifecycle (MCP)", () => {
+    let createdWebhookId: string | undefined;
+
+    it("creates a webhook via callTool", async () => {
+      const result = await client.callTool({
+        name: "webhook_create",
+        arguments: {
+          callback_url: TEST_CALLBACK_URL,
+          types: ["v1/transactions"],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookItem;
+      WebhookSubscriptionSchema.parse(parsed);
+      expect(parsed.id).toBeDefined();
+      expect(parsed.callback_url).toBe(TEST_CALLBACK_URL);
+      expect(parsed.types).toContain("v1/transactions");
+      createdWebhookId = parsed.id;
+    });
+
+    it("updates the webhook by widening the event filter", async () => {
+      if (createdWebhookId === undefined) return;
+
+      // The Qonto API treats PUT as full-replacement (not partial) — sending
+      // only `types` returns "HTTP 400: CallbackURL is missing", so the URL
+      // has to be re-sent on every update even when unchanged. The MCP
+      // surface mirrors that contract directly; auto-merge would be a UX
+      // improvement but is out of scope for #452.
+      const result = await client.callTool({
+        name: "webhook_update",
+        arguments: {
+          id: createdWebhookId,
+          callback_url: TEST_CALLBACK_URL,
+          types: ["v1/transactions", "v1/cards"],
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookItem;
+      WebhookSubscriptionSchema.parse(parsed);
+      expect(parsed.id).toBe(createdWebhookId);
+      expect(parsed.types).toEqual(expect.arrayContaining(["v1/transactions", "v1/cards"]));
+    });
+
+    it("deletes the webhook via callTool", async () => {
+      if (createdWebhookId === undefined) return;
+
+      const result = await client.callTool({
+        name: "webhook_delete",
+        arguments: { id: createdWebhookId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as { deleted: boolean; id: string };
+      expect(parsed.deleted).toBe(true);
+      expect(parsed.id).toBe(createdWebhookId);
+    });
+
+    it("returns 404 when fetching the deleted webhook", async () => {
+      if (createdWebhookId === undefined) return;
+
+      const result = await client.callTool({
+        name: "webhook_show",
+        arguments: { id: createdWebhookId },
+      });
+
+      expect(result.isError).toBe(true);
+      // The MCP error wrapper surfaces `QontoApiError` as text content with the
+      // human-readable "Qonto API error (HTTP 404):" prefix; assert on that
+      // rather than re-parsing the structured shape.
+      const text = firstTextFromMcpResult(result);
+      expect(text).toMatch(/HTTP 404/);
     });
   });
 });

--- a/packages/mcp/src/tools/webhook.test.ts
+++ b/packages/mcp/src/tools/webhook.test.ts
@@ -6,13 +6,16 @@ import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { jsonResponse } from "@qontoctl/core/testing";
 import { connectInMemory } from "../testing/mcp-helpers.js";
 
+// Mirrors the actual Qonto API response shape (empirically verified
+// 2026-05-10 against the live sandbox via #452): the `description` field is
+// omitted entirely, single-resource responses are unwrapped, and lists wrap
+// items under `subscriptions`.
 const sampleWebhook = {
   id: "wh-123",
   organization_id: "org-1",
   membership_id: "mem-1",
   callback_url: "https://example.com/webhook",
-  types: ["transaction.created", "transaction.updated"],
-  description: null,
+  types: ["v1/transactions", "v1/cards"],
   secret: "whsec_abc123",
   created_at: "2026-01-15T10:00:00Z",
   updated_at: "2026-01-15T10:00:00Z",
@@ -36,7 +39,7 @@ describe("webhook MCP tools", () => {
     it("returns webhook subscriptions from API", async () => {
       fetchSpy.mockReturnValue(
         jsonResponse({
-          webhook_subscriptions: [sampleWebhook],
+          subscriptions: [sampleWebhook],
           meta: {
             current_page: 1,
             next_page: null,
@@ -56,14 +59,14 @@ describe("webhook MCP tools", () => {
       const content = result.content as { type: string; text: string }[];
       expect(content).toHaveLength(1);
       const first = content[0] as { type: string; text: string };
-      const parsed = JSON.parse(first.text) as { webhook_subscriptions: unknown[] };
-      expect(parsed.webhook_subscriptions).toHaveLength(1);
+      const parsed = JSON.parse(first.text) as { subscriptions: unknown[] };
+      expect(parsed.subscriptions).toHaveLength(1);
     });
 
     it("passes pagination params to API", async () => {
       fetchSpy.mockReturnValue(
         jsonResponse({
-          webhook_subscriptions: [],
+          subscriptions: [],
           meta: {
             current_page: 2,
             next_page: null,
@@ -88,7 +91,7 @@ describe("webhook MCP tools", () => {
 
   describe("webhook_show", () => {
     it("returns a single webhook subscription", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleWebhook));
 
       const result = await mcpClient.callTool({
         name: "webhook_show",
@@ -104,7 +107,7 @@ describe("webhook MCP tools", () => {
     });
 
     it("calls the correct API endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleWebhook));
 
       await mcpClient.callTool({
         name: "webhook_show",
@@ -118,13 +121,13 @@ describe("webhook MCP tools", () => {
 
   describe("webhook_create", () => {
     it("creates a webhook and returns the result", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleWebhook));
 
       const result = await mcpClient.callTool({
         name: "webhook_create",
         arguments: {
           callback_url: "https://example.com/webhook",
-          types: ["transaction.created"],
+          types: ["v1/transactions"],
         },
       });
 
@@ -136,13 +139,13 @@ describe("webhook MCP tools", () => {
     });
 
     it("sends POST to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleWebhook));
 
       await mcpClient.callTool({
         name: "webhook_create",
         arguments: {
           callback_url: "https://example.com/webhook",
-          types: ["transaction.created"],
+          types: ["v1/transactions"],
         },
       });
 
@@ -154,9 +157,7 @@ describe("webhook MCP tools", () => {
 
   describe("webhook_update", () => {
     it("updates a webhook and returns the result", async () => {
-      fetchSpy.mockReturnValue(
-        jsonResponse({ webhook_subscription: { ...sampleWebhook, callback_url: "https://example.com/new" } }),
-      );
+      fetchSpy.mockReturnValue(jsonResponse({ ...sampleWebhook, callback_url: "https://example.com/new" }));
 
       const result = await mcpClient.callTool({
         name: "webhook_update",
@@ -174,7 +175,7 @@ describe("webhook MCP tools", () => {
     });
 
     it("sends PUT to the correct endpoint", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ webhook_subscription: sampleWebhook }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleWebhook));
 
       await mcpClient.callTool({
         name: "webhook_update",

--- a/packages/mcp/src/tools/webhook.ts
+++ b/packages/mcp/src/tools/webhook.ts
@@ -28,7 +28,7 @@ export function registerWebhookTools(server: McpServer, getClient: () => Promise
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ webhook_subscriptions: result.webhook_subscriptions, meta: result.meta }, null, 2),
+              text: JSON.stringify({ subscriptions: result.subscriptions, meta: result.meta }, null, 2),
             },
           ],
         };


### PR DESCRIPTION
## Summary

Closes #452 (umbrella #449 Group 3).

**Two commits in dependency order** — same pattern as #463 (test) + 8d40fa6 (fix):

1. `(fix) align webhook Zod schema and CLI/MCP surface with actual Qonto API`
2. `(test) E2E for webhook CRUD round-trip (#452)`

The test surfaces three independent contract drifts in qontoctl's webhook handling that were hidden behind mock-only unit tests — exactly the failure mode umbrella #449 was opened to catch.

## Empirical findings (sandbox, 2026-05-10, OAuth)

| Endpoint | Drift | Effect before fix |
|---|---|---|
| `POST /v2/webhook_subscriptions` | No `webhook_subscription` envelope; `description` field omitted | Every `webhook create` failed with "Invalid API response: webhook_subscription: expected object, received undefined" |
| `GET /v2/webhook_subscriptions/{id}` | Same — no envelope | Every `webhook show` / `webhook_show` MCP call failed identically |
| `PUT /v2/webhook_subscriptions/{id}` | Same — no envelope | Every `webhook update` failed identically |
| `GET /v2/webhook_subscriptions` | Items wrap under `subscriptions`, not `webhook_subscriptions` | CLI `webhook list` silently returned `[]` regardless of actual subscriptions (because `fetchPaginated` reads the response by collection key without schema validation, so the wrong key just yielded undefined → empty array) |

Also documented (not a bug — Qonto API design): `PUT` is full-replacement, so `callback_url` must be re-sent on every update or the API returns "HTTP 400: CallbackURL is missing".

## Changes

**Fix commit** (11 files):
- `packages/core/src/webhooks/schemas.ts` — drop `WebhookSubscriptionResponseSchema`; rename list key to `subscriptions`; loosen `description` to `nullish()`
- `packages/core/src/webhooks/service.ts` — parse single-resource responses with `WebhookSubscriptionSchema` directly; document PUT-replaces-all semantics
- `packages/core/src/types/webhook-subscription.ts` — make `description` optional+nullable
- `packages/core/src/webhooks/index.ts` + `packages/core/src/index.ts` — drop the removed schema export
- `packages/cli/src/commands/webhook.ts` — flip `fetchPaginated` collection key from `webhook_subscriptions` to `subscriptions`
- `packages/mcp/src/tools/webhook.ts` — flip MCP wire output to `subscriptions` (matches API)
- Unit tests (`schemas.test.ts`, `service.test.ts`, CLI `webhook.test.ts`, MCP `webhook.test.ts`) — fixtures rewritten to mirror the actual API contract

**Test commit** (2 files):
- `packages/e2e/src/webhooks/cli.e2e.test.ts` + `packages/e2e/src/webhooks/mcp.e2e.test.ts` — add a `webhook CRUD lifecycle` describe block with sequential `create → update → delete → 404-on-show` `it` cases. Fixed `webhook.site` UUID encodes #452 to make stray sandbox webhooks easy to spot. The pre-existing `webhook delete without --yes` test stays — it covers the local CLI guard, complementary to the real API delete added here.

## Acceptance criteria

- [x] Single E2E test exercises full lifecycle: create → assert ID → update (widen filter) → assert update applied → delete → assert show returns 404 (CLI + MCP)
- [x] Uses a stable test callback URL (webhook.site/0…00452); no real event delivery asserted
- [x] CLI surface AND MCP surface both updated
- [x] The current `webhook delete` test (--yes guard) is extended (kept guard test + added real API delete in the lifecycle suite)

## Test plan

- [x] `pnpm build` (5 packages, all green)
- [x] `pnpm lint` (8 packages, all green)
- [x] `pnpm test` (744 unit tests pass)
- [x] `pnpm test:e2e` for `src/webhooks` (16/16 pass against live sandbox — both CLI and MCP suites)
- [x] `pnpm license-check` (100 prod deps, all allowed licenses)
- [x] Full `pnpm test:e2e` run — only pre-existing failures in `cards`, `clients`, `internal-transfers`, `profile` (unrelated to webhook; verified failing on clean `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)