### PR TITLE
(test) E2E for insurance document upload + delete

### DIFF
--- a/packages/cli/src/commands/insurance.test.ts
+++ b/packages/cli/src/commands/insurance.test.ts
@@ -29,11 +29,8 @@ const sampleContract = {
 
 const sampleDocument = {
   id: "doc-123",
-  file_name: "policy.pdf",
-  file_size: "54321",
-  file_content_type: "application/pdf",
-  url: "https://example.com/documents/doc-123",
-  created_at: "2026-01-01T10:00:00Z",
+  name: "policy.pdf",
+  type: "contract",
 };
 
 describe("insurance commands", () => {
@@ -278,23 +275,38 @@ describe("insurance commands", () => {
   });
 
   describe("insurance upload-doc", () => {
-    it("uploads a document via multipart form-data", async () => {
-      fetchSpy.mockImplementation(() => jsonResponse({ insurance_document: sampleDocument }));
+    it("uploads a document via multipart form-data with required --type", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse(sampleDocument));
 
       const { createProgram } = await import("../program.js");
       const program = createProgram();
       program.exitOverride();
 
-      await program.parseAsync(["insurance", "upload-doc", "ic-123", "package.json"], { from: "user" });
+      await program.parseAsync(["insurance", "upload-doc", "ic-123", "package.json", "--type", "contract"], {
+        from: "user",
+      });
 
       expect(stdoutSpy).toHaveBeenCalled();
       const output = stdoutSpy.mock.calls[0]?.[0] as string;
       expect(output).toContain("doc-123");
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/documents");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/attachments");
       expect(opts.method).toBe("POST");
       expect(opts.body).toBeInstanceOf(FormData);
+      const fd = opts.body as FormData;
+      expect(fd.get("name")).toBe("package.json");
+      expect(fd.get("type")).toBe("contract");
+    });
+
+    it("rejects upload-doc without --type", async () => {
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.exitOverride();
+
+      await expect(
+        program.parseAsync(["insurance", "upload-doc", "ic-123", "package.json"], { from: "user" }),
+      ).rejects.toThrow();
     });
   });
 
@@ -327,7 +339,7 @@ describe("insurance commands", () => {
       expect(output).toContain("Document doc-123 removed");
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/documents/doc-123");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-123/attachments/doc-123");
       expect(opts.method).toBe("DELETE");
     });
   });

--- a/packages/cli/src/commands/insurance.ts
+++ b/packages/cli/src/commands/insurance.ts
@@ -214,13 +214,21 @@ export function registerInsuranceCommands(program: Command): void {
   });
 
   // --- upload-doc ---
+  // Known `--type` values (open enum at Qonto's side, so we don't constrain
+  // with .choices(...)): contract, amendment, invoice, other, policy, certificate.
   const uploadDoc = insurance
     .command("upload-doc <id> <file>")
-    .description("Upload a document to an insurance contract");
+    .description("Upload a document to an insurance contract")
+    .addOption(
+      new Option(
+        "--type <type>",
+        "document category (e.g. contract, amendment, invoice, other, policy, certificate)",
+      ).makeOptionMandatory(),
+    );
   addInheritableOptions(uploadDoc);
   addWriteOptions(uploadDoc);
   uploadDoc.action(async (id: string, file: string, _options: unknown, cmd: Command) => {
-    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions>(cmd);
+    const opts = resolveGlobalOptions<GlobalOptions & WriteOptions & { type: string }>(cmd);
     const client = await createClient(opts);
 
     const buffer = await readFile(file);
@@ -231,21 +239,12 @@ export function registerInsuranceCommands(program: Command): void {
       id,
       new Blob([buffer]),
       fileName,
+      opts.type,
       opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
     );
 
     const data =
-      opts.output === "json" || opts.output === "yaml"
-        ? doc
-        : [
-            {
-              id: doc.id,
-              file_name: doc.file_name,
-              file_size: doc.file_size,
-              file_content_type: doc.file_content_type,
-              created_at: doc.created_at,
-            },
-          ];
+      opts.output === "json" || opts.output === "yaml" ? doc : [{ id: doc.id, name: doc.name, type: doc.type }];
 
     process.stdout.write(formatOutput(data, opts.output) + "\n");
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -469,7 +469,6 @@ export {
   InsuranceContractResponseSchema,
   InsuranceContractSchema,
   InsuranceContractStatusSchema,
-  InsuranceDocumentResponseSchema,
   InsuranceDocumentSchema,
 } from "./insurance-contracts/index.js";
 

--- a/packages/core/src/insurance-contracts/index.ts
+++ b/packages/core/src/insurance-contracts/index.ts
@@ -29,6 +29,5 @@ export {
   InsuranceContractResponseSchema,
   InsuranceContractSchema,
   InsuranceContractStatusSchema,
-  InsuranceDocumentResponseSchema,
   InsuranceDocumentSchema,
 } from "./schemas.js";

--- a/packages/core/src/insurance-contracts/schemas.test.ts
+++ b/packages/core/src/insurance-contracts/schemas.test.ts
@@ -2,21 +2,13 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, it, expect } from "vitest";
-import {
-  InsuranceContractSchema,
-  InsuranceContractResponseSchema,
-  InsuranceDocumentSchema,
-  InsuranceDocumentResponseSchema,
-} from "./schemas.js";
+import { InsuranceContractSchema, InsuranceContractResponseSchema, InsuranceDocumentSchema } from "./schemas.js";
 
 describe("InsuranceDocumentSchema", () => {
   const validDocument = {
     id: "doc-1",
-    file_name: "policy.pdf",
-    file_size: "12345",
-    file_content_type: "application/pdf",
-    url: "https://example.com/policy.pdf",
-    created_at: "2025-06-01T00:00:00.000Z",
+    name: "policy.pdf",
+    type: "contract",
   };
 
   it("accepts a valid document", () => {
@@ -24,32 +16,28 @@ describe("InsuranceDocumentSchema", () => {
     expect(result).toEqual(validDocument);
   });
 
-  it("coerces file_size to string", () => {
-    const result = InsuranceDocumentSchema.parse({ ...validDocument, file_size: 12345 });
-    expect(result.file_size).toBe("12345");
+  it("accepts any string for type (open enum)", () => {
+    for (const type of ["contract", "amendment", "invoice", "other", "policy", "certificate", "future_kind"]) {
+      expect(() => InsuranceDocumentSchema.parse({ ...validDocument, type })).not.toThrow();
+    }
   });
 
   it("rejects missing required fields", () => {
     expect(() => InsuranceDocumentSchema.parse({ ...validDocument, id: undefined })).toThrow();
-    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, file_name: undefined })).toThrow();
-    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, url: undefined })).toThrow();
+    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, name: undefined })).toThrow();
+    expect(() => InsuranceDocumentSchema.parse({ ...validDocument, type: undefined })).toThrow();
   });
-});
 
-describe("InsuranceDocumentResponseSchema", () => {
-  it("validates response wrapper", () => {
-    const response = {
-      insurance_document: {
-        id: "doc-1",
-        file_name: "policy.pdf",
-        file_size: "12345",
-        file_content_type: "application/pdf",
-        url: "https://example.com/policy.pdf",
-        created_at: "2025-06-01T00:00:00.000Z",
-      },
-    };
-    const result = InsuranceDocumentResponseSchema.parse(response);
-    expect(result.insurance_document.id).toBe("doc-1");
+  it("strips unknown fields (e.g. the legacy file_size envelope)", () => {
+    const result = InsuranceDocumentSchema.parse({
+      ...validDocument,
+      file_name: "ignored.pdf",
+      file_size: "12345",
+      url: "https://example.com/ignored",
+    } as unknown);
+    expect(result).not.toHaveProperty("file_name");
+    expect(result).not.toHaveProperty("file_size");
+    expect(result).not.toHaveProperty("url");
   });
 });
 

--- a/packages/core/src/insurance-contracts/schemas.ts
+++ b/packages/core/src/insurance-contracts/schemas.ts
@@ -32,14 +32,17 @@ export const InsuranceContractDocumentRefSchema = z
   })
   .strip();
 
+// The Qonto upload-attachment endpoint (`POST /v2/insurance_contracts/{id}/attachments`)
+// returns a flat `{ id, name, type }` payload — NOT the file_name/file_size/
+// file_content_type/url/created_at shape an earlier draft inferred. Empirically
+// confirmed against the live sandbox during #454. The same shape echoes back
+// in `InsuranceContract.documents[]`, so this and `InsuranceContractDocumentRef`
+// describe the same record under two endpoints.
 export const InsuranceDocumentSchema = z
   .object({
     id: z.string(),
-    file_name: z.string(),
-    file_size: z.coerce.string(),
-    file_content_type: z.string(),
-    url: z.string(),
-    created_at: z.string(),
+    name: z.string(),
+    type: z.string(),
   })
   .strip() satisfies z.ZodType<InsuranceDocument>;
 
@@ -70,11 +73,5 @@ export const InsuranceContractSchema = z
 export const InsuranceContractResponseSchema = z
   .object({
     insurance_contract: InsuranceContractSchema,
-  })
-  .strip();
-
-export const InsuranceDocumentResponseSchema = z
-  .object({
-    insurance_document: InsuranceDocumentSchema,
   })
   .strip();

--- a/packages/core/src/insurance-contracts/service.test.ts
+++ b/packages/core/src/insurance-contracts/service.test.ts
@@ -28,11 +28,8 @@ const sampleContract = {
 
 const sampleDocument = {
   id: "doc-1",
-  file_name: "policy.pdf",
-  file_size: "54321",
-  file_content_type: "application/pdf",
-  url: "https://example.com/documents/doc-1",
-  created_at: "2026-01-01T10:00:00Z",
+  name: "policy.pdf",
+  type: "contract",
 };
 
 describe("insurance contract service", () => {
@@ -156,25 +153,29 @@ describe("insurance contract service", () => {
   });
 
   describe("uploadInsuranceDocument", () => {
-    it("uploads a document via multipart form-data", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+    it("uploads a document via multipart form-data to /attachments", async () => {
+      fetchSpy.mockReturnValue(jsonResponse(sampleDocument));
 
       const file = new Blob(["file content"], { type: "application/pdf" });
-      const result = await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf");
+      const result = await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf", "contract");
 
       expect(result).toEqual(sampleDocument);
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/attachments");
       expect(opts.method).toBe("POST");
       expect(opts.body).toBeInstanceOf(FormData);
+      const fd = opts.body as FormData;
+      expect(fd.get("name")).toBe("policy.pdf");
+      expect(fd.get("type")).toBe("contract");
+      expect(fd.get("file")).toBeInstanceOf(Blob);
     });
 
     it("passes idempotency key when provided", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+      fetchSpy.mockReturnValue(jsonResponse(sampleDocument));
 
       const file = new Blob(["file content"]);
-      await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf", { idempotencyKey: "key-789" });
+      await uploadInsuranceDocument(client, "ic-1", file, "policy.pdf", "contract", { idempotencyKey: "key-789" });
 
       const [, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       const headers = opts.headers as Record<string, string>;
@@ -189,7 +190,7 @@ describe("insurance contract service", () => {
       await removeInsuranceDocument(client, "ic-1", "doc-1");
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents/doc-1");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/attachments/doc-1");
       expect(opts.method).toBe("DELETE");
     });
 

--- a/packages/core/src/insurance-contracts/service.ts
+++ b/packages/core/src/insurance-contracts/service.ts
@@ -3,7 +3,7 @@
 
 import type { HttpClient } from "../http-client.js";
 import { parseResponse } from "../response.js";
-import { InsuranceContractResponseSchema, InsuranceDocumentResponseSchema } from "./schemas.js";
+import { InsuranceContractResponseSchema, InsuranceDocumentSchema } from "./schemas.js";
 import type {
   InsuranceContract,
   InsuranceContractOrigin,
@@ -112,10 +112,17 @@ export async function updateInsuranceContract(
 /**
  * Upload a document to an insurance contract via multipart form-data.
  *
+ * The Qonto endpoint is `/attachments` (not `/documents`, despite the contract
+ * response naming the array `documents`) and the multipart body requires
+ * three fields: `file`, `name`, and `type`. The response is a flat
+ * `{ id, name, type }` payload — NOT wrapped in `insurance_document`.
+ *
  * @param client - The HTTP client to use for the request.
  * @param contractId - The insurance contract UUID.
  * @param file - The file content as a Blob.
- * @param fileName - The file name.
+ * @param fileName - The file name (becomes the `name` multipart field as well).
+ * @param type - Document category. Known values: `contract`, `amendment`,
+ *   `invoice`, `other`, `policy`, `certificate` (open enum — pass through).
  * @param options - Optional idempotency key.
  * @returns The uploaded document details.
  */
@@ -124,14 +131,17 @@ export async function uploadInsuranceDocument(
   contractId: string,
   file: Blob,
   fileName: string,
+  type: string,
   options?: { readonly idempotencyKey?: string },
 ): Promise<InsuranceDocument> {
   const formData = new FormData();
   formData.append("file", file, fileName);
+  formData.append("name", fileName);
+  formData.append("type", type);
 
-  const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(contractId)}/documents`;
+  const endpointPath = `/v2/insurance_contracts/${encodeURIComponent(contractId)}/attachments`;
   const response = await client.postFormData(endpointPath, formData, options);
-  return parseResponse(InsuranceDocumentResponseSchema, response, endpointPath).insurance_document;
+  return parseResponse(InsuranceDocumentSchema, response, endpointPath);
 }
 
 /**
@@ -149,7 +159,7 @@ export async function removeInsuranceDocument(
   options?: { readonly idempotencyKey?: string },
 ): Promise<void> {
   await client.delete(
-    `/v2/insurance_contracts/${encodeURIComponent(contractId)}/documents/${encodeURIComponent(documentId)}`,
+    `/v2/insurance_contracts/${encodeURIComponent(contractId)}/attachments/${encodeURIComponent(documentId)}`,
     options,
   );
 }

--- a/packages/core/src/insurance-contracts/types.ts
+++ b/packages/core/src/insurance-contracts/types.ts
@@ -66,13 +66,18 @@ export interface InsuranceContract {
 }
 
 /**
- * A document attached to an insurance contract, as returned by the upload-document endpoint.
+ * A document attached to an insurance contract, as returned by both the
+ * upload endpoint (`POST /v2/insurance_contracts/{id}/attachments`) and the
+ * contract's `documents[]` array. The Qonto API uses both names — the path
+ * is "/attachments" but the contract field is "documents" — and returns the
+ * same `{ id, name, type }` payload from each.
+ *
+ * Known `type` values (empirically observed): `contract`, `amendment`,
+ * `invoice`, `other`, `policy`, `certificate`. The field is open (no Qonto
+ * docs enum at time of writing), so qontoctl pins it as `string`.
  */
 export interface InsuranceDocument {
   readonly id: string;
-  readonly file_name: string;
-  readonly file_size: string;
-  readonly file_content_type: string;
-  readonly url: string;
-  readonly created_at: string;
+  readonly name: string;
+  readonly type: string;
 }

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -1,10 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { InsuranceContractSchema } from "@qontoctl/core";
+import { resolve } from "node:path";
+import { InsuranceContractSchema, InsuranceDocumentSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli } from "../helpers.js";
 import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the document upload
+ * round-trip. Shared with attachments/client-invoice/supplier-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
+
+interface InsuranceDocumentRef {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+}
 
 describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -63,6 +76,60 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdId);
       expect(parsed).toHaveProperty("provider_slug", "allianz");
+    });
+
+    // Real document upload + delete round-trip against the live sandbox — closes
+    // the audit gap from umbrella #449 (Group 4b): insurance document write
+    // paths were fully implemented but uncovered by E2E. Reuses the `createdId`
+    // closure variable from the CRUD lifecycle above so the contract is shared
+    // across the suite (mirrors the attachment pattern in #453). The PDF
+    // fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
+    let uploadedDocId: string | undefined;
+
+    it("uploads a document via insurance upload-doc", () => {
+      if (createdId === undefined) return;
+
+      // `--type` is required by the Qonto API (one of contract, amendment,
+      // invoice, other, policy, certificate — empirically observed values).
+      const output = cli(
+        "--output",
+        "json",
+        "insurance",
+        "upload-doc",
+        createdId,
+        PDF_FIXTURE_PATH,
+        "--type",
+        "contract",
+      );
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      InsuranceDocumentSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("name", "tiny.pdf");
+      expect(parsed).toHaveProperty("type", "contract");
+      uploadedDocId = parsed["id"] as string;
+    });
+
+    it("insurance show reflects the uploaded document", () => {
+      if (createdId === undefined || uploadedDocId === undefined) return;
+
+      const output = cli("--output", "json", "insurance", "show", createdId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      InsuranceContractSchema.parse(parsed);
+      const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
+      expect(documents.map((d) => d.id)).toContain(uploadedDocId);
+    });
+
+    it("removes the document via insurance remove-doc --yes", () => {
+      if (createdId === undefined || uploadedDocId === undefined) return;
+
+      // `--yes` is required: without it, the CLI prints a confirmation prompt
+      // to stderr and exits 1 (see `packages/cli/src/commands/insurance.ts`).
+      cli("--output", "json", "insurance", "remove-doc", createdId, uploadedDocId, "--yes");
+
+      const output = cli("--output", "json", "insurance", "show", createdId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
+      expect(documents.map((d) => d.id)).not.toContain(uploadedDocId);
     });
   });
 });

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -1,12 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { InsuranceContractSchema } from "@qontoctl/core";
+import { InsuranceContractSchema, InsuranceDocumentSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the document upload
+ * round-trip. Shared with attachments/client-invoice/supplier-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
+
+interface InsuranceDocumentRef {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+}
 
 describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -88,6 +101,67 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdId);
       expect(parsed).toHaveProperty("provider_slug", "allianz");
+    });
+
+    // Real document upload + delete round-trip against the live sandbox — closes
+    // the audit gap from umbrella #449 (Group 4b): insurance document write
+    // paths were fully implemented but uncovered by E2E. Reuses the `createdId`
+    // closure variable from the CRUD lifecycle above so the contract is shared
+    // across the suite (mirrors the attachment pattern in #453). The PDF
+    // fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
+    let uploadedDocId: string | undefined;
+
+    it("uploads a document via insurance_upload_document", async () => {
+      if (createdId === undefined) return;
+
+      // `type` is required by the Qonto API (one of contract, amendment,
+      // invoice, other, policy, certificate — empirically observed values).
+      const result = await client.callTool({
+        name: "insurance_upload_document",
+        arguments: { contract_id: createdId, file_path: PDF_FIXTURE_PATH, type: "contract" },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      InsuranceDocumentSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("name", "tiny.pdf");
+      expect(parsed).toHaveProperty("type", "contract");
+      uploadedDocId = parsed["id"] as string;
+    });
+
+    it("insurance_show reflects the uploaded document", async () => {
+      if (createdId === undefined || uploadedDocId === undefined) return;
+
+      const result = await client.callTool({
+        name: "insurance_show",
+        arguments: { id: createdId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      InsuranceContractSchema.parse(parsed);
+      const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
+      expect(documents.map((d) => d.id)).toContain(uploadedDocId);
+    });
+
+    it("removes the document via insurance_remove_document", async () => {
+      if (createdId === undefined || uploadedDocId === undefined) return;
+
+      const removeResult = await client.callTool({
+        name: "insurance_remove_document",
+        arguments: { contract_id: createdId, document_id: uploadedDocId },
+      });
+      expect(removeResult.isError).toBeFalsy();
+
+      const showResult = await client.callTool({
+        name: "insurance_show",
+        arguments: { id: createdId },
+      });
+      expect(showResult.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(showResult)) as Record<string, unknown>;
+      const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
+      expect(documents.map((d) => d.id)).not.toContain(uploadedDocId);
     });
   });
 });

--- a/packages/mcp/src/tools/insurance.test.ts
+++ b/packages/mcp/src/tools/insurance.test.ts
@@ -22,11 +22,8 @@ const sampleContract = {
 
 const sampleDocument = {
   id: "doc-1",
-  file_name: "policy.pdf",
-  file_size: "54321",
-  file_content_type: "application/pdf",
-  url: "https://example.com/documents/doc-1",
-  created_at: "2026-01-01T10:00:00Z",
+  name: "policy.pdf",
+  type: "contract",
 };
 
 describe("insurance MCP tools", () => {
@@ -224,14 +221,15 @@ describe("insurance MCP tools", () => {
   });
 
   describe("insurance_upload_document", () => {
-    it("uploads a document to an insurance contract", async () => {
-      fetchSpy.mockReturnValue(jsonResponse({ insurance_document: sampleDocument }));
+    it("uploads a document to an insurance contract with required type", async () => {
+      fetchSpy.mockReturnValue(jsonResponse(sampleDocument));
 
       const result = await mcpClient.callTool({
         name: "insurance_upload_document",
         arguments: {
           contract_id: "ic-1",
           file_path: "package.json",
+          type: "contract",
         },
       });
 
@@ -241,9 +239,23 @@ describe("insurance MCP tools", () => {
       expect(parsed.id).toBe("doc-1");
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/attachments");
       expect(opts.method).toBe("POST");
       expect(opts.body).toBeInstanceOf(FormData);
+      const fd = opts.body as FormData;
+      expect(fd.get("name")).toBe("package.json");
+      expect(fd.get("type")).toBe("contract");
+    });
+
+    it("returns an error result when type is missing", async () => {
+      const result = await mcpClient.callTool({
+        name: "insurance_upload_document",
+        arguments: {
+          contract_id: "ic-1",
+          file_path: "package.json",
+        },
+      });
+      expect(result.isError).toBe(true);
     });
   });
 
@@ -265,7 +277,7 @@ describe("insurance MCP tools", () => {
       expect((content[0] as { type: string; text: string }).text).toContain("removed");
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
-      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/documents/doc-1");
+      expect(url.pathname).toBe("/v2/insurance_contracts/ic-1/attachments/doc-1");
       expect(opts.method).toBe("DELETE");
     });
   });

--- a/packages/mcp/src/tools/insurance.ts
+++ b/packages/mcp/src/tools/insurance.ts
@@ -186,13 +186,16 @@ export function registerInsuranceTools(server: McpServer, getClient: () => Promi
       inputSchema: {
         contract_id: z.string().describe("Insurance contract ID (UUID)"),
         file_path: z.string().describe("Absolute path to the file to upload"),
+        type: z
+          .string()
+          .describe("Document category (e.g. 'contract', 'amendment', 'invoice', 'other', 'policy', 'certificate')"),
       },
     },
-    async ({ contract_id, file_path }) =>
+    async ({ contract_id, file_path, type }) =>
       withClient(getClient, async (client) => {
         const buffer = await readFile(file_path);
         const fileName = basename(file_path);
-        const doc = await uploadInsuranceDocument(client, contract_id, new Blob([buffer]), fileName);
+        const doc = await uploadInsuranceDocument(client, contract_id, new Blob([buffer]), fileName, type);
 
         return {
           content: [


### PR DESCRIPTION
## Summary

Closes #454.

Closes the audit gap from umbrella #449 Group 4b: insurance document write paths were fully implemented but uncovered by E2E. Writing the E2E surfaced that qontoctl was calling the wrong endpoint with the wrong payload shape — bundled fix-then-test in two commits, mirroring the just-landed #453 pattern.

### Two commits

1. **`(fix) align insurance document upload Zod schema and CLI/MCP surface with actual Qonto API`** — `/documents` → `/attachments`, multipart needs `name` + `type` fields, response is `{ id, name, type }` (not the inferred file_name/file_size/file_content_type/url/created_at envelope). CLI gains required `--type`, MCP gains required `type`. Unit-test mocks aligned.
2. **`(test) E2E for insurance document upload + delete round-trip (#454)`** — CLI and MCP suites extended with `upload-doc → show (asserts documents[] contains id) → remove → show (asserts documents[] no longer contains id)`. Reuses `packages/e2e/fixtures/tiny.pdf` from #G4A.

### Why the alignment fix is bundled

Same pattern as #453 (`9af3cb3 (fix)` + `fe53be9 (test)` in one PR): the E2E is what surfaced the drift, and bundling them lands the contract correction together with the regression test that pins it. The whole point of #449 is to surface exactly this kind of "mocked-only coverage hides drift" gap.

### Auth gate

Inherits the suite's `describe.skipIf(!hasOAuthCredentials())` + `pinAuthPreference("oauth-first")` — insurance contracts is OAuth-only on Qonto's side, so this is local-only by design. CI's api-key E2E job will skip the entire insurance suite naturally; no CI gate impact.

## Test plan

- [x] `pnpm build` clean across all packages
- [x] `pnpm lint` clean
- [x] `pnpm license-check` clean
- [x] `pnpm test` clean (746 CLI tests + others, 0 fails)
- [x] `pnpm --filter @qontoctl/e2e test:e2e -- src/insurance` against live sandbox — 2 files, 12 tests, all green
- [x] Manual probe against live sandbox confirmed:
  - `POST /v2/insurance_contracts/{id}/attachments` with multipart `file` + `name` + `type` returns `201 { id, name, type }`
  - `DELETE /v2/insurance_contracts/{id}/attachments/{id}` returns `204`
  - Observed `type` values: contract, amendment, invoice, other, policy, certificate
- [x] Pre-existing failures in unrelated suites (cards/clients/internal-transfers/profile/transactions) reproduce on `main` without my changes — sandbox-state issues, not regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)