### PR TITLE
(test) E2E for supplier-invoice bulk creation (multipart) (#456)

### DIFF
--- a/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/cli.e2e.test.ts
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { resolve } from "node:path";
 import { SupplierInvoiceSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { cli } from "../helpers.js";
 import { hasApiKeyCredentials } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the bulk-create round-trip.
+ * Shared with attachments/insurance/client-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
 
 describe.skipIf(!hasApiKeyCredentials())("supplier-invoice commands (e2e)", () => {
   describe("supplier-invoice list", () => {
@@ -47,6 +54,50 @@ describe.skipIf(!hasApiKeyCredentials())("supplier-invoice commands (e2e)", () =
       SupplierInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
+    });
+  });
+
+  // Multipart bulk upload + per-invoice retrieval round-trip against the live
+  // sandbox — closes the audit gap from umbrella #449 (Group 4d): the
+  // bulk-create write path (POST /v2/supplier_invoices/bulk) was fully
+  // implemented but uncovered by E2E. The PDF fixture
+  // (`packages/e2e/fixtures/tiny.pdf`) is shared with attachment/insurance/
+  // client-invoice E2E (landed with #G4A).
+  //
+  // **Accepted state pollution**: qontoctl exposes no DELETE endpoint for
+  // supplier invoices, so bulk-uploaded fixtures accumulate in the sandbox
+  // organization. This is documented as accepted per AC #4 of #456.
+  describe("supplier-invoice bulk-create", () => {
+    it("uploads N=2 PDFs via multipart and asserts each is queryable", () => {
+      // Upload the same fixture twice — the CLI assigns a fresh random
+      // idempotency key per file (see packages/cli/src/commands/supplier-invoice/bulk-create.ts),
+      // so the API creates two distinct supplier invoices from one file path.
+      const output = cli("--output", "json", "supplier-invoice", "bulk-create", PDF_FIXTURE_PATH, PDF_FIXTURE_PATH);
+      // With `--output json`, the CLI emits the `supplier_invoices` array directly
+      // (errors are written to stderr; a non-empty errors array sets exit code 1
+      // which would cause `cli()` to throw).
+      const created = JSON.parse(output) as Record<string, unknown>[];
+      expect(Array.isArray(created)).toBe(true);
+      expect(created.length).toBe(2);
+
+      for (const invoice of created) {
+        SupplierInvoiceSchema.parse(invoice);
+        expect(invoice).toHaveProperty("id");
+        expect(typeof invoice["id"]).toBe("string");
+        expect(invoice).toHaveProperty("status");
+        expect(invoice).toHaveProperty("file_name", "tiny.pdf");
+      }
+
+      // Assert each returned invoice is queryable via `supplier-invoice show`.
+      for (const invoice of created) {
+        const invoiceId = invoice["id"] as string;
+        const showOutput = cli("--output", "json", "supplier-invoice", "show", invoiceId);
+        const fetched = JSON.parse(showOutput) as Record<string, unknown>;
+        SupplierInvoiceSchema.parse(fetched);
+        expect(fetched).toHaveProperty("id", invoiceId);
+        expect(fetched).toHaveProperty("file_name", "tiny.pdf");
+        expect(fetched).toHaveProperty("status");
+      }
     });
   });
 });

--- a/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/supplier-invoices/mcp.e2e.test.ts
@@ -1,12 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { SupplierInvoiceListResponseSchema, SupplierInvoiceSchema } from "@qontoctl/core";
+import {
+  BulkCreateSupplierInvoicesResultSchema,
+  SupplierInvoiceListResponseSchema,
+  SupplierInvoiceSchema,
+} from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+
+/**
+ * Absolute path to the committed PDF fixture used by the bulk-create round-trip.
+ * Shared with attachments/insurance/client-invoice E2E.
+ */
+const PDF_FIXTURE_PATH = resolve(import.meta.dirname, "..", "..", "fixtures", "tiny.pdf");
 
 describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () => {
   let client: Client;
@@ -78,6 +89,61 @@ describe.skipIf(!hasApiKeyCredentials())("MCP supplier invoice tools (e2e)", () 
       SupplierInvoiceSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", invoiceId);
       expect(parsed).toHaveProperty("status");
+    });
+  });
+
+  // Multipart bulk upload + per-invoice retrieval round-trip against the live
+  // sandbox — closes the audit gap from umbrella #449 (Group 4d): the
+  // bulk-create write path (POST /v2/supplier_invoices/bulk) was fully
+  // implemented but uncovered by E2E. The PDF fixture
+  // (`packages/e2e/fixtures/tiny.pdf`) is shared with attachment/insurance/
+  // client-invoice E2E (landed with #G4A).
+  //
+  // **Accepted state pollution**: qontoctl exposes no DELETE endpoint for
+  // supplier invoices, so bulk-uploaded fixtures accumulate in the sandbox
+  // organization. This is documented as accepted per AC #4 of #456.
+  describe("supplier_invoice_bulk_create", () => {
+    it("uploads N=2 PDFs via multipart and asserts each is queryable", async () => {
+      // Upload the same fixture twice — the MCP tool assigns a fresh random
+      // idempotency key per file (see packages/mcp/src/tools/supplier-invoice.ts),
+      // so the API creates two distinct supplier invoices from one file path.
+      const result = await client.callTool({
+        name: "supplier_invoice_bulk_create",
+        arguments: { file_paths: [PDF_FIXTURE_PATH, PDF_FIXTURE_PATH] },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      BulkCreateSupplierInvoicesResultSchema.parse(parsed);
+
+      const created = parsed["supplier_invoices"] as Record<string, unknown>[];
+      const errors = parsed["errors"] as unknown[];
+      expect(Array.isArray(created)).toBe(true);
+      expect(created.length).toBe(2);
+      expect(Array.isArray(errors)).toBe(true);
+      expect(errors.length).toBe(0);
+
+      for (const invoice of created) {
+        expect(invoice).toHaveProperty("id");
+        expect(typeof invoice["id"]).toBe("string");
+        expect(invoice).toHaveProperty("status");
+        expect(invoice).toHaveProperty("file_name", "tiny.pdf");
+      }
+
+      // Assert each returned invoice is queryable via `supplier_invoice_show`.
+      for (const invoice of created) {
+        const invoiceId = invoice["id"] as string;
+        const showResult = await client.callTool({
+          name: "supplier_invoice_show",
+          arguments: { id: invoiceId },
+        });
+        expect(showResult.isError).toBeFalsy();
+        const fetched = JSON.parse(firstTextFromMcpResult(showResult)) as Record<string, unknown>;
+        SupplierInvoiceSchema.parse(fetched);
+        expect(fetched).toHaveProperty("id", invoiceId);
+        expect(fetched).toHaveProperty("file_name", "tiny.pdf");
+        expect(fetched).toHaveProperty("status");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds live-sandbox E2E coverage for `bulkCreateSupplierInvoices` (POST `/v2/supplier_invoices/bulk`) on both CLI (`supplier-invoice bulk-create`) and MCP (`supplier_invoice_bulk_create`) surfaces — closes umbrella #449 Group 4d.
- Each test uploads N=2 `tiny.pdf` fixtures via multipart, asserts each returned invoice has `id` / `status` / `file_name`, then re-fetches each via `supplier-invoice show` / `supplier_invoice_show` to verify queryability (AC #2).
- Documents that qontoctl exposes no DELETE endpoint for supplier invoices, so sandbox state accumulates as accepted pollution (AC #4).

## Test plan

- [x] `pnpm exec vitest run --config ../../vitest.e2e.config.ts src/supplier-invoices/` → 8/8 pass (6 existing list+show + 2 new bulk-create)
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `prettier --check` clean

Closes #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)