### PR TITLE
(fix) client_show MCP E2E asserts kind-discriminated name (#537)

### DIFF
--- a/packages/e2e/src/clients/mcp.e2e.test.ts
+++ b/packages/e2e/src/clients/mcp.e2e.test.ts
@@ -75,8 +75,20 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       ClientSchema.parse(parsed);
       expect(parsed).toHaveProperty("id", clientId);
-      expect(parsed).toHaveProperty("name");
       expect(parsed).toHaveProperty("type");
+      expect(parsed).toHaveProperty("kind");
+      // Qonto omits `name` entirely for individual/freelancer clients and returns
+      // `first_name` + `last_name` instead. Assert against the kind-discriminated
+      // contract rather than blanket `toHaveProperty("name")`, which fails when
+      // the sandbox's first client is an individual (#537). Mirrors the schema
+      // shape pinned in `ClientSchema` (`packages/core/src/types/client.schema.ts`).
+      const kind = (parsed as { kind: string }).kind;
+      if (kind === "company") {
+        expect(parsed).toHaveProperty("name");
+      } else {
+        expect(parsed).toHaveProperty("first_name");
+        expect(parsed).toHaveProperty("last_name");
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #537. The `client_show` MCP E2E test failed on `main` because it asserted `toHaveProperty("name")` on the first client returned by `client_list`, but Qonto's sandbox seeds an `individual`-kind client and the API omits `name` entirely for `individual`/`freelancer` clients (returning `first_name` + `last_name` instead — same contract that prompted the schema fix in #496).

Replace the blanket assertion with a `kind`-discriminated check that mirrors `ClientSchema`:

- `company` → expect `name`
- `individual` / `freelancer` → expect `first_name` + `last_name`

## Scope notes

- CLI `client show` test (`packages/e2e/src/clients/cli.e2e.test.ts`) is intentionally untouched: it self-creates a `kind: "company"` client in the CRUD lifecycle and shows it by id, so `name` is always present. The original AC asked to mirror the fix "if it has the same assumption" — it doesn't.
- Also added `expect(parsed).toHaveProperty("kind")` alongside the existing `type` assertion, since `kind` is the schema-required discriminator the new branch reads.

## Test plan

- [x] `pnpm --filter @qontoctl/e2e exec vitest run --config ../../vitest.e2e.config.ts src/clients` → 12/12 pass
- [x] `pnpm --filter @qontoctl/e2e lint` → clean
- [x] `pnpm --filter @qontoctl/e2e typecheck` → clean
- [x] Full `pnpm test:e2e` locally → all suites pass except a **pre-existing, unrelated** failure in `src/profile/profile.e2e.test.ts:253` (`reports success with organization name for valid credentials` — exit code 1 instead of 0). Verified the same failure occurs on `main` at `56fcc80`, so it predates this branch and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)