### PR TITLE
(test) E2E for transfer SCA write paths + audit AC #4 (#554)

### DIFF
--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson } from "../helpers.js";
-import { hasApiKeyCredentials } from "../sandbox.js";
+import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { approveAndRetryCli, SCA_POLL_URL_RE, triggerScaCli } from "../sca-helpers.js";
+
+const execFileAsync = promisify(execFile);
 
 interface TransferItem {
   readonly id: string;
@@ -17,6 +26,35 @@ interface TransferItem {
   readonly note: string | null;
   readonly scheduled_date: string;
   readonly bank_account_id: string;
+}
+
+interface BeneficiaryListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly trusted: boolean;
+}
+
+interface BankAccountItem {
+  readonly id: string;
+  readonly main: boolean;
+  readonly balance_cents: number;
+}
+
+interface VopResultLite {
+  readonly match_result: string;
+  readonly matched_name: string | null;
+  readonly proof_token: { readonly token: string };
+}
+
+interface BulkVopResultsLite {
+  readonly requests: ReadonlyArray<{
+    readonly id: string;
+    readonly response?: VopResultLite;
+    readonly error?: { readonly code: string };
+  }>;
+  readonly proof_token: { readonly token: string };
 }
 
 function firstTransfer(transfers: readonly TransferItem[]): TransferItem | undefined {
@@ -107,3 +145,299 @@ describe.skipIf(!hasApiKeyCredentials())("transfer CLI commands (e2e)", () => {
     });
   });
 });
+
+// =============================================================================
+// Non-SCA OAuth paths: verify-payee / bulk-verify-payee
+// =============================================================================
+//
+// `verifyPayee` and `bulkVerifyPayee` are NOT SCA-gated under PSD2 — the
+// endpoints respond 200 directly, never 428. CLI commands wrap with
+// `executeWithCliSca` defensively (consistent with the rest of the transfer
+// surface), but the wrap is a no-op since the API never challenges. The
+// audit refresh for #458 confirmed this against the SCA-gated endpoint
+// matrix; #449's original audit incorrectly flagged these as SCA-gated.
+//
+// `getTransferProof` is intentionally NOT covered in this block — see
+// note below the SCA-gated block.
+
+describe.skipIf(!hasOAuthCredentials())("transfer CLI commands (e2e, non-SCA OAuth paths)", () => {
+  pinAuthPreference("oauth-first");
+
+  describe("transfer verify-payee", () => {
+    it("returns a VoP proof token for an existing beneficiary", () => {
+      // VoP is a verification query — not state-changing on Qonto's side —
+      // and is NOT SCA-gated. Its output `proof_token` binds the SCA token
+      // of a subsequent `transfer create` per PSD2 dynamic-linking
+      // (RTS Art. 5, `docs/security/sca-token-binding.md`); that binding
+      // semantic is exercised end-to-end by
+      // `packages/e2e/src/sca-continuation/cli.e2e.test.ts`. This test
+      // covers only the proof-token shape from a standalone VoP call.
+      const beneficiaries = cliJson<BeneficiaryListItem[]>("beneficiary", "list");
+      const beneficiary = beneficiaries[0];
+      if (beneficiary === undefined) {
+        throw new Error("E2E setup: no beneficiaries in sandbox");
+      }
+
+      const result = cliJson<VopResultLite>(
+        "transfer",
+        "verify-payee",
+        "--iban",
+        beneficiary.iban,
+        "--name",
+        beneficiary.name,
+      );
+      // Qonto VoP proof tokens are pipe-delimited composites
+      // (`version|attempt|epoch-ms|base64url-signature`) — they are NOT
+      // bare base64url, so we assert only non-emptiness and a sanity
+      // shape that excludes whitespace.
+      expect(result.proof_token.token.length).toBeGreaterThan(0);
+      expect(result.proof_token.token).toMatch(/^\S+$/);
+      expect(typeof result.match_result).toBe("string");
+    });
+  });
+
+  describe("transfer bulk-verify-payee", () => {
+    it("returns proof token and per-entry results for a CSV batch", () => {
+      const beneficiaries = cliJson<BeneficiaryListItem[]>("beneficiary", "list");
+      const sample = beneficiaries.slice(0, 2);
+      if (sample.length === 0) {
+        throw new Error("E2E setup: no beneficiaries in sandbox");
+      }
+
+      const csv = ["iban,name", ...sample.map((b) => `${b.iban},${b.name}`)].join("\n");
+      const csvDir = mkdtempSync(join(tmpdir(), "qontoctl-bulk-vop-e2e-"));
+      const csvPath = join(csvDir, "entries.csv");
+      try {
+        writeFileSync(csvPath, csv, "utf-8");
+        const result = cliJson<BulkVopResultsLite>("transfer", "bulk-verify-payee", "--file", csvPath);
+        expect(result.proof_token.token.length).toBeGreaterThan(0);
+        expect(result.proof_token.token).toMatch(/^\S+$/);
+        expect(result.requests.length).toBe(sample.length);
+        // Bulk VoP, like single VoP, is NOT SCA-gated.
+      } finally {
+        rmSync(csvDir, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+// =============================================================================
+// `transfer cancel` (with conditional-SCA outcome)
+// =============================================================================
+//
+// `cancelTransfer` (POST /v2/sepa/transfers/{id}/cancel) was originally
+// audited as SCA-gated, and the CLI / MCP code defensively wraps it with
+// `executeWithCliSca` / `executeWithMcpSca`. Empirical probe against the
+// Qonto sandbox (2026-05-12) shows the endpoint returns `204 No Content`
+// DIRECTLY without any 428 challenge — i.e., the wrap is effectively a
+// no-op for this endpoint in sandbox.
+//
+// This test uses the conditional-outcome pattern established in #549–#553:
+// the create call (which IS reliably SCA-gated) runs through the standard
+// `triggerScaCli` + `approveAndRetryCli` round-trip; the cancel call is
+// run via a spawned-CLI probe that tolerates either path (SCA triggers, or
+// direct success). If sandbox behavior shifts to start SCA-gating cancel,
+// the test still passes and starts asserting on the polling URL.
+//
+// `createTransfer` is already covered with three variants by
+// `packages/e2e/src/sca-continuation/cli.e2e.test.ts` (wait=false / wait=5 /
+// wait=10). The create here is setup-for-cancel, not the operation under
+// test.
+//
+// AUDIT AC #4 (#458, originally Notable Finding #2 in #449):
+// "bulk-transfers and recurring-transfers create paths complete without SCA
+// in sandbox" — REFUTED by existing tests:
+//   - packages/e2e/src/bulk-transfers/cli.e2e.test.ts L71 (sandbox SCA)
+//   - packages/e2e/src/recurring-transfers/cli.e2e.test.ts L180 (sandbox SCA)
+//   - packages/e2e/src/recurring-transfers/cli.e2e.test.ts L232 (sandbox SCA)
+// The original audit was wrong; no new probe is required for AC #4.
+
+interface SpawnedCliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+  readonly scaTriggered: boolean;
+}
+
+/**
+ * Spawn a CLI command that MAY or MAY NOT trigger SCA — watch stderr for the
+ * polling URL and, if seen, mock-approve the captured token; otherwise let
+ * the command exit on its own. Mirrors the conditional-SCA helper from
+ * `packages/e2e/src/beneficiaries/cli.e2e.test.ts` (#551) and is necessary
+ * because empirical sandbox enforcement varies per endpoint.
+ */
+async function runWithConditionalSca(args: readonly string[]): Promise<SpawnedCliResult> {
+  const child = spawn("node", [CLI_PATH, "--verbose", "--output", "json", ...args], {
+    env: cliEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let stderrBuffer = "";
+  let scaToken: string | undefined;
+  let approvePromise: Promise<unknown> = Promise.resolve();
+
+  child.stdout.setEncoding("utf-8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.setEncoding("utf-8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+    if (scaToken !== undefined) return;
+    stderrBuffer += chunk;
+    let nlIdx: number;
+    while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
+      const line = stderrBuffer.slice(0, nlIdx);
+      stderrBuffer = stderrBuffer.slice(nlIdx + 1);
+      if (scaToken !== undefined) continue;
+      const match = line.match(SCA_POLL_URL_RE);
+      if (match !== null && match[1] !== undefined) {
+        scaToken = match[1];
+        approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
+          env: cliEnv(),
+          timeout: 25_000,
+        });
+      }
+    }
+  });
+
+  const exit = await new Promise<{ readonly code: number | null }>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code });
+    });
+  });
+  await approvePromise;
+
+  return {
+    stdout,
+    stderr,
+    exitCode: exit.code,
+    scaTriggered: scaToken !== undefined,
+  };
+}
+
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
+  "transfer CLI commands (e2e, SCA write paths)",
+  () => {
+    pinAuthPreference("oauth-first");
+
+    it("transfer cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
+      const beneficiaries = cliJson<BeneficiaryListItem[]>("beneficiary", "list");
+      // PSD2 Article 13(b) trusted-beneficiary exemption — pick a non-trusted
+      // beneficiary so the create call actually triggers SCA. Prefer
+      // `validated && !trusted`; fall back to any non-trusted entry (typically
+      // `pending`, whose first-use validation challenge exercises the same
+      // client polling/retry code path). Same rationale as
+      // `sca-continuation/cli.e2e.test.ts`.
+      const beneficiary =
+        beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
+        beneficiaries.find((b) => !b.trusted);
+      if (beneficiary === undefined) {
+        throw new Error(
+          "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA on transfer create",
+        );
+      }
+
+      const accounts = cliJson<BankAccountItem[]>("account", "list");
+      // `main: true` account avoids `400 insufficient_funds` on the post-SCA
+      // retry; fall back to highest-balance for defensive sandbox-config drift.
+      const account =
+        accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+      if (account === undefined) {
+        throw new Error("E2E setup: no bank accounts in sandbox");
+      }
+
+      // Pre-resolve VoP outside the SCA flow so the per-test budget isn't
+      // burned on a separate verify-payee call inside the SCA polling window.
+      const vop = cliJson<VopResultLite>(
+        "transfer",
+        "verify-payee",
+        "--iban",
+        beneficiary.iban,
+        "--name",
+        beneficiary.name,
+      );
+      const vopProofToken = vop.proof_token.token;
+
+      // Schedule the transfer ~3 days into the future so it stays in
+      // `pending` status and is cancellable. Without this, the sandbox
+      // moves a freshly-created same-day transfer past the `pending` state
+      // before the cancel SCA round-trip completes, and cancel returns
+      // `400 cannot_cancel`. The 3-day buffer is generous against any
+      // weekend / sandbox clock-skew.
+      const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+
+      // ---- Round-trip #1: create the transfer to cancel -------------------
+      const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
+      const createTrigger = await triggerScaCli([
+        "--output",
+        "json",
+        "transfer",
+        "create",
+        "--beneficiary",
+        beneficiary.id,
+        "--debit-account",
+        account.id,
+        "--reference",
+        reference,
+        "--amount",
+        "1.50",
+        "--scheduled-date",
+        scheduledDate,
+        "--vop-proof-token",
+        vopProofToken,
+      ]);
+      expect(createTrigger.scaSessionToken).not.toBe("unknown");
+      expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+      const createExit = await approveAndRetryCli(createTrigger, "allow");
+      if (createExit.exitCode !== 0) {
+        throw new Error(
+          `transfer create exited ${String(createExit.exitCode)}\n--- stderr ---\n${createExit.stderr}\n--- stdout ---\n${createExit.stdout}`,
+        );
+      }
+      const transfer = JSON.parse(createExit.stdout) as { readonly id: string };
+      expect(transfer.id.length).toBeGreaterThan(0);
+
+      // ---- Round-trip #2 (conditional): cancel the transfer ---------------
+      // Cancel MAY trigger SCA (audit assumption) or MAY return 204 directly
+      // (empirical sandbox behavior, 2026-05-12). The conditional helper
+      // mock-approves if SCA fires and lets the command exit otherwise.
+      const cancelResult = await runWithConditionalSca(["transfer", "cancel", transfer.id, "--yes"]);
+
+      if (cancelResult.scaTriggered) {
+        console.log(`[transfer cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
+        expect(cancelResult.stderr).toMatch(SCA_POLL_URL_RE);
+      } else {
+        console.log(`[transfer cancel SCA probe] NO SCA in OAuth+sandbox for transfer cancel.`);
+        expect(cancelResult.stderr).not.toMatch(SCA_POLL_URL_RE);
+      }
+
+      if (cancelResult.exitCode !== 0) {
+        throw new Error(
+          `transfer cancel exited ${String(cancelResult.exitCode)}\n--- stderr ---\n${cancelResult.stderr}\n--- stdout ---\n${cancelResult.stdout}`,
+        );
+      }
+      // Wire-log evidence the cancel POST landed regardless of SCA path.
+      expect(cancelResult.stderr).toMatch(/POST .*\/v2\/sepa\/transfers\/[^/]+\/cancel/);
+      const cancelJson = JSON.parse(cancelResult.stdout) as {
+        readonly canceled?: boolean;
+        readonly id?: string;
+      };
+      expect(cancelJson.canceled).toBe(true);
+      expect(cancelJson.id).toBe(transfer.id);
+    });
+  },
+);
+
+// NOTE: `getTransferProof` (CLI: `transfer proof`, MCP: `transfer_proof`)
+// E2E coverage is deferred. Empirical probe against Qonto sandbox org
+// `0909-future-club-2702` on 2026-05-12: `GET /v2/sepa/transfers/{id}/proof`
+// returns `404 not_found` for ALL 10 most-recent `status: settled`
+// transfers. The proof PDF is reliably generated post-settlement in
+// production but the sandbox simulator does not produce it. The CLI and
+// MCP code paths are confirmed correct by code inspection and the audit
+// refresh — both delegate to `getTransferProof` → `client.getBuffer`,
+// which is not SCA-gated. Tracked as a follow-up to #554.

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -319,118 +319,113 @@ async function runWithConditionalSca(args: readonly string[]): Promise<SpawnedCl
   };
 }
 
-describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
-  "transfer CLI commands (e2e, SCA write paths)",
-  () => {
-    pinAuthPreference("oauth-first");
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("transfer CLI commands (e2e, SCA write paths)", () => {
+  pinAuthPreference("oauth-first");
 
-    it("transfer cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
-      const beneficiaries = cliJson<BeneficiaryListItem[]>("beneficiary", "list");
-      // PSD2 Article 13(b) trusted-beneficiary exemption — pick a non-trusted
-      // beneficiary so the create call actually triggers SCA. Prefer
-      // `validated && !trusted`; fall back to any non-trusted entry (typically
-      // `pending`, whose first-use validation challenge exercises the same
-      // client polling/retry code path). Same rationale as
-      // `sca-continuation/cli.e2e.test.ts`.
-      const beneficiary =
-        beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
-        beneficiaries.find((b) => !b.trusted);
-      if (beneficiary === undefined) {
-        throw new Error(
-          "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA on transfer create",
-        );
-      }
-
-      const accounts = cliJson<BankAccountItem[]>("account", "list");
-      // `main: true` account avoids `400 insufficient_funds` on the post-SCA
-      // retry; fall back to highest-balance for defensive sandbox-config drift.
-      const account =
-        accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
-      if (account === undefined) {
-        throw new Error("E2E setup: no bank accounts in sandbox");
-      }
-
-      // Pre-resolve VoP outside the SCA flow so the per-test budget isn't
-      // burned on a separate verify-payee call inside the SCA polling window.
-      const vop = cliJson<VopResultLite>(
-        "transfer",
-        "verify-payee",
-        "--iban",
-        beneficiary.iban,
-        "--name",
-        beneficiary.name,
+  it("transfer cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
+    const beneficiaries = cliJson<BeneficiaryListItem[]>("beneficiary", "list");
+    // PSD2 Article 13(b) trusted-beneficiary exemption — pick a non-trusted
+    // beneficiary so the create call actually triggers SCA. Prefer
+    // `validated && !trusted`; fall back to any non-trusted entry (typically
+    // `pending`, whose first-use validation challenge exercises the same
+    // client polling/retry code path). Same rationale as
+    // `sca-continuation/cli.e2e.test.ts`.
+    const beneficiary =
+      beneficiaries.find((b) => b.status === "validated" && !b.trusted) ?? beneficiaries.find((b) => !b.trusted);
+    if (beneficiary === undefined) {
+      throw new Error(
+        "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA on transfer create",
       );
-      const vopProofToken = vop.proof_token.token;
+    }
 
-      // Schedule the transfer ~3 days into the future so it stays in
-      // `pending` status and is cancellable. Without this, the sandbox
-      // moves a freshly-created same-day transfer past the `pending` state
-      // before the cancel SCA round-trip completes, and cancel returns
-      // `400 cannot_cancel`. The 3-day buffer is generous against any
-      // weekend / sandbox clock-skew.
-      const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+    const accounts = cliJson<BankAccountItem[]>("account", "list");
+    // `main: true` account avoids `400 insufficient_funds` on the post-SCA
+    // retry; fall back to highest-balance for defensive sandbox-config drift.
+    const account = accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    if (account === undefined) {
+      throw new Error("E2E setup: no bank accounts in sandbox");
+    }
 
-      // ---- Round-trip #1: create the transfer to cancel -------------------
-      const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
-      const createTrigger = await triggerScaCli([
-        "--output",
-        "json",
-        "transfer",
-        "create",
-        "--beneficiary",
-        beneficiary.id,
-        "--debit-account",
-        account.id,
-        "--reference",
-        reference,
-        "--amount",
-        "1.50",
-        "--scheduled-date",
-        scheduledDate,
-        "--vop-proof-token",
-        vopProofToken,
-      ]);
-      expect(createTrigger.scaSessionToken).not.toBe("unknown");
-      expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
-      const createExit = await approveAndRetryCli(createTrigger, "allow");
-      if (createExit.exitCode !== 0) {
-        throw new Error(
-          `transfer create exited ${String(createExit.exitCode)}\n--- stderr ---\n${createExit.stderr}\n--- stdout ---\n${createExit.stdout}`,
-        );
-      }
-      const transfer = JSON.parse(createExit.stdout) as { readonly id: string };
-      expect(transfer.id.length).toBeGreaterThan(0);
+    // Pre-resolve VoP outside the SCA flow so the per-test budget isn't
+    // burned on a separate verify-payee call inside the SCA polling window.
+    const vop = cliJson<VopResultLite>(
+      "transfer",
+      "verify-payee",
+      "--iban",
+      beneficiary.iban,
+      "--name",
+      beneficiary.name,
+    );
+    const vopProofToken = vop.proof_token.token;
 
-      // ---- Round-trip #2 (conditional): cancel the transfer ---------------
-      // Cancel MAY trigger SCA (audit assumption) or MAY return 204 directly
-      // (empirical sandbox behavior, 2026-05-12). The conditional helper
-      // mock-approves if SCA fires and lets the command exit otherwise.
-      const cancelResult = await runWithConditionalSca(["transfer", "cancel", transfer.id, "--yes"]);
+    // Schedule the transfer ~3 days into the future so it stays in
+    // `pending` status and is cancellable. Without this, the sandbox
+    // moves a freshly-created same-day transfer past the `pending` state
+    // before the cancel SCA round-trip completes, and cancel returns
+    // `400 cannot_cancel`. The 3-day buffer is generous against any
+    // weekend / sandbox clock-skew.
+    const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
 
-      if (cancelResult.scaTriggered) {
-        console.log(`[transfer cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
-        expect(cancelResult.stderr).toMatch(SCA_POLL_URL_RE);
-      } else {
-        console.log(`[transfer cancel SCA probe] NO SCA in OAuth+sandbox for transfer cancel.`);
-        expect(cancelResult.stderr).not.toMatch(SCA_POLL_URL_RE);
-      }
+    // ---- Round-trip #1: create the transfer to cancel -------------------
+    const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
+    const createTrigger = await triggerScaCli([
+      "--output",
+      "json",
+      "transfer",
+      "create",
+      "--beneficiary",
+      beneficiary.id,
+      "--debit-account",
+      account.id,
+      "--reference",
+      reference,
+      "--amount",
+      "1.50",
+      "--scheduled-date",
+      scheduledDate,
+      "--vop-proof-token",
+      vopProofToken,
+    ]);
+    expect(createTrigger.scaSessionToken).not.toBe("unknown");
+    expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    const createExit = await approveAndRetryCli(createTrigger, "allow");
+    if (createExit.exitCode !== 0) {
+      throw new Error(
+        `transfer create exited ${String(createExit.exitCode)}\n--- stderr ---\n${createExit.stderr}\n--- stdout ---\n${createExit.stdout}`,
+      );
+    }
+    const transfer = JSON.parse(createExit.stdout) as { readonly id: string };
+    expect(transfer.id.length).toBeGreaterThan(0);
 
-      if (cancelResult.exitCode !== 0) {
-        throw new Error(
-          `transfer cancel exited ${String(cancelResult.exitCode)}\n--- stderr ---\n${cancelResult.stderr}\n--- stdout ---\n${cancelResult.stdout}`,
-        );
-      }
-      // Wire-log evidence the cancel POST landed regardless of SCA path.
-      expect(cancelResult.stderr).toMatch(/POST .*\/v2\/sepa\/transfers\/[^/]+\/cancel/);
-      const cancelJson = JSON.parse(cancelResult.stdout) as {
-        readonly canceled?: boolean;
-        readonly id?: string;
-      };
-      expect(cancelJson.canceled).toBe(true);
-      expect(cancelJson.id).toBe(transfer.id);
-    });
-  },
-);
+    // ---- Round-trip #2 (conditional): cancel the transfer ---------------
+    // Cancel MAY trigger SCA (audit assumption) or MAY return 204 directly
+    // (empirical sandbox behavior, 2026-05-12). The conditional helper
+    // mock-approves if SCA fires and lets the command exit otherwise.
+    const cancelResult = await runWithConditionalSca(["transfer", "cancel", transfer.id, "--yes"]);
+
+    if (cancelResult.scaTriggered) {
+      console.log(`[transfer cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
+      expect(cancelResult.stderr).toMatch(SCA_POLL_URL_RE);
+    } else {
+      console.log(`[transfer cancel SCA probe] NO SCA in OAuth+sandbox for transfer cancel.`);
+      expect(cancelResult.stderr).not.toMatch(SCA_POLL_URL_RE);
+    }
+
+    if (cancelResult.exitCode !== 0) {
+      throw new Error(
+        `transfer cancel exited ${String(cancelResult.exitCode)}\n--- stderr ---\n${cancelResult.stderr}\n--- stdout ---\n${cancelResult.stdout}`,
+      );
+    }
+    // Wire-log evidence the cancel POST landed regardless of SCA path.
+    expect(cancelResult.stderr).toMatch(/POST .*\/v2\/sepa\/transfers\/[^/]+\/cancel/);
+    const cancelJson = JSON.parse(cancelResult.stdout) as {
+      readonly canceled?: boolean;
+      readonly id?: string;
+    };
+    expect(cancelJson.canceled).toBe(true);
+    expect(cancelJson.id).toBe(transfer.id);
+  });
+});
 
 // NOTE: `getTransferProof` (CLI: `transfer proof`, MCP: `transfer_proof`)
 // E2E coverage is deferred. Empirical probe against Qonto sandbox org

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -302,128 +302,124 @@ async function callWithConditionalSca(
   return { result: firstResult, scaTriggered: false };
 }
 
-describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
-  "transfer MCP tools (e2e, SCA write paths)",
-  () => {
-    pinAuthPreference("oauth-first");
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("transfer MCP tools (e2e, SCA write paths)", () => {
+  pinAuthPreference("oauth-first");
 
-    let client: Client;
-    let transport: StdioClientTransport;
-    let beneficiaryId: string;
-    let bankAccountId: string;
-    let vopProofToken: string;
+  let client: Client;
+  let transport: StdioClientTransport;
+  let beneficiaryId: string;
+  let bankAccountId: string;
+  let vopProofToken: string;
 
-    beforeAll(async () => {
-      transport = new StdioClientTransport({
-        command: "node",
-        args: [CLI_PATH, "mcp"],
-        env: cliEnv({ authPreference: "oauth-first" }),
-        stderr: "pipe",
-      });
-      client = new Client({ name: "e2e-transfer-sca", version: "0.0.0" });
-      await client.connect(transport);
-
-      // Pick a non-trusted beneficiary so create actually triggers SCA
-      // (PSD2 Art. 13(b) trusted-beneficiary exemption). Pick `main: true`
-      // account to avoid `400 insufficient_funds` on post-SCA retry. Both
-      // selections follow `sca-continuation/mcp.e2e.test.ts`.
-      const benResult = await client.callTool({
-        name: "beneficiary_list",
-        arguments: {},
-      });
-      const benList = JSON.parse(firstTextFromMcpResult(benResult)) as { beneficiaries: BeneficiaryListItem[] };
-      const beneficiary =
-        benList.beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
-        benList.beneficiaries.find((b) => !b.trusted);
-      if (beneficiary === undefined) {
-        throw new Error(
-          "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA",
-        );
-      }
-      beneficiaryId = beneficiary.id;
-
-      const accountsResult = await client.callTool({
-        name: "account_list",
-        arguments: {},
-      });
-      const accounts = JSON.parse(firstTextFromMcpResult(accountsResult)) as BankAccountItem[];
-      const account =
-        accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
-      if (account === undefined) {
-        throw new Error("E2E setup: no bank accounts in sandbox");
-      }
-      bankAccountId = account.id;
-
-      const vopResult = await client.callTool({
-        name: "transfer_verify_payee",
-        arguments: { iban: beneficiary.iban, name: beneficiary.name },
-      });
-      const vop = JSON.parse(firstTextFromMcpResult(vopResult)) as VopResultLite;
-      vopProofToken = vop.proof_token.token;
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv({ authPreference: "oauth-first" }),
+      stderr: "pipe",
     });
+    client = new Client({ name: "e2e-transfer-sca", version: "0.0.0" });
+    await client.connect(transport);
 
-    afterAll(async () => {
-      await client.close();
+    // Pick a non-trusted beneficiary so create actually triggers SCA
+    // (PSD2 Art. 13(b) trusted-beneficiary exemption). Pick `main: true`
+    // account to avoid `400 insufficient_funds` on post-SCA retry. Both
+    // selections follow `sca-continuation/mcp.e2e.test.ts`.
+    const benResult = await client.callTool({
+      name: "beneficiary_list",
+      arguments: {},
     });
-
-    it("transfer_cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
-      // Schedule the transfer ~3 days into the future so it stays in
-      // `pending` status long enough for the cancel SCA round-trip to land.
-      // Without this, the sandbox moves a same-day transfer past `pending`
-      // and cancel returns `400 cannot_cancel`. See CLI counterpart for
-      // the canonical rationale.
-      const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
-
-      // ---- Round-trip #1: create the transfer to cancel ------------------
-      const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
-      const createArgs = {
-        beneficiary_id: beneficiaryId,
-        bank_account_id: bankAccountId,
-        reference,
-        amount: 1.5,
-        scheduled_date: scheduledDate,
-        vop_proof_token: vopProofToken,
-      };
-
-      const createTrigger = await triggerScaMcp(client, "transfer_create", createArgs);
-      expect(createTrigger.scaSessionToken).not.toBe("unknown");
-      expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
-      expect(createTrigger.pendingText).toContain("sca_session_show");
-      expect(createTrigger.pendingText).toContain("sca_session_token");
-
-      const createRetry = await approveAndRetryMcp(createTrigger, "allow");
-      expect(createRetry.isError).not.toBe(true);
-      const createText = firstTextFromMcpResult(createRetry);
-      expect(createText).not.toMatch(/^SCA required/);
-      const transfer = JSON.parse(createText) as { readonly id: string };
-      TransferSchema.parse(JSON.parse(createText));
-      expect(transfer.id.length).toBeGreaterThan(0);
-
-      // ---- Round-trip #2 (conditional): cancel the transfer --------------
-      // The cancel endpoint is empirically NOT SCA-gated in sandbox — the
-      // helper handles both paths so the test remains correct if Qonto
-      // shifts behavior to start enforcing SCA on cancel.
-      const { result: cancelRetry, scaTriggered: cancelScaTriggered } = await callWithConditionalSca(
-        client,
-        "transfer_cancel",
-        { id: transfer.id },
+    const benList = JSON.parse(firstTextFromMcpResult(benResult)) as { beneficiaries: BeneficiaryListItem[] };
+    const beneficiary =
+      benList.beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
+      benList.beneficiaries.find((b) => !b.trusted);
+    if (beneficiary === undefined) {
+      throw new Error(
+        "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA",
       );
+    }
+    beneficiaryId = beneficiary.id;
 
-      if (cancelScaTriggered) {
-        console.log(`[transfer_cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
-      } else {
-        console.log(`[transfer_cancel SCA probe] NO SCA in OAuth+sandbox for transfer_cancel.`);
-      }
-
-      expect(cancelRetry.isError).not.toBe(true);
-      const cancelText = firstTextFromMcpResult(cancelRetry);
-      expect(cancelText).not.toMatch(/^SCA required/);
-      const cancelResult = JSON.parse(cancelText) as { readonly canceled?: boolean; readonly id?: string };
-      expect(cancelResult.canceled).toBe(true);
-      expect(cancelResult.id).toBe(transfer.id);
+    const accountsResult = await client.callTool({
+      name: "account_list",
+      arguments: {},
     });
-  },
-);
+    const accounts = JSON.parse(firstTextFromMcpResult(accountsResult)) as BankAccountItem[];
+    const account = accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+    if (account === undefined) {
+      throw new Error("E2E setup: no bank accounts in sandbox");
+    }
+    bankAccountId = account.id;
+
+    const vopResult = await client.callTool({
+      name: "transfer_verify_payee",
+      arguments: { iban: beneficiary.iban, name: beneficiary.name },
+    });
+    const vop = JSON.parse(firstTextFromMcpResult(vopResult)) as VopResultLite;
+    vopProofToken = vop.proof_token.token;
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it("transfer_cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
+    // Schedule the transfer ~3 days into the future so it stays in
+    // `pending` status long enough for the cancel SCA round-trip to land.
+    // Without this, the sandbox moves a same-day transfer past `pending`
+    // and cancel returns `400 cannot_cancel`. See CLI counterpart for
+    // the canonical rationale.
+    const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+
+    // ---- Round-trip #1: create the transfer to cancel ------------------
+    const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
+    const createArgs = {
+      beneficiary_id: beneficiaryId,
+      bank_account_id: bankAccountId,
+      reference,
+      amount: 1.5,
+      scheduled_date: scheduledDate,
+      vop_proof_token: vopProofToken,
+    };
+
+    const createTrigger = await triggerScaMcp(client, "transfer_create", createArgs);
+    expect(createTrigger.scaSessionToken).not.toBe("unknown");
+    expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(createTrigger.pendingText).toContain("sca_session_show");
+    expect(createTrigger.pendingText).toContain("sca_session_token");
+
+    const createRetry = await approveAndRetryMcp(createTrigger, "allow");
+    expect(createRetry.isError).not.toBe(true);
+    const createText = firstTextFromMcpResult(createRetry);
+    expect(createText).not.toMatch(/^SCA required/);
+    const transfer = JSON.parse(createText) as { readonly id: string };
+    TransferSchema.parse(JSON.parse(createText));
+    expect(transfer.id.length).toBeGreaterThan(0);
+
+    // ---- Round-trip #2 (conditional): cancel the transfer --------------
+    // The cancel endpoint is empirically NOT SCA-gated in sandbox — the
+    // helper handles both paths so the test remains correct if Qonto
+    // shifts behavior to start enforcing SCA on cancel.
+    const { result: cancelRetry, scaTriggered: cancelScaTriggered } = await callWithConditionalSca(
+      client,
+      "transfer_cancel",
+      { id: transfer.id },
+    );
+
+    if (cancelScaTriggered) {
+      console.log(`[transfer_cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
+    } else {
+      console.log(`[transfer_cancel SCA probe] NO SCA in OAuth+sandbox for transfer_cancel.`);
+    }
+
+    expect(cancelRetry.isError).not.toBe(true);
+    const cancelText = firstTextFromMcpResult(cancelRetry);
+    expect(cancelText).not.toMatch(/^SCA required/);
+    const cancelResult = JSON.parse(cancelText) as { readonly canceled?: boolean; readonly id?: string };
+    expect(cancelResult.canceled).toBe(true);
+    expect(cancelResult.id).toBe(transfer.id);
+  });
+});
 
 // NOTE: `transfer_proof` E2E coverage is deferred — same blocker as the CLI
 // counterpart. Qonto sandbox `0909-future-club-2702` returns `404 not_found`

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { randomUUID } from "node:crypto";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { approveAndRetryMcp, SCA_PENDING_TOKEN_RE, triggerScaMcp } from "../sca-helpers.js";
 
 interface TransferItem {
   readonly id: string;
@@ -25,6 +28,35 @@ interface TransferListResponse {
     readonly total_pages: number;
     readonly total_count: number;
   };
+}
+
+interface BeneficiaryListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly trusted: boolean;
+}
+
+interface BankAccountItem {
+  readonly id: string;
+  readonly main: boolean;
+  readonly balance_cents: number;
+}
+
+interface VopResultLite {
+  readonly match_result: string;
+  readonly matched_name: string | null;
+  readonly proof_token: { readonly token: string };
+}
+
+interface BulkVopResultsLite {
+  readonly requests: ReadonlyArray<{
+    readonly id: string;
+    readonly response?: VopResultLite;
+    readonly error?: { readonly code: string };
+  }>;
+  readonly proof_token: { readonly token: string };
 }
 
 describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
@@ -115,3 +147,288 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
     });
   });
 });
+
+// =============================================================================
+// Non-SCA OAuth paths: transfer_verify_payee / transfer_bulk_verify_payee
+// =============================================================================
+//
+// MCP equivalents of the CLI non-SCA paths. These endpoints respond 200
+// directly under PSD2 (no 428), so the MCP tools deliberately omit the SCA
+// continuation schema — see `packages/mcp/src/tools/transfer.ts`. The
+// audit refresh for #458 confirmed this; #449 originally over-flagged them.
+//
+// `transfer_proof` is intentionally NOT covered in this block — see note
+// below the SCA-gated block.
+
+describe.skipIf(!hasOAuthCredentials())("transfer MCP tools (e2e, non-SCA OAuth paths)", () => {
+  pinAuthPreference("oauth-first");
+
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv({ authPreference: "oauth-first" }),
+      stderr: "pipe",
+    });
+    client = new Client({ name: "e2e-transfer-non-sca", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("transfer_verify_payee", () => {
+    it("returns proof_token for an existing beneficiary (no SCA challenge)", async () => {
+      // Same VoP test as the CLI counterpart — proof-token shape only.
+      // The PSD2 dynamic-linking semantic (token binds the SCA token of a
+      // subsequent transfer_create per RTS Art. 5) is exercised by
+      // `packages/e2e/src/sca-continuation/mcp.e2e.test.ts`.
+      const benResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: {},
+      });
+      const benList = JSON.parse(firstTextFromMcpResult(benResult)) as { beneficiaries: BeneficiaryListItem[] };
+      const beneficiary = benList.beneficiaries[0];
+      if (beneficiary === undefined) {
+        throw new Error("E2E setup: no beneficiaries in sandbox");
+      }
+
+      const result = await client.callTool({
+        name: "transfer_verify_payee",
+        arguments: { iban: beneficiary.iban, name: beneficiary.name },
+      });
+      const vop = JSON.parse(firstTextFromMcpResult(result)) as VopResultLite;
+      // VoP proof tokens are pipe-delimited composites
+      // (`version|attempt|epoch-ms|base64url-signature`) — see CLI
+      // counterpart for the canonical rationale.
+      expect(vop.proof_token.token.length).toBeGreaterThan(0);
+      expect(vop.proof_token.token).toMatch(/^\S+$/);
+      expect(typeof vop.match_result).toBe("string");
+    });
+  });
+
+  describe("transfer_bulk_verify_payee", () => {
+    it("returns proof token and per-entry results for an array batch", async () => {
+      const benResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: {},
+      });
+      const benList = JSON.parse(firstTextFromMcpResult(benResult)) as { beneficiaries: BeneficiaryListItem[] };
+      const sample = benList.beneficiaries.slice(0, 2);
+      if (sample.length === 0) {
+        throw new Error("E2E setup: no beneficiaries in sandbox");
+      }
+
+      const result = await client.callTool({
+        name: "transfer_bulk_verify_payee",
+        arguments: {
+          entries: sample.map((b) => ({ iban: b.iban, name: b.name })),
+        },
+      });
+      const bulk = JSON.parse(firstTextFromMcpResult(result)) as BulkVopResultsLite;
+      expect(bulk.proof_token.token.length).toBeGreaterThan(0);
+      expect(bulk.proof_token.token).toMatch(/^\S+$/);
+      expect(bulk.requests.length).toBe(sample.length);
+    });
+  });
+});
+
+// =============================================================================
+// `transfer_cancel` (with conditional-SCA outcome)
+// =============================================================================
+//
+// Mirrors the CLI block: create a transfer (SCA round-trip #1), then cancel
+// it (conditional outcome). The cancel endpoint is empirically NOT SCA-gated
+// in Qonto sandbox (2026-05-12 probe), even though `transfer_cancel` wraps
+// defensively with `executeWithMcpSca`. The test handles both branches —
+// matches sandbox today, will still pass if Qonto starts enforcing SCA on
+// cancel later.
+//
+// `transfer_create` itself is fully covered by
+// `packages/e2e/src/sca-continuation/mcp.e2e.test.ts` (three variants:
+// wait=false / wait=5 / wait=10); this block targets the cancel path only.
+//
+// AUDIT AC #4 (#458, originally Notable Finding #2 in #449): REFUTED by
+//   - packages/e2e/src/bulk-transfers/cli.e2e.test.ts L71 (sandbox SCA)
+//   - packages/e2e/src/recurring-transfers/mcp.e2e.test.ts L102 (sandbox SCA)
+//   - packages/e2e/src/recurring-transfers/mcp.e2e.test.ts L168 (sandbox SCA)
+// No new probe required.
+
+/**
+ * Call an MCP write tool with `wait: false`. If the response is the SCA
+ * pending text payload, mock-approve and retry; otherwise return the
+ * direct (no-SCA) result. Mirrors `callWithConditionalSca` in
+ * `packages/e2e/src/beneficiaries/mcp.e2e.test.ts` (#551).
+ */
+async function callWithConditionalSca(
+  client: Client,
+  toolName: string,
+  baseArgs: Record<string, unknown>,
+): Promise<{ readonly result: CallToolResult; readonly scaTriggered: boolean }> {
+  const firstResult = (await client.callTool({
+    name: toolName,
+    arguments: { ...baseArgs, wait: false },
+  })) as CallToolResult;
+  const firstText = firstTextFromMcpResult(firstResult);
+
+  if (/^SCA required/.test(firstText)) {
+    const tokenMatch = firstText.match(SCA_PENDING_TOKEN_RE);
+    if (tokenMatch === null || tokenMatch[1] === undefined) {
+      throw new Error(`No "Session token: ..." line in SCA-pending response:\n${firstText}`);
+    }
+    const token = tokenMatch[1];
+    expect(token).not.toBe("unknown");
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const approveResult = (await client.callTool({
+      name: "sca_session_mock_decision",
+      arguments: { token, decision: "allow" },
+    })) as CallToolResult;
+    if (approveResult.isError === true) {
+      throw new Error(`sca_session_mock_decision failed:\n${JSON.stringify(approveResult, null, 2)}`);
+    }
+
+    const retryResult = (await client.callTool({
+      name: toolName,
+      arguments: { ...baseArgs, sca_session_token: token },
+    })) as CallToolResult;
+    return { result: retryResult, scaTriggered: true };
+  }
+
+  return { result: firstResult, scaTriggered: false };
+}
+
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
+  "transfer MCP tools (e2e, SCA write paths)",
+  () => {
+    pinAuthPreference("oauth-first");
+
+    let client: Client;
+    let transport: StdioClientTransport;
+    let beneficiaryId: string;
+    let bankAccountId: string;
+    let vopProofToken: string;
+
+    beforeAll(async () => {
+      transport = new StdioClientTransport({
+        command: "node",
+        args: [CLI_PATH, "mcp"],
+        env: cliEnv({ authPreference: "oauth-first" }),
+        stderr: "pipe",
+      });
+      client = new Client({ name: "e2e-transfer-sca", version: "0.0.0" });
+      await client.connect(transport);
+
+      // Pick a non-trusted beneficiary so create actually triggers SCA
+      // (PSD2 Art. 13(b) trusted-beneficiary exemption). Pick `main: true`
+      // account to avoid `400 insufficient_funds` on post-SCA retry. Both
+      // selections follow `sca-continuation/mcp.e2e.test.ts`.
+      const benResult = await client.callTool({
+        name: "beneficiary_list",
+        arguments: {},
+      });
+      const benList = JSON.parse(firstTextFromMcpResult(benResult)) as { beneficiaries: BeneficiaryListItem[] };
+      const beneficiary =
+        benList.beneficiaries.find((b) => b.status === "validated" && !b.trusted) ??
+        benList.beneficiaries.find((b) => !b.trusted);
+      if (beneficiary === undefined) {
+        throw new Error(
+          "E2E setup: no non-trusted beneficiaries available; need at least one untrusted beneficiary to trigger SCA",
+        );
+      }
+      beneficiaryId = beneficiary.id;
+
+      const accountsResult = await client.callTool({
+        name: "account_list",
+        arguments: {},
+      });
+      const accounts = JSON.parse(firstTextFromMcpResult(accountsResult)) as BankAccountItem[];
+      const account =
+        accounts.find((a) => a.main) ?? [...accounts].sort((a, b) => b.balance_cents - a.balance_cents)[0];
+      if (account === undefined) {
+        throw new Error("E2E setup: no bank accounts in sandbox");
+      }
+      bankAccountId = account.id;
+
+      const vopResult = await client.callTool({
+        name: "transfer_verify_payee",
+        arguments: { iban: beneficiary.iban, name: beneficiary.name },
+      });
+      const vop = JSON.parse(firstTextFromMcpResult(vopResult)) as VopResultLite;
+      vopProofToken = vop.proof_token.token;
+    });
+
+    afterAll(async () => {
+      await client.close();
+    });
+
+    it("transfer_cancel: create + cancel lifecycle (cancel conditionally SCA-gated)", async () => {
+      // Schedule the transfer ~3 days into the future so it stays in
+      // `pending` status long enough for the cancel SCA round-trip to land.
+      // Without this, the sandbox moves a same-day transfer past `pending`
+      // and cancel returns `400 cannot_cancel`. See CLI counterpart for
+      // the canonical rationale.
+      const scheduledDate = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10);
+
+      // ---- Round-trip #1: create the transfer to cancel ------------------
+      const reference = `e2e-sca-cancel-${randomUUID().slice(0, 12)}`;
+      const createArgs = {
+        beneficiary_id: beneficiaryId,
+        bank_account_id: bankAccountId,
+        reference,
+        amount: 1.5,
+        scheduled_date: scheduledDate,
+        vop_proof_token: vopProofToken,
+      };
+
+      const createTrigger = await triggerScaMcp(client, "transfer_create", createArgs);
+      expect(createTrigger.scaSessionToken).not.toBe("unknown");
+      expect(createTrigger.scaSessionToken).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(createTrigger.pendingText).toContain("sca_session_show");
+      expect(createTrigger.pendingText).toContain("sca_session_token");
+
+      const createRetry = await approveAndRetryMcp(createTrigger, "allow");
+      expect(createRetry.isError).not.toBe(true);
+      const createText = firstTextFromMcpResult(createRetry);
+      expect(createText).not.toMatch(/^SCA required/);
+      const transfer = JSON.parse(createText) as { readonly id: string };
+      TransferSchema.parse(JSON.parse(createText));
+      expect(transfer.id.length).toBeGreaterThan(0);
+
+      // ---- Round-trip #2 (conditional): cancel the transfer --------------
+      // The cancel endpoint is empirically NOT SCA-gated in sandbox — the
+      // helper handles both paths so the test remains correct if Qonto
+      // shifts behavior to start enforcing SCA on cancel.
+      const { result: cancelRetry, scaTriggered: cancelScaTriggered } = await callWithConditionalSca(
+        client,
+        "transfer_cancel",
+        { id: transfer.id },
+      );
+
+      if (cancelScaTriggered) {
+        console.log(`[transfer_cancel SCA probe] SCA triggered in OAuth+sandbox; round-trip exercised.`);
+      } else {
+        console.log(`[transfer_cancel SCA probe] NO SCA in OAuth+sandbox for transfer_cancel.`);
+      }
+
+      expect(cancelRetry.isError).not.toBe(true);
+      const cancelText = firstTextFromMcpResult(cancelRetry);
+      expect(cancelText).not.toMatch(/^SCA required/);
+      const cancelResult = JSON.parse(cancelText) as { readonly canceled?: boolean; readonly id?: string };
+      expect(cancelResult.canceled).toBe(true);
+      expect(cancelResult.id).toBe(transfer.id);
+    });
+  },
+);
+
+// NOTE: `transfer_proof` E2E coverage is deferred — same blocker as the CLI
+// counterpart. Qonto sandbox `0909-future-club-2702` returns `404 not_found`
+// from `GET /v2/sepa/transfers/{id}/proof` for ALL settled transfers
+// (empirical 2026-05-12 probe of the 10 most-recent). The MCP tool path
+// is confirmed correct by code inspection — it delegates to `getTransferProof`
+// → `client.getBuffer`, wraps the buffer as a base64-encoded MCP resource,
+// and is not SCA-gated. Tracked as a follow-up to #554.


### PR DESCRIPTION
## Summary

- Add CLI + MCP E2E coverage for the transfer write surface under #458 Group 6
- `transfer cancel` / `transfer_cancel`: conditional-SCA create + cancel lifecycle (sandbox empirically does NOT challenge cancel; test still passes if Qonto adds enforcement later)
- `transfer verify-payee` + `transfer bulk-verify-payee` (+ MCP equivalents): non-SCA happy paths asserting VoP proof-token shape; inline documentation that VoP `proof_token` binds the SCA token of a subsequent `transfer create` per PSD2 dynamic-linking (RTS Art. 5)
- `transfer create` cross-reference comment to existing `sca-continuation/` coverage
- Audit AC #4 closed inline (refuted by existing `bulk-transfers/` and `recurring-transfers/` `(sandbox SCA)` blocks)

## Empirical findings

- **`cancelTransfer` is NOT SCA-gated in Qonto sandbox** (2026-05-12 probe): `POST /v2/sepa/transfers/{id}/cancel` returns `204 No Content` directly, no 428. CLI / MCP code defensively wraps with `executeWith*Sca` per the audit refresh — wrap is a no-op for this endpoint in sandbox. Test uses the conditional-outcome pattern from #549–#553 to remain correct under either path.
- Same-day transfers move past `pending` before the SCA round-trip completes; cancel test uses `--scheduled-date` / `scheduled_date` ~3 days in the future to keep the transfer cancellable.
- VoP proof tokens are pipe-delimited composites (`version|attempt|epoch-ms|base64url-sig`) — not bare base64url; regex updated accordingly.

## Deferred AC

- `getTransferProof` / `transfer_proof` E2E coverage deferred to #565. Sandbox returns 404 not_found for ALL 10 most-recent settled transfers (empirical probe). Code paths confirmed correct by inspection; production-only validation tracked in #565.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` clean (746 passing)
- [x] `pnpm test:e2e` full suite green (314 passed, 5 skipped, 0 failed)
- [x] Targeted `transfers/` suite green (19/19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)