### PR TITLE
(fix) wrap account_create/update/close with executeWithMcpSca (#553)

### DIFF
--- a/packages/mcp/src/tools/accounts.ts
+++ b/packages/mcp/src/tools/accounts.ts
@@ -13,6 +13,7 @@ import {
   closeBankAccount,
 } from "@qontoctl/core";
 import { withClient } from "../errors.js";
+import { coreOptionsFromContext, executeWithMcpSca, scaContinuationSchema, scaOptionsFromArgs } from "../sca.js";
 
 export function registerAccountTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
   server.registerTool("account_list", { description: "List all bank accounts for the organization" }, async () =>
@@ -70,59 +71,73 @@ export function registerAccountTools(server: McpServer, getClient: () => Promise
   server.registerTool(
     "account_create",
     {
-      description: "Create a new bank account",
+      description:
+        "Create a new bank account. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         name: z.string().describe("Account name"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ name }) =>
-      withClient(getClient, async (client) => {
-        const bankAccount = await createBankAccount(client, { name });
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(bankAccount, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) => createBankAccount(client, { name: args.name }, coreOptionsFromContext(context)),
+          (bankAccount) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(bankAccount, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 
   server.registerTool(
     "account_update",
     {
-      description: "Update an existing bank account",
+      description:
+        "Update an existing bank account. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Bank account UUID"),
         name: z.string().optional().describe("New account name"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id, ...fields }) =>
+    async (args) =>
       withClient(getClient, async (client) => {
         const body: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(fields)) {
-          if (value !== undefined) {
-            body[key] = value;
-          }
-        }
+        if (args.name !== undefined) body["name"] = args.name;
 
-        const bankAccount = await updateBankAccount(client, id, body);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify(bankAccount, null, 2) }],
-        };
+        return executeWithMcpSca(
+          client,
+          (context) => updateBankAccount(client, args.id, body, coreOptionsFromContext(context)),
+          (bankAccount) => ({
+            content: [{ type: "text" as const, text: JSON.stringify(bankAccount, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        );
       }),
   );
 
   server.registerTool(
     "account_close",
     {
-      description: "Close a bank account",
+      description:
+        "Close a bank account. SCA: this operation may require Strong Customer Authentication; the tool polls inline by default (wait=30s) and falls back to a structured pending response so the caller can continue via sca_session_show + sca_session_token.",
       inputSchema: {
         id: z.string().describe("Bank account UUID"),
+        ...scaContinuationSchema,
       },
     },
-    async ({ id }) =>
-      withClient(getClient, async (client) => {
-        await closeBankAccount(client, id);
-        return {
-          content: [{ type: "text" as const, text: JSON.stringify({ closed: true, id }, null, 2) }],
-        };
-      }),
+    async (args) =>
+      withClient(getClient, async (client) =>
+        executeWithMcpSca(
+          client,
+          (context) => closeBankAccount(client, args.id, coreOptionsFromContext(context)),
+          () => ({
+            content: [{ type: "text" as const, text: JSON.stringify({ closed: true, id: args.id }, null, 2) }],
+          }),
+          scaOptionsFromArgs(args),
+        ),
+      ),
   );
 }


### PR DESCRIPTION
## Summary

- Fixes the `executeWithMcpSca` wrap defect on `account_create`, `account_update`, `account_close` (surfaced by #449 audit refresh).
- Mirrors the wrap pattern from `packages/mcp/src/tools/beneficiary.ts` and `intl-beneficiary.ts` (post-#552).
- Injects `...scaContinuationSchema` into each tool's `inputSchema` and wires the call through `executeWithMcpSca(client, op, formatter, scaOptionsFromArgs(args))`.
- SCA support is now surfaced in each tool's description.

Without this fix, if SCA were to trigger on any of these 3 MCP calls, the tool would fail with an unhandled 428 instead of surfacing the SCA-pending response.

## Scope narrowed

E2E lifecycle coverage (create → update → close) was originally in #553's scope but is parked in #563 pending sandbox unblock. Empirical findings 2026-05-12 on `0909-future-club-2702`:

| Endpoint | Sandbox status |
|----------|----------------|
| `account create` | `400 bank_accounts_limit` (plan limit hit) |
| `account update` | `404 not_found` on `PUT /v2/bank_accounts/{id}` for BOTH pre-existing accounts (main \"Hauptkonto\" + non-main \"asdfasdf\") |
| `account close` | Cannot exercise without a freshly-created account (plan limit blocks recreation; closing existing accounts is destructive) |

Rather than ship graceful-skip tests or a placeholder, all 3 E2E paths are deferred to #563 with a documented blocker list. The MCP wrap fix in this PR is the load-bearing production-relevant change.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [x] `pnpm prettier --check` — green
- [x] `pnpm license-check` — green
- [x] `pnpm --filter @qontoctl/mcp test` — 366 unit tests pass
- [x] `pnpm test:e2e` (full suite, OAuth + sandbox + staging-token local) — 61 test files passed, 1 skipped; no regression
- [ ] Resume #563 once sandbox supports bank-account create OR update

Closes #553.
Refs #458, #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)