### PR TITLE
(test) E2E for client-invoice file upload + retrieval (#455)

### DIFF
--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { ClientInvoiceSchema } from "@qontoctl/core";
+import { resolve } from "node:path";
+import { ClientInvoiceSchema, ClientInvoiceUploadSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli } from "../helpers.js";
 import { hasApiKeyCredentials } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the upload round-trip.
+ * Shared with attachments/insurance/supplier-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
 
 describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => {
   describe("client-invoice list", () => {
@@ -92,6 +99,48 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
       const output = cli("--output", "json", "client-invoice", "update", createdInvoiceId, "--body", body);
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id", createdInvoiceId);
+    });
+
+    // Real file upload + retrieval round-trip against the live sandbox — closes
+    // the audit gap from umbrella #449 (Group 4c): client-invoice upload write
+    // paths were fully implemented but uncovered by E2E. Sequential `it` blocks
+    // share `uploadedFileId` via closure on top of the parent CRUD lifecycle's
+    // `createdInvoiceId`, mirroring the attachment/insurance pattern in #453/#454.
+    // The PDF fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
+    //
+    // Unlike attachments and insurance, the client-invoice upload endpoint has no
+    // delete pair — uploads are removed implicitly when the parent invoice is
+    // deleted in the final lifecycle step.
+    let uploadedFileId: string | undefined;
+
+    it("uploads a PDF to the created invoice via client-invoice upload", () => {
+      if (createdInvoiceId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "upload", createdInvoiceId, PDF_FIXTURE_PATH);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      ClientInvoiceUploadSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("file_name", "tiny.pdf");
+      expect(parsed).toHaveProperty("file_content_type");
+      expect(parsed).toHaveProperty("file_size");
+      uploadedFileId = parsed["id"] as string;
+    });
+
+    it("retrieves the upload via client-invoice upload-show", () => {
+      if (createdInvoiceId === undefined || uploadedFileId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "upload-show", createdInvoiceId, uploadedFileId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      ClientInvoiceUploadSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id", uploadedFileId);
+      expect(parsed).toHaveProperty("file_name", "tiny.pdf");
+      expect(parsed).toHaveProperty("file_content_type");
+      expect(parsed).toHaveProperty("url");
+      expect(parsed).toHaveProperty("created_at");
     });
 
     it("deletes the created invoice", () => {

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { ClientInvoiceListResponseSchema, ClientInvoiceSchema } from "@qontoctl/core";
+import { ClientInvoiceListResponseSchema, ClientInvoiceSchema, ClientInvoiceUploadSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the upload round-trip.
+ * Shared with attachments/insurance/supplier-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
 
 describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () => {
   let client: Client;
@@ -77,6 +84,116 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
       expect(parsed).toHaveProperty("items");
+    });
+  });
+
+  // Real file upload + retrieval round-trip against the live sandbox — closes
+  // the audit gap from umbrella #449 (Group 4c): client-invoice upload write
+  // paths were fully implemented but uncovered by E2E. Sequential `it` blocks
+  // share `createdInvoiceId` / `uploadedFileId` via closure (mirrors the CLI
+  // pattern in this file and the attachment/insurance MCP patterns in #453/#454).
+  // The PDF fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
+  //
+  // The MCP suite currently has no CRUD lifecycle (unlike CLI), so this block
+  // creates its own draft invoice as a precondition, performs the upload+show
+  // round-trip, then cleans up by deleting the invoice (which implicitly
+  // removes the upload — there is no upload-delete endpoint).
+  describe("client_invoice upload + retrieval round-trip (MCP)", () => {
+    let createdInvoiceId: string | undefined;
+    let uploadedFileId: string | undefined;
+
+    it("creates a draft invoice as a precondition for upload", async () => {
+      // Fetch a client ID from existing clients (mirrors the CLI lifecycle).
+      const clientListResult = await client.callTool({
+        name: "client_list",
+        arguments: {},
+      });
+      if (clientListResult.isError === true) return;
+
+      const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
+        clients: { id: string }[];
+      };
+      if (clientsParsed.clients.length === 0) {
+        return;
+      }
+
+      const clientId = (clientsParsed.clients[0] as { id: string }).id;
+      const today = new Date().toISOString().split("T")[0] as string;
+      const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const createResult = await client.callTool({
+        name: "client_invoice_create",
+        arguments: {
+          client_id: clientId,
+          issue_date: today,
+          due_date: dueDate,
+          currency: "EUR",
+          terms_and_conditions: "E2E test invoice — safe to delete",
+          items: [
+            {
+              title: "E2E Test Service",
+              quantity: "1",
+              unit_price: { value: "100.00", currency: "EUR" },
+              vat_rate: "20",
+            },
+          ],
+        },
+      });
+
+      // Invoice creation may fail if the organization lacks required setup
+      // (e.g., IBAN not configured) — skip downstream lifecycle when it does.
+      if (createResult.isError === true) return;
+
+      const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("status", "draft");
+      createdInvoiceId = parsed["id"] as string;
+    });
+
+    it("uploads a PDF to the created invoice via client_invoice_upload", async () => {
+      if (createdInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_upload",
+        arguments: { id: createdInvoiceId, file_path: PDF_FIXTURE_PATH },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      ClientInvoiceUploadSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id");
+      expect(parsed).toHaveProperty("file_name", "tiny.pdf");
+      expect(parsed).toHaveProperty("file_content_type");
+      expect(parsed).toHaveProperty("file_size");
+      uploadedFileId = parsed["id"] as string;
+    });
+
+    it("retrieves the upload via client_invoice_upload_show", async () => {
+      if (createdInvoiceId === undefined || uploadedFileId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_upload_show",
+        arguments: { id: createdInvoiceId, upload_id: uploadedFileId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      ClientInvoiceUploadSchema.parse(parsed);
+      expect(parsed).toHaveProperty("id", uploadedFileId);
+      expect(parsed).toHaveProperty("file_name", "tiny.pdf");
+      expect(parsed).toHaveProperty("file_content_type");
+      expect(parsed).toHaveProperty("url");
+      expect(parsed).toHaveProperty("created_at");
+    });
+
+    it("deletes the created invoice (cleanup)", async () => {
+      if (createdInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_delete",
+        arguments: { id: createdInvoiceId },
+      });
+      expect(result.isError).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Closes #455. Audit gap from umbrella #449 Group 4c: client-invoice upload write paths were fully implemented but uncovered by E2E.
- Extends `packages/e2e/src/client-invoices/cli.e2e.test.ts` and `packages/e2e/src/client-invoices/mcp.e2e.test.ts` with `upload → upload-show` round-trip, reusing the existing `packages/e2e/fixtures/tiny.pdf` fixture.
- Both upload steps validate the response against `ClientInvoiceUploadSchema` to pin the live API contract.

## Coverage details

| Suite | Endpoints exercised | Auth gate |
|-------|---------------------|-----------|
| CLI (`cli.e2e.test.ts`) | `POST /v2/client_invoices/:id/uploads`, `GET /v2/client_invoices/:id/uploads/:uploadId` via `client-invoice upload` / `upload-show` | `hasApiKeyCredentials()` (unchanged from existing suite) |
| MCP (`mcp.e2e.test.ts`) | Same endpoints via `client_invoice_upload` / `client_invoice_upload_show` tools | Same |

The MCP suite had no CRUD lifecycle prior to this change — the new describe block creates a draft invoice as a precondition (fetching a `client_id` from `client_list`), then runs upload→show→delete. There is no upload-delete endpoint on the Qonto API, so the parent-invoice delete is the cleanup path (unlike attachments and insurance, which have dedicated remove endpoints — see commit body for the contrast).

## Test plan

- [x] `pnpm build` clean (5 packages)
- [x] `pnpm lint` clean (8 tasks)
- [x] `pnpm test` clean (746 unit tests across 84 files)
- [x] `pnpm test:e2e src/client-invoices/` passes (17 tests; new tests gracefully skip when invoice creation fails due to org missing IBAN, matching the established pattern in the existing CRUD lifecycle)
- [x] Full `pnpm test:e2e` regression check: only pre-existing failures (profile / clients / cards), verified identical on `main` — UNRELATED to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)