### PR TITLE
(test) E2E for internal-transfer SCA write path + CLI wrap fix (#549)

### DIFF
--- a/packages/cli/src/commands/internal-transfer.ts
+++ b/packages/cli/src/commands/internal-transfer.ts
@@ -2,11 +2,12 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { Command, Option } from "commander";
-import type { InternalTransfer } from "@qontoctl/core";
+import { createInternalTransfer, type InternalTransfer } from "@qontoctl/core";
 import { createClient } from "../client.js";
 import { formatOutput } from "../formatters/index.js";
 import { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "../inherited-options.js";
 import type { GlobalOptions, WriteOptions } from "../options.js";
+import { executeWithCliSca } from "../sca.js";
 
 interface InternalTransferCreateOptions extends GlobalOptions, WriteOptions {
   readonly debitIban: string;
@@ -45,20 +46,25 @@ export function createInternalTransferCommand(): Command {
     const opts = resolveGlobalOptions<InternalTransferCreateOptions>(cmd);
     const client = await createClient(opts);
 
-    const response = await client.post<{ internal_transfer: InternalTransfer }>(
-      "/v2/internal_transfers",
-      {
-        internal_transfer: {
-          debit_iban: opts.debitIban,
-          credit_iban: opts.creditIban,
-          reference: opts.reference,
-          amount: opts.amount,
-          currency: opts.currency,
-        },
-      },
-      opts.idempotencyKey !== undefined ? { idempotencyKey: opts.idempotencyKey } : undefined,
+    const t = await executeWithCliSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        createInternalTransfer(
+          client,
+          {
+            debit_iban: opts.debitIban,
+            credit_iban: opts.creditIban,
+            reference: opts.reference,
+            amount: opts.amount,
+            currency: opts.currency,
+          },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
     );
-    const t = response.internal_transfer;
 
     const data = opts.output === "json" || opts.output === "yaml" ? t : [internalTransferToTableRow(t)];
 

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -216,11 +216,10 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
           const match = line.match(SCA_POLL_URL_RE);
           if (match !== null && match[1] !== undefined) {
             scaToken = match[1];
-            approvePromise = execFileAsync(
-              "node",
-              [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"],
-              { env: cliEnv(), timeout: 25_000 },
-            );
+            approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
+              env: cliEnv(),
+              timeout: 25_000,
+            });
           }
         }
       });

--- a/packages/e2e/src/internal-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/cli.e2e.test.ts
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
 import { InternalTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson, cliRaw } from "../helpers.js";
-import { hasApiKeyCredentials } from "../sandbox.js";
+import { CLI_PATH, cli, cliJson, cliRaw } from "../helpers.js";
+import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_POLL_URL_RE } from "../sca-helpers.js";
+
+const execFileAsync = promisify(execFile);
 
 interface OrgBankAccount {
   readonly id: string;
@@ -47,11 +53,10 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer CLI commands (e2e)",
     // production api-key endpoint): internal-transfer create succeeds without
     // triggering SCA at amount=1 EUR. #438's probe confirmed the same at
     // amount=1.50, and the prior local probe at amount=0.01 also succeeded.
-    // If a future test run starts failing with HTTP 428 / `sca_required`,
-    // the org's SCA enforcement may have changed — coordinate with #449
-    // Group 6 (SCA-gated paths) and migrate this exercise to the
-    // SCA-orchestrated pattern used by `bulk-transfers/` and
-    // `recurring-transfers/`.
+    // The OAuth+sandbox path is now empirically probed by the
+    // `(OAuth+sandbox SCA probe)` describe block below — if a future run
+    // flips SCA enforcement on either path, that block surfaces the change
+    // explicitly without breaking the api-key happy path here.
     //
     // Precondition: the test organization must have ≥2 active internal
     // (Qonto-owned, non-aggregated) bank accounts. The original test org
@@ -127,3 +132,141 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer CLI commands (e2e)",
     });
   });
 });
+
+// OAuth+sandbox SCA probe — local-only (requires OAuth credentials AND a
+// staging token, which routes requests to the Qonto sandbox). Sibling to the
+// api-key path above; coexists rather than replacing it because the two paths
+// historically exhibit different SCA-enforcement (see audit Notable Finding
+// #2 in #449, refuted for bulk-transfers/recurring-transfers, still empirically
+// unknown for internal-transfer until this probe runs).
+//
+// The test conditionally exercises either branch of the SCA-trigger decision
+// the sandbox makes at request time:
+//   - If 428 SCA-required is returned → captures the polling token via the
+//     CLI's verbose-log stream, approves through `sca-session mock-decision`,
+//     awaits the CLI's retry, asserts the underlying create succeeded.
+//   - If the create completes without SCA → asserts no SCA polling URL was
+//     logged and the operation still returned a valid InternalTransfer.
+// Either outcome is documented via `console.log` so the empirical truth is
+// visible in CI / local runs without a flaky pass/fail decision.
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
+  "internal-transfer create (OAuth+sandbox SCA probe)",
+  () => {
+    pinAuthPreference("oauth-first");
+
+    it("triggers SCA round-trip OR completes without SCA in OAuth+sandbox", async () => {
+      const accounts = discoverInternalAccounts();
+      const TRANSFER_AMOUNT_EUR = 1;
+      const debit = accounts.find((a) => a.balance > TRANSFER_AMOUNT_EUR);
+      const credit = accounts.find((a) => a.id !== debit?.id);
+      if (debit === undefined || credit === undefined) {
+        console.warn(
+          `[e2e] internal-transfer SCA probe: skipping — requires ≥2 active internal Qonto bank ` +
+            `accounts with at least one funded above ${String(TRANSFER_AMOUNT_EUR)} EUR. ` +
+            `Found ${String(accounts.length)} internal account(s).`,
+        );
+        return;
+      }
+
+      const reference = `e2e-sca-${randomUUID().slice(0, 12)}`;
+
+      const child = spawn(
+        "node",
+        [
+          CLI_PATH,
+          "--verbose",
+          "--output",
+          "json",
+          "internal-transfer",
+          "create",
+          "--debit-iban",
+          debit.iban,
+          "--credit-iban",
+          credit.iban,
+          "--reference",
+          reference,
+          "--amount",
+          String(TRANSFER_AMOUNT_EUR),
+          "--currency",
+          "EUR",
+        ],
+        { env: cliEnv(), stdio: ["ignore", "pipe", "pipe"] },
+      );
+
+      let stdout = "";
+      let stderr = "";
+      let stderrBuffer = "";
+      let scaToken: string | undefined;
+      let approvePromise: Promise<unknown> = Promise.resolve();
+
+      child.stdout.setEncoding("utf-8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.setEncoding("utf-8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+        if (scaToken !== undefined) return;
+        stderrBuffer += chunk;
+        let nlIdx: number;
+        while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
+          const line = stderrBuffer.slice(0, nlIdx);
+          stderrBuffer = stderrBuffer.slice(nlIdx + 1);
+          if (scaToken !== undefined) continue;
+          const match = line.match(SCA_POLL_URL_RE);
+          if (match !== null && match[1] !== undefined) {
+            scaToken = match[1];
+            approvePromise = execFileAsync(
+              "node",
+              [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"],
+              { env: cliEnv(), timeout: 25_000 },
+            );
+          }
+        }
+      });
+
+      const exit = await new Promise<{ readonly code: number | null }>((resolve, reject) => {
+        child.on("error", reject);
+        child.on("close", (code) => {
+          resolve({ code });
+        });
+      });
+      // Wait for the mock-decision subprocess so its result (or rejection)
+      // is observable in the test's failure context.
+      await approvePromise;
+
+      if (scaToken !== undefined) {
+        // SCA-trigger path — the round-trip primitives (#450, #530) are
+        // exercised end-to-end. Documenting via console.log so the sandbox's
+        // empirical enforcement is visible without driving the test's
+        // pass/fail (the assertion is on the final transfer object).
+        console.log(
+          `[internal-transfer SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised. ` +
+            `This diverges from #463's api-key+production observation; sandbox SCA enforcement ` +
+            `for internal-transfer is endpoint-inconsistent (see audit Notable Finding #2 in #449).`,
+        );
+        expect(stderr).toMatch(SCA_POLL_URL_RE);
+      } else {
+        console.log(
+          `[internal-transfer SCA probe] NO SCA in OAuth+sandbox at amount=${String(TRANSFER_AMOUNT_EUR)} EUR ` +
+            `(consistent with #463's api-key+production observation at the same amount). ` +
+            `The SCA round-trip primitives stay exercised by sca-continuation/ for transfer_create.`,
+        );
+        expect(stderr).not.toMatch(SCA_POLL_URL_RE);
+      }
+
+      if (exit.code !== 0) {
+        throw new Error(
+          `internal-transfer create exited ${String(exit.code)}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`,
+        );
+      }
+      const transfer = InternalTransferSchema.parse(JSON.parse(stdout));
+      expect(transfer.id.length).toBeGreaterThan(0);
+      expect(transfer.slug.length).toBeGreaterThan(0);
+      expect(transfer.reference).toBe(reference);
+      expect(transfer.amount_currency).toBe("EUR");
+      expect(transfer.amount).toBe(TRANSFER_AMOUNT_EUR);
+      expect(transfer.amount_cents).toBe(TRANSFER_AMOUNT_EUR * 100);
+    });
+  },
+);

--- a/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/internal-transfers/mcp.e2e.test.ts
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { randomUUID } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { InternalTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_PENDING_TOKEN_RE } from "../sca-helpers.js";
 
 interface OrgBankAccount {
   readonly id: string;
@@ -69,11 +72,10 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", ()
     // production api-key endpoint): internal-transfer create succeeds without
     // triggering SCA at amount=1 EUR. #438's probe confirmed the same at
     // amount=1.50, and the prior local probe at amount=0.01 also succeeded.
-    // If a future test run starts returning the `executeWithMcpSca`
-    // SCA-pending fallback (a structured text response instead of the
-    // InternalTransfer JSON), coordinate with #449 Group 6 and adapt this
-    // test to the inline mock-decision orchestration pattern used by
-    // `bulk-transfers/mcp.e2e.test.ts`.
+    // The OAuth+sandbox path is now empirically probed by the
+    // `(OAuth+sandbox SCA probe)` describe block below — if a future run
+    // flips SCA enforcement on either path, that block surfaces the change
+    // explicitly without breaking the api-key happy path here.
     //
     // Precondition: the test organization must have ≥2 active internal
     // (Qonto-owned, non-aggregated) bank accounts. See cli.e2e.test.ts for
@@ -133,3 +135,134 @@ describe.skipIf(!hasApiKeyCredentials())("internal-transfer MCP tools (e2e)", ()
     });
   });
 });
+
+// OAuth+sandbox SCA probe — local-only (requires OAuth credentials AND a
+// staging token). Conditionally exercises the SCA round-trip via two-step
+// orchestration:
+//   - call `internal_transfer_create` with `wait: false`
+//   - if response is "SCA required" → mock-approve via `sca_session_mock_decision`,
+//     retry with `sca_session_token` set
+//   - if response is the InternalTransfer JSON directly → SCA was not required;
+//     assert that and document the observation
+// Documents the empirical truth via console.log; the pass/fail decision is on
+// the final InternalTransfer object.
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
+  "internal_transfer_create (OAuth+sandbox SCA probe)",
+  () => {
+    pinAuthPreference("oauth-first");
+
+    let probeClient: Client;
+    let probeTransport: StdioClientTransport;
+
+    beforeAll(async () => {
+      probeTransport = new StdioClientTransport({
+        command: "node",
+        args: [CLI_PATH, "mcp"],
+        env: cliEnv(),
+        stderr: "pipe",
+      });
+      probeClient = new Client({ name: "e2e-internal-sca-probe", version: "0.0.0" });
+      await probeClient.connect(probeTransport);
+    });
+
+    afterAll(async () => {
+      await probeClient.close();
+    });
+
+    // Local mirror of the api-key describe's helper; bound to `probeClient`
+    // (different MCP transport/scope than the outer block's `client`).
+    async function discoverInternalAccountsViaProbe(): Promise<readonly OrgBankAccount[]> {
+      const result = await probeClient.callTool({ name: "org_show", arguments: {} });
+      expect(result.isError).not.toBe(true);
+      const text = firstTextFromMcpResult(result);
+      const org = JSON.parse(text) as Organization;
+      return org.bank_accounts.filter((a) => !a.is_external_account && a.status === "active");
+    }
+
+    it("triggers SCA round-trip OR returns transfer directly in OAuth+sandbox", async () => {
+      const accounts = await discoverInternalAccountsViaProbe();
+      const TRANSFER_AMOUNT_EUR = 1;
+      const debit = accounts.find((a) => a.balance > TRANSFER_AMOUNT_EUR);
+      const credit = accounts.find((a) => a.id !== debit?.id);
+      if (debit === undefined || credit === undefined) {
+        console.warn(
+          `[e2e] internal_transfer_create SCA probe: skipping — requires ≥2 active internal Qonto bank ` +
+            `accounts with at least one funded above ${String(TRANSFER_AMOUNT_EUR)} EUR. ` +
+            `Found ${String(accounts.length)} internal account(s).`,
+        );
+        return;
+      }
+
+      const reference = `e2e-sca-mcp-${randomUUID().slice(0, 12)}`;
+      const baseArgs = {
+        debit_iban: debit.iban,
+        credit_iban: credit.iban,
+        reference,
+        amount: TRANSFER_AMOUNT_EUR,
+        currency: "EUR",
+      };
+
+      // wait: false → server returns SCA-pending immediately on 428, no inline
+      // polling. This is the canonical two-step pattern, mirroring
+      // `sca-continuation/mcp.e2e.test.ts:235`. PSD2 dynamic-linking requires
+      // the retry call to use identical args plus the captured token.
+      const firstResult = (await probeClient.callTool({
+        name: "internal_transfer_create",
+        arguments: { ...baseArgs, wait: false },
+      })) as CallToolResult;
+      const firstText = firstTextFromMcpResult(firstResult);
+
+      if (/^SCA required/.test(firstText)) {
+        // SCA-trigger path — exercise the round-trip.
+        console.log(
+          `[internal_transfer_create SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised. ` +
+            `This diverges from #463's api-key+production observation; sandbox SCA enforcement ` +
+            `for internal-transfer is endpoint-inconsistent (see audit Notable Finding #2 in #449).`,
+        );
+        const tokenMatch = firstText.match(SCA_PENDING_TOKEN_RE);
+        if (tokenMatch === null || tokenMatch[1] === undefined) {
+          throw new Error(`No "Session token: ..." line in SCA-pending response:\n${firstText}`);
+        }
+        const token = tokenMatch[1];
+        expect(token).not.toBe("unknown");
+        expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
+        const approveResult = (await probeClient.callTool({
+          name: "sca_session_mock_decision",
+          arguments: { token, decision: "allow" },
+        })) as CallToolResult;
+        if (approveResult.isError === true) {
+          throw new Error(`sca_session_mock_decision failed:\n${JSON.stringify(approveResult, null, 2)}`);
+        }
+
+        const retryResult = (await probeClient.callTool({
+          name: "internal_transfer_create",
+          arguments: { ...baseArgs, sca_session_token: token },
+        })) as CallToolResult;
+        expect(retryResult.isError).not.toBe(true);
+        const retryText = firstTextFromMcpResult(retryResult);
+        expect(retryText).not.toMatch(/^SCA required/);
+        const transfer = InternalTransferSchema.parse(JSON.parse(retryText));
+        expect(transfer.id.length).toBeGreaterThan(0);
+        expect(transfer.reference).toBe(reference);
+        expect(transfer.amount).toBe(TRANSFER_AMOUNT_EUR);
+        expect(transfer.amount_currency).toBe("EUR");
+        expect(transfer.amount_cents).toBe(TRANSFER_AMOUNT_EUR * 100);
+      } else {
+        // No-SCA path — the first call returned the transfer directly.
+        console.log(
+          `[internal_transfer_create SCA probe] NO SCA in OAuth+sandbox at amount=${String(TRANSFER_AMOUNT_EUR)} EUR ` +
+            `(consistent with #463's api-key+production observation at the same amount). ` +
+            `The SCA round-trip primitives stay exercised by sca-continuation/ for transfer_create.`,
+        );
+        expect(firstResult.isError).not.toBe(true);
+        const transfer = InternalTransferSchema.parse(JSON.parse(firstText));
+        expect(transfer.id.length).toBeGreaterThan(0);
+        expect(transfer.reference).toBe(reference);
+        expect(transfer.amount).toBe(TRANSFER_AMOUNT_EUR);
+        expect(transfer.amount_currency).toBe("EUR");
+        expect(transfer.amount_cents).toBe(TRANSFER_AMOUNT_EUR * 100);
+      }
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Closes #549 (sub A of #458 SCA-gated write paths).

Two-commit PR:

1. **`(fix)`** — Wrap CLI `internal-transfer create` with `executeWithCliSca`. The CLI was the only SCA-gated command in the 8 #458 sub-domains without a SCA wrap; the MCP tool was already correctly wrapped. Defensive fix matching the convention used by every other SCA-gated CLI command.
2. **`(test)`** — Add an OAuth+sandbox SCA probe describe block (CLI + MCP) that conditionally exercises either the SCA round-trip or the no-SCA happy path, depending on what the sandbox enforces at request time. Refutes audit Notable Finding #2 in #449 for `internal-transfer` (now empirically confirmed).

The api-key+production real-API exercise added by #463 is preserved unchanged. The new block is gated on `hasOAuthCredentials() && hasStagingToken()` → local-only.

## Empirical findings logged inline

```
[internal-transfer SCA probe] NO SCA in OAuth+sandbox at amount=1 EUR
(consistent with #463's api-key+production observation at the same amount).
The SCA round-trip primitives stay exercised by sca-continuation/ for transfer_create.
```

## Test plan

- [x] `pnpm build` — 5/5 successful
- [x] `pnpm lint` — clean across all packages
- [x] `pnpm test` — 84 files, 746 unit tests pass (incl. the 5 unit tests around `createInternalTransferCommand`)
- [x] `pnpm license-check` — 100 prod deps, all allowed
- [x] `pnpm test:e2e` (full suite, locally with OAuth+sandbox+staging-token) — 304 passed, 5 skipped, 1 test file skipped (fish completions). Both new SCA probe tests pass on first run.

## Audit alignment

See [audit refresh comment](https://github.com/alexey-pelykh/qontoctl/issues/458#issuecomment-4430156150) on #458 — this PR addresses sub A with the corrected scope (api-key path was already covered by #463; real gaps were the CLI wrap defect + OAuth+sandbox path probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)