### PR TITLE
(fix) wrap intl_beneficiary add/update/remove with executeWithMcpSca (#552)

### DIFF
--- a/packages/mcp/src/tools/intl-beneficiary.ts
+++ b/packages/mcp/src/tools/intl-beneficiary.ts
@@ -12,6 +12,7 @@ import {
   removeIntlBeneficiary,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerIntlBeneficiaryTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool(
@@ -73,7 +74,8 @@ export function registerIntlBeneficiaryTools(server: McpServer, getClient: () =>
   server.registerTool(
     "intl_beneficiary_add",
     {
-      description: "Create a new international beneficiary",
+      description:
+        "Create a new international beneficiary. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         country: z.string().describe("Country code (ISO 3166-1 alpha-2)"),
         currency: z.string().describe("Currency code (ISO 4217)"),
@@ -81,6 +83,7 @@ export function registerIntlBeneficiaryTools(server: McpServer, getClient: () =>
           .record(z.string(), z.unknown())
           .optional()
           .describe("Additional beneficiary fields as key-value pairs"),
+        ...scaContinuationSchema,
       },
     },
     async (args) =>
@@ -91,65 +94,63 @@ export function registerIntlBeneficiaryTools(server: McpServer, getClient: () =>
           ...(args.fields !== undefined ? args.fields : {}),
         };
 
-        const beneficiary = await createIntlBeneficiary(client, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(beneficiary, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) => createIntlBeneficiary(client, params, coreOptionsFromContext(context)),
+          (beneficiary) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "intl_beneficiary_update",
     {
-      description: "Update an international beneficiary",
+      description:
+        "Update an international beneficiary. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("International beneficiary ID (UUID)"),
         fields: z.record(z.string(), z.unknown()).describe("Fields to update as key-value pairs"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
-        const params: UpdateIntlBeneficiaryParams = { ...fields };
+        const params: UpdateIntlBeneficiaryParams = { ...args.fields };
 
-        const beneficiary = await updateIntlBeneficiary(client, id, params);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(beneficiary, null, 2),
-            },
-          ],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) => updateIntlBeneficiary(client, args.id, params, coreOptionsFromContext(context)),
+          (beneficiary) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(beneficiary, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "intl_beneficiary_remove",
     {
-      description: "Remove an international beneficiary",
+      description:
+        "Remove an international beneficiary. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("International beneficiary ID (UUID)"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        await removeIntlBeneficiary(client, id);
-
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify({ removed: true, id }, null, 2),
-            },
-          ],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) => removeIntlBeneficiary(client, args.id, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ removed: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 }


### PR DESCRIPTION
## Summary

- Fixes the `executeWithMcpSca` wrap defect on `intl_beneficiary_add`, `intl_beneficiary_update`, `intl_beneficiary_remove` (surfaced by #449 audit refresh).
- Matches the wrap pattern from `packages/mcp/src/tools/beneficiary.ts` (which already wraps all 4 of its SEPA write tools).
- Injects `...scaContinuationSchema` into each tool's `inputSchema` and wires the call through `executeWithMcpSca(client, op, formatter, scaOptionsFromArgs(args))`.
- SCA support is now surfaced in each tool's description (mirrors `beneficiary.ts`).

Without this fix, if SCA were to trigger on any of these 3 MCP calls, the tool would fail with an unhandled 428 instead of surfacing the SCA-pending response so the caller can continue via `sca_session_show` + `sca_session_token`.

## Scope narrowed

E2E lifecycle coverage (create → update → remove) was originally in #552's scope but is parked in #561 pending sandbox unblock. Empirical finding 2026-05-12:

- `POST /v2/international/beneficiaries` returns HTTP 500 in the Qonto sandbox for every payload variant
- Corridors probed: US/USD, GB/GBP, DE/EUR, CH/CHF, JP/JPY
- Field shapes probed: name-only, ACH-shape (name + account_number + aba), UK-shape (name + account_number + sort_code), empty
- All return `{\"errors\":[{\"code\":\"unknown\",\"detail\":\"Unknown error\"}]}` — no actionable hint

Rather than ship a tripwire or graceful-skip test that masks the gap, the lifecycle E2E is parked in #561 explicitly.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [x] `pnpm prettier --check` — green
- [x] `pnpm license-check` — green
- [x] `pnpm --filter @qontoctl/mcp test` — 366 unit tests pass (mocked-fetch insensitive to wrap; verified)
- [x] `pnpm test:e2e` (full suite, OAuth + sandbox + staging-token local) — 61 test files passed, 1 skipped; no regression
- [ ] Resume #561 once sandbox `POST /v2/international/beneficiaries` returns something other than 500

Closes #552.
Refs #458, #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)