### PR TITLE
(docs) document client_invoice_cancel SCA-exclusion (#528)

### DIFF
--- a/packages/core/src/client-invoices/service.ts
+++ b/packages/core/src/client-invoices/service.ts
@@ -156,6 +156,22 @@ export async function unmarkClientInvoicePaid(client: HttpClient, id: string): P
 
 /**
  * Cancel a finalized client invoice.
+ *
+ * Transitions invoice status from `unpaid` to `canceled` — a billing-state
+ * change, not a payment-initiation operation. SCA not required by the Qonto
+ * API as of 2026-05-12; verified against the official endpoint documentation
+ * (`POST /v2/client_invoices/{id}/mark_as_canceled` declares responses
+ * `200`/`400`/`401`/`403`/`422`/`500` — no `428 Precondition Required`, which
+ * is the SCA-required signal per the Qonto SCA flow docs). The OAuth scope
+ * (`client_invoice.write`) is a billing scope, distinct from payment-write
+ * scopes that gate PSD2 dynamic-linking SCA flows. The signature intentionally
+ * omits an `options` parameter (no `idempotencyKey`/`scaSessionToken`) — the
+ * absence is structural: no SCA continuation surface exists on this endpoint.
+ *
+ * If this assumption ever needs re-verification:
+ * - Source: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices/mark-a-client-invoice-as-canceled.md
+ * - SCA contract: https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows.md
+ * - Re-audit ticket: #528 (closed) — repeat the response-code check
  */
 export async function cancelClientInvoice(client: HttpClient, id: string): Promise<ClientInvoice> {
   const endpointPath = `/v2/client_invoices/${encodeURIComponent(id)}/mark_as_canceled`;


### PR DESCRIPTION
## Summary

- Audits `client_invoice_cancel` (deferred by #500) — finding: **SCA NOT required**, verified against Qonto API docs.
- Extends `cancelClientInvoice` JSDoc with the audit finding, regulatory framing (PSD2 / OAuth scope distinction), structural signal (signature has no `options` param), and re-audit pointers.

## Finding

Per the [official endpoint OpenAPI](https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices/mark-a-client-invoice-as-canceled.md), `POST /v2/client_invoices/{id}/mark_as_canceled` declares responses `200/400/401/403/422/500` — no `428 Precondition Required`, which is THE SCA signal per the [SCA flow docs](https://docs.qonto.com/api-reference/business-api/authentication/sca/sca-flows.md). The OAuth scope `client_invoice.write` is a billing-state scope, distinct from payment-write scopes that gate PSD2 dynamic-linking SCA flows. The function signature already encodes this empirically: no `options` param, no `idempotencyKey`/`scaSessionToken` extension point.

## Change

Documentation-only. JSDoc-only edit on `packages/core/src/client-invoices/service.ts` `cancelClientInvoice`. No behavior change. No CLI/MCP/E2E surface added because the audit confirmed the absence of an SCA surface, not its presence.

## Test plan

- [x] `pnpm --filter @qontoctl/core build` — clean (tsc)
- [x] `pnpm --filter @qontoctl/core lint` — clean (eslint)
- [x] `pnpm --filter @qontoctl/core test -- --run` — 1036/1036 pass, 65 test files
- [x] `pnpm build` (full workspace) — 5/5 packages successful
- [x] `pnpm lint` (full workspace) — 8/8 packages successful
- [ ] `pnpm test:e2e` (full suite) — running locally

## Polish

Polished via fresh-context subprocess (`workflow-polish`); verdict CLEAN. All material claims verified against authoritative sources.

## Scope Lock follow-up

Polish review surfaced an unrelated bug: MCP and CLI `client-invoice list` declare the `status` filter enum as `["draft", "pending", "paid", "cancelled"]` but Qonto's canonical enum is `["draft", "unpaid", "paid", "canceled"]` (`pending`→`unpaid`, UK `cancelled`→US `canceled`). Tracked separately as #544; not bundled here per Scope Lock — this PR is JSDoc-only.

Closes #528