### PR TITLE
(fix) card list E2E CSV + YAML tests handle empty sandbox (#538)

### DIFF
--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -59,6 +59,11 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
     });
 
     it("outputs CSV format", () => {
+      // CSV formatter emits no output for an empty list, so there is no header
+      // row to assert against — skip when the sandbox has zero cards.
+      const cards = cliJson<CardItem[]>("card", "list", "--per-page", "5");
+      if (cards[0] === undefined) return;
+
       const output = cli("card", "list", "--output", "csv", "--per-page", "5");
       const lines = output.trim().split("\n");
       expect(lines.length).toBeGreaterThanOrEqual(1);
@@ -68,6 +73,11 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
     });
 
     it("outputs YAML format", () => {
+      // YAML formatter emits `[]` for an empty list, so there is no `id:`
+      // field to assert against — skip when the sandbox has zero cards.
+      const cards = cliJson<CardItem[]>("card", "list", "--per-page", "2");
+      if (cards[0] === undefined) return;
+
       const output = cli("card", "list", "--output", "yaml", "--per-page", "2");
       expect(output).toContain("id:");
     });


### PR DESCRIPTION
## Summary

- Card list CSV and YAML E2E tests asserted on `id` / `id:` markers that only appear when the API returns rows. On an empty sandbox (zero cards), the CSV formatter emits no output and the YAML formatter emits `[]`, breaking both assertions.
- Apply the **skip-when-empty** pattern already used by sibling `card show` (line 80-82) and `card iframe-url` (line 105-107) tests: pre-fetch via `cliJson<CardItem[]>`, return early when the list is empty. When data exists, the original format assertions still run unchanged.

Closes #538.

## Acceptance criteria

- [x] CSV test handles empty sandbox gracefully (skip pattern)
- [x] YAML test handles empty sandbox gracefully (skip pattern)
- [x] When sandbox has ≥1 card, both tests still assert the expected format (`id`/`status` CSV header; `id:` in YAML)
- [x] Fix shape: skip-when-empty (matches sibling tests' pattern, not a formatter behavior change)

## Test plan

- [x] `pnpm --filter @qontoctl/e2e lint` — clean
- [x] Full E2E suite — `cards/cli.e2e.test.ts` passes (the 2 unrelated baseline failures in `clients/mcp.e2e.test.ts` and `profile/profile.e2e.test.ts` are tracked by #537 and #536, respectively)
- [ ] CI `e2e` job — runs against production with api-key (where the card describe block is skipped because OAuth-only); CI green = no regression