### PR TITLE
(fix) profile test E2E isolates env to avoid sandbox routing (#536)

### DIFF
--- a/packages/e2e/src/profile/profile.e2e.test.ts
+++ b/packages/e2e/src/profile/profile.e2e.test.ts
@@ -241,17 +241,28 @@ describe.skipIf(!hasApiKeyCredentials())("profile test (e2e)", () => {
     // Skip if API key credentials are not available (e.g. OAuth-only sandbox)
     if (creds.organizationSlug === undefined || creds.secretKey === undefined) return;
 
-    const { stdout, exitCode } = cli(["profile", "test"], {
-      env: {
-        ...(process.env as Record<string, string>),
-        HOME: tempDir,
-        USERPROFILE: tempDir,
+    // Use homeEnv() (not `...process.env`) to isolate from the parent shell's
+    // env. Spreading process.env inherits whatever direnv has exported — most
+    // importantly QONTOCTL_CONFIG_FILE, which points at the repo's
+    // .qontoctl.yaml. That file may carry an oauth.staging-token, which the
+    // CLI uses to route ALL requests (including api-key) to the Qonto sandbox.
+    // Sandbox does not accept api-key auth, so the CLI gets a 302 and exits 1.
+    // homeEnv() ships only PATH + HOME/USERPROFILE, matching how the sibling
+    // "invalid credentials" test (and every other test in this file) is wired,
+    // so the CLI uses production URLs and api-key auth uniformly local + CI.
+    const { stdout, stderr, exitCode } = cli(["profile", "test"], {
+      env: homeEnv(tempDir, {
         QONTOCTL_ORGANIZATION_SLUG: creds.organizationSlug,
         QONTOCTL_SECRET_KEY: creds.secretKey,
-      },
+      }),
     });
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("Success: connected to organization");
+    // Surface stderr in assertion messages so a CLI failure is diagnosable
+    // from the test report alone — without it, the report only shows the
+    // exit-code mismatch and hides the actual "API error (…)" line.
+    expect(exitCode, `expected exit 0 but got ${String(exitCode)}; stderr: ${stderr}`).toBe(0);
+    expect(stdout, `stdout did not contain success line; stderr: ${stderr}`).toContain(
+      "Success: connected to organization",
+    );
   });
 
   // AC: Given invalid credentials,


### PR DESCRIPTION
## Summary

Fix `profile.e2e.test.ts > "reports success with organization name for valid credentials"` failing locally with exit code 1.

## Root cause

The test built its env by spreading `...process.env`, which (when `direnv` is set up) inherits `QONTOCTL_CONFIG_FILE` pointing at the repo's `.qontoctl.yaml`. That file carries an `oauth.staging-token`, which the CLI uses to route **all** requests — including api-key ones — to the Qonto sandbox via the `X-Qonto-Staging-Token` header. Sandbox does not accept api-key auth, so the CLI received a 302 and exited 1.

Confirmed empirically (per AC #1):

```
$ QONTOCTL_CONFIG_FILE=$PWD/.qontoctl.yaml HOME=<tempdir> \
    QONTOCTL_ORGANIZATION_SLUG=... QONTOCTL_SECRET_KEY=... \
    node packages/qontoctl/dist/cli.js profile test
API error (302): Qonto API error 302: unknown: Unknown error
```

Pinning `QONTOCTL_AUTH=api-key` does **not** fix it — the staging-token routing happens regardless of auth method. The hypothesis on the issue ("regression from #523's oauth-first default") is a co-factor at most; the proximate cause is the `QONTOCTL_CONFIG_FILE` inheritance.

The test was the only one in the file that constructed env this way. The sibling "reports failure with error message for invalid credentials" test and all the local-only tests (`profile list/show/add/remove`) use `homeEnv()`, which inherits only `PATH` + `HOME`/`USERPROFILE`.

The `...process.env` form was introduced in `9d942b8` ("replace sandbox config with OAuth staging token") — likely to inherit the sandbox-routing env at the time. Now that staging-token routing is fully owned by config, the spread is the bug, not the feature.

## Fix

- Switch to `homeEnv(tempDir, { QONTOCTL_ORGANIZATION_SLUG, QONTOCTL_SECRET_KEY })` — matches the sibling failure-case test and every other test in the file. Production URLs + api-key auth uniformly local + CI.
- No CLI change needed (AC #3): the CLI already degrades `oauth-first` → api-key when only api-key is available, and `profile test` already honors api-key env vars without an explicit auth pin. Verified by inspection of `packages/core/src/auth/preference.ts` § `selectAuthChain` and by ad-hoc CLI invocation against production with clean env (returns 401 from invalid creds — which is correct, the chain reaches production not sandbox).
- Also surface `stderr` in the assertion failure message so a future CLI error is diagnosable from the test report alone (the issue body called out that "stderr is not captured by the assertion, so the failure mode is opaque to the test report").

## Test plan

- [x] Unit tests pass (`pnpm test` — 746 passed)
- [x] Lint + typecheck pass (`pnpm lint`)
- [x] Local repro confirmed: before fix → 302 from sandbox; after fix → 401 from production with my local invalid creds (verified independently via direct `curl` against production: same 401)
- [x] Full E2E suite diff vs `main`: same baseline failures on both branches; my change introduces zero regressions
- [ ] CI E2E job (with valid prod api-key secrets) runs the test against production → expect green

## AC checklist

- [x] Determine the actual failure mode (302 from sandbox routing — see "Root cause" above)
- [x] Test passes on a fresh clone with valid api-key env vars (CI scenario — would pass after this fix; the env handling is now identical between local and CI)
- [x] CLI honors api-key env vars without an explicit auth pin (already true; no CLI change)
- [x] Root cause is test setup; documented rationale in code comment + this PR
- [ ] `pnpm test:e2e packages/e2e/src/profile/profile.e2e.test.ts` exits 0 (gated on whether `getCredentials()` returns valid-against-production api-key — CI: yes; local: depends on user's `.qontoctl.yaml`)

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)