### PR TITLE
(test) E2E: OAuth+sandbox SCA probe for intl-transfer create (#550)

### DIFF
--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -1,9 +1,30 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson } from "../helpers.js";
-import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
+import { CLI_PATH, cli, cliJson, cliRaw } from "../helpers.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_POLL_URL_RE } from "../sca-helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+interface IntlBeneficiary {
+  readonly id: string;
+  readonly name: string;
+  readonly currency: string;
+  readonly country: string;
+}
+
+interface IntlQuote {
+  readonly id: string;
+  readonly source_currency: string;
+  readonly target_currency: string;
+  readonly source_amount: number;
+  readonly target_amount: number;
+}
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -24,5 +45,172 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () =
       const parsed = JSON.parse(output) as Record<string, unknown>;
       expect(parsed).toHaveProperty("requirements");
     });
+  });
+});
+
+// OAuth+sandbox SCA probe for `intl-transfer create` — local-only (requires
+// OAuth credentials AND a staging token). Sibling to the requirements
+// describe; coexists because the create endpoint is SCA-gated whereas
+// requirements is read-only. Mirrors the structure of
+// `internal-transfers/cli.e2e.test.ts`'s SCA probe (#549).
+//
+// Setup chain (all OAuth, staging-token-routed):
+//   1. Discover an intl-beneficiary across PROBE_CURRENCIES.
+//   2. Create an intl-quote for the beneficiary's currency (small amount).
+//   3. Spawn `intl-transfer create` with --verbose so the SCA polling URL
+//      lands on stderr.
+//   4. Either: SCA triggers → capture token from stderr → approve via
+//      `sca-session mock-decision` → CLI's internal poller retries → assert
+//      transfer JSON on stdout. Or: SCA does NOT trigger → assert no SCA URL
+//      logged and the operation still returned a valid transfer.
+// Either outcome is documented via `console.log` so the empirical truth is
+// visible in CI / local runs without driving the test's pass/fail decision.
+//
+// Precondition: the test org must have ≥1 active intl-beneficiary in one
+// of PROBE_CURRENCIES. The sandbox org `0909-future-club-2702` ships with
+// zero on a fresh reset; #552's create_intl_beneficiary E2E provisions one
+// as a side effect, so running #552 before this test populates the corridor
+// and unblocks this assertion. When no beneficiary is available, the test
+// skips with a console warning rather than failing.
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("intl-transfer create (OAuth+sandbox SCA probe)", () => {
+  pinAuthPreference("oauth-first");
+
+  /**
+   * Sandbox-provisionable currencies probed in priority order when
+   * searching for an existing intl-beneficiary. The Qonto API requires
+   * `--currency` on `intl beneficiary list`, so we have to query each
+   * corridor explicitly.
+   */
+  const PROBE_CURRENCIES = ["USD", "GBP", "CHF", "CAD", "AUD", "JPY", "HKD", "SGD"];
+
+  function discoverIntlBeneficiary(): IntlBeneficiary | undefined {
+    for (const currency of PROBE_CURRENCIES) {
+      const result = cliRaw(["--output", "json", "intl", "beneficiary", "list", "--currency", currency]);
+      if (!result.ok) continue;
+      let list: IntlBeneficiary[];
+      try {
+        list = JSON.parse(result.stdout) as IntlBeneficiary[];
+      } catch {
+        continue;
+      }
+      if (list.length > 0 && list[0] !== undefined) return list[0];
+    }
+    return undefined;
+  }
+
+  it("triggers SCA round-trip OR completes without SCA in OAuth+sandbox", async () => {
+    const beneficiary = discoverIntlBeneficiary();
+    if (beneficiary === undefined) {
+      console.warn(
+        `[e2e] intl-transfer create SCA probe: skipping — no intl-beneficiary found across ` +
+          `[${PROBE_CURRENCIES.join(", ")}]. Provision one via #552's intl-beneficiary create flow ` +
+          `(or run \`qontoctl intl beneficiary create\` against an SCA-cleared sandbox) and rerun.`,
+      );
+      return;
+    }
+
+    // Create a fresh quote per test run — intl quotes are single-use and
+    // expire (their `expires_at` is short). A small `amount` keeps sandbox
+    // perturbation negligible regardless of FX rate; `direction: "send"`
+    // means the amount is what we pay in EUR (the org's home currency).
+    const quoteOutput = cli(
+      "--output",
+      "json",
+      "intl",
+      "quote",
+      "create",
+      "--currency",
+      beneficiary.currency,
+      "--amount",
+      "10",
+      "--direction",
+      "send",
+    );
+    const quote = JSON.parse(quoteOutput) as IntlQuote;
+    expect(quote.id.length).toBeGreaterThan(0);
+
+    const reference = `e2e-intl-sca-${randomUUID().slice(0, 12)}`;
+    const child = spawn(
+      "node",
+      [
+        CLI_PATH,
+        "--verbose",
+        "--output",
+        "json",
+        "intl-transfer",
+        "create",
+        "--beneficiary",
+        beneficiary.id,
+        "--quote",
+        quote.id,
+        "--field",
+        `reference=${reference}`,
+      ],
+      { env: cliEnv(), stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    let stdout = "";
+    let stderr = "";
+    let stderrBuffer = "";
+    let scaToken: string | undefined;
+    let approvePromise: Promise<unknown> = Promise.resolve();
+
+    child.stdout.setEncoding("utf-8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.setEncoding("utf-8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+      if (scaToken !== undefined) return;
+      stderrBuffer += chunk;
+      let nlIdx: number;
+      while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
+        const line = stderrBuffer.slice(0, nlIdx);
+        stderrBuffer = stderrBuffer.slice(nlIdx + 1);
+        if (scaToken !== undefined) continue;
+        const match = line.match(SCA_POLL_URL_RE);
+        if (match !== null && match[1] !== undefined) {
+          scaToken = match[1];
+          approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
+            env: cliEnv(),
+            timeout: 25_000,
+          });
+        }
+      }
+    });
+
+    const exit = await new Promise<{ readonly code: number | null }>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("close", (code) => {
+        resolve({ code });
+      });
+    });
+    // Wait for the mock-decision subprocess so its result (or rejection)
+    // is observable in the test's failure context.
+    await approvePromise;
+
+    if (scaToken !== undefined) {
+      console.log(
+        `[intl-transfer SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised. ` +
+          `Beneficiary currency: ${beneficiary.currency}.`,
+      );
+      expect(stderr).toMatch(SCA_POLL_URL_RE);
+    } else {
+      console.log(
+        `[intl-transfer SCA probe] NO SCA in OAuth+sandbox at amount=10 EUR send. ` +
+          `Beneficiary currency: ${beneficiary.currency}. ` +
+          `The SCA round-trip primitives stay exercised by sca-continuation/ for transfer_create.`,
+      );
+      expect(stderr).not.toMatch(SCA_POLL_URL_RE);
+    }
+
+    if (exit.code !== 0) {
+      throw new Error(
+        `intl-transfer create exited ${String(exit.code)}\n--- stderr ---\n${stderr}\n--- stdout ---\n${stdout}`,
+      );
+    }
+    const transfer = JSON.parse(stdout) as { id: string };
+    expect(transfer.id.length).toBeGreaterThan(0);
   });
 });

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -1,12 +1,26 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { randomUUID } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_PENDING_TOKEN_RE } from "../sca-helpers.js";
+
+interface IntlBeneficiary {
+  readonly id: string;
+  readonly name: string;
+  readonly currency: string;
+  readonly country: string;
+}
+
+interface IntlQuote {
+  readonly id: string;
+}
 
 describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
@@ -55,5 +69,149 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       IntlTransferRequirementsResponseSchema.parse(parsed);
     });
+  });
+});
+
+// OAuth+sandbox SCA probe for `intl_transfer_create` — local-only (requires
+// OAuth credentials AND a staging token). Two-step pattern: call with
+// `wait: false`, inspect response, conditionally branch on SCA-required
+// vs. direct success. Mirrors `internal-transfers/mcp.e2e.test.ts`'s
+// SCA probe (#549) — same conditional-outcome handling because empirical
+// SCA enforcement for `intl_transfer_create` is unknown.
+//
+// Precondition: ≥1 intl-beneficiary across PROBE_CURRENCIES (typically
+// provisioned by #552's create_intl_beneficiary E2E). Skips with a
+// console warning otherwise.
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("intl_transfer_create (OAuth+sandbox SCA probe)", () => {
+  pinAuthPreference("oauth-first");
+
+  const PROBE_CURRENCIES = ["USD", "GBP", "CHF", "CAD", "AUD", "JPY", "HKD", "SGD"];
+
+  let probeClient: Client;
+  let probeTransport: StdioClientTransport;
+
+  beforeAll(async () => {
+    probeTransport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      stderr: "pipe",
+    });
+    probeClient = new Client({ name: "e2e-intl-sca-probe", version: "0.0.0" });
+    await probeClient.connect(probeTransport);
+  });
+
+  afterAll(async () => {
+    await probeClient.close();
+  });
+
+  /**
+   * Discover an existing intl-beneficiary by probing each corridor in
+   * priority order. The MCP `intl_beneficiary_list` tool returns a
+   * shape of `{ international_beneficiaries: [...] }`; iterate
+   * currencies until we find one that yields a non-empty list.
+   */
+  async function discoverIntlBeneficiaryViaProbe(): Promise<IntlBeneficiary | undefined> {
+    for (const currency of PROBE_CURRENCIES) {
+      const result = await probeClient.callTool({
+        name: "intl_beneficiary_list",
+        arguments: { currency },
+      });
+      if (result.isError === true) continue;
+      let parsed: { international_beneficiaries: IntlBeneficiary[] };
+      try {
+        parsed = JSON.parse(firstTextFromMcpResult(result)) as {
+          international_beneficiaries: IntlBeneficiary[];
+        };
+      } catch {
+        continue;
+      }
+      if (parsed.international_beneficiaries.length > 0 && parsed.international_beneficiaries[0] !== undefined) {
+        return parsed.international_beneficiaries[0];
+      }
+    }
+    return undefined;
+  }
+
+  it("triggers SCA round-trip OR returns transfer directly in OAuth+sandbox", async () => {
+    const beneficiary = await discoverIntlBeneficiaryViaProbe();
+    if (beneficiary === undefined) {
+      console.warn(
+        `[e2e] intl_transfer_create SCA probe: skipping — no intl-beneficiary found across ` +
+          `[${PROBE_CURRENCIES.join(", ")}]. Provision one via #552's intl-beneficiary create flow ` +
+          `and rerun.`,
+      );
+      return;
+    }
+
+    // Create a fresh single-use quote matching the beneficiary's corridor.
+    const quoteResult = await probeClient.callTool({
+      name: "intl_quote_create",
+      arguments: {
+        currency: beneficiary.currency,
+        amount: 10,
+        direction: "send",
+      },
+    });
+    expect(quoteResult.isError).not.toBe(true);
+    const quote = JSON.parse(firstTextFromMcpResult(quoteResult)) as IntlQuote;
+    expect(quote.id.length).toBeGreaterThan(0);
+
+    const reference = `e2e-intl-sca-mcp-${randomUUID().slice(0, 12)}`;
+    const baseArgs = {
+      beneficiary_id: beneficiary.id,
+      quote_id: quote.id,
+      fields: { reference },
+    };
+
+    // wait: false → server returns SCA-pending immediately on 428, no
+    // inline polling. Canonical two-step pattern, mirroring
+    // `internal-transfers/mcp.e2e.test.ts` (#549).
+    const firstResult = (await probeClient.callTool({
+      name: "intl_transfer_create",
+      arguments: { ...baseArgs, wait: false },
+    })) as CallToolResult;
+    const firstText = firstTextFromMcpResult(firstResult);
+
+    if (/^SCA required/.test(firstText)) {
+      console.log(
+        `[intl_transfer_create SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised. ` +
+          `Beneficiary currency: ${beneficiary.currency}.`,
+      );
+      const tokenMatch = firstText.match(SCA_PENDING_TOKEN_RE);
+      if (tokenMatch === null || tokenMatch[1] === undefined) {
+        throw new Error(`No "Session token: ..." line in SCA-pending response:\n${firstText}`);
+      }
+      const token = tokenMatch[1];
+      expect(token).not.toBe("unknown");
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
+      const approveResult = (await probeClient.callTool({
+        name: "sca_session_mock_decision",
+        arguments: { token, decision: "allow" },
+      })) as CallToolResult;
+      if (approveResult.isError === true) {
+        throw new Error(`sca_session_mock_decision failed:\n${JSON.stringify(approveResult, null, 2)}`);
+      }
+
+      const retryResult = (await probeClient.callTool({
+        name: "intl_transfer_create",
+        arguments: { ...baseArgs, sca_session_token: token },
+      })) as CallToolResult;
+      expect(retryResult.isError).not.toBe(true);
+      const retryText = firstTextFromMcpResult(retryResult);
+      expect(retryText).not.toMatch(/^SCA required/);
+      const transfer = JSON.parse(retryText) as { id: string };
+      expect(transfer.id.length).toBeGreaterThan(0);
+    } else {
+      console.log(
+        `[intl_transfer_create SCA probe] NO SCA in OAuth+sandbox at amount=10 EUR send. ` +
+          `Beneficiary currency: ${beneficiary.currency}. ` +
+          `The SCA round-trip primitives stay exercised by sca-continuation/ for transfer_create.`,
+      );
+      expect(firstResult.isError).not.toBe(true);
+      const transfer = JSON.parse(firstText) as { id: string };
+      expect(transfer.id.length).toBeGreaterThan(0);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds CLI + MCP SCA E2E coverage for `intl-transfer create` / `intl_transfer_create`, structured to mirror #549's `internal-transfer create` probe.
- Gated on OAuth credentials + staging token; `pinAuthPreference("oauth-first")`.
- Discovers an existing intl-beneficiary across `PROBE_CURRENCIES`, creates a single-use intl-quote in the matching corridor, then exercises the SCA-gated create — handling both empirical outcomes (SCA triggered vs. not) via console.log.
- Skips with a clear console warning when no beneficiary is provisioned (current sandbox state on `0909-future-club-2702`), pointing to #552's create flow as the unblocker.
- No production code changes — CLI `intl-transfer/create.ts` and MCP `intl-transfer.ts` already wrap with `executeWithCliSca` / `executeWithMcpSca` per the #449 audit refresh.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [x] `pnpm prettier --check packages/e2e/src/intl-transfers/` — green
- [x] `pnpm license-check` — green
- [x] `pnpm test` — 746 unit tests pass
- [x] `pnpm test:e2e` (full suite, OAuth + sandbox + staging-token local) — 306 passed, 5 skipped; new SCA probe blocks skip with the documented "no intl-beneficiary" warning
- [ ] Re-run after #552 merges to verify the SCA round-trip exercises end-to-end on the populated corridor

Closes #550.
Refs #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)