### PR TITLE
(chore) coverage drift detector for new core/CLI/MCP code (#462)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: pnpm lint
       - run: pnpm license-check
       - run: pnpm publish-check
+      - run: pnpm coverage-drift-check
       - run: pnpm test ${{ matrix.os == 'ubuntu-latest' && '-- -- --coverage' || '' }}
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,38 @@ pnpm test:e2e                       # Full E2E suite
 
 **What's covered:** Each domain has its own directory under `packages/e2e/src/` with CLI and MCP test files. Check the directory structure for current coverage — do not rely on a hardcoded list.
 
+### Coverage Drift Policy
+
+**Policy:** Every Qonto API endpoint qontoctl ships must be reachable from at least one E2E test exercising the live sandbox, OR carry an explicit `accepted_gap` justification. New core service functions, CLI command files, and MCP tools must be reflected in the coverage manifest in the same PR that introduces them.
+
+**Manifest:** [`packages/e2e/coverage.json`](packages/e2e/coverage.json). One entry per surface, keyed by:
+
+- `mcp:<tool_name>` — each `server.registerTool("...")` in `packages/mcp/src/tools/`
+- `cli:<relative-file-path>` — each non-`index.ts` source file in `packages/cli/src/commands/`
+- `core:<relative-file-path>#<function-name>` — each `export function` in `packages/core/src/**/service.ts`
+
+Each entry has `status`, `tests`, and `notes`:
+
+- **`covered`** — `tests` must list at least one existing E2E test file.
+- **`pending`** — known gap, tracked separately. `tests` and `notes` may be empty. Non-blocking; intended as a transient state while gaps are being closed (e.g., #449 sub-items).
+- **`accepted_gap`** — surface cannot be E2E tested (e.g., Embed-partner-only endpoints). `notes` is required and must explain why.
+
+**Enforcement:** `pnpm coverage-drift-check` runs in CI on every PR. It fails when:
+
+1. A surface exists in code but has no manifest entry (NEW).
+2. A manifest entry references a surface that no longer exists in code (STALE).
+3. A `covered` entry points to a missing test file or has an empty `tests` array (BROKEN_REF).
+4. An `accepted_gap` entry has an empty `notes` field (MISSING_NOTE).
+
+**Workflow when adding a new surface:**
+
+1. Add the code (new tool, command file, or core function).
+2. Run `pnpm coverage-drift-check` locally — it will fail with `[NEW]` findings.
+3. Either add the corresponding E2E test now and update the manifest with `status: "covered"`, or add the entry with `status: "pending"` (with an issue link in `notes`) for follow-up, or mark `status: "accepted_gap"` with a justification.
+4. Re-run `pnpm coverage-drift-check` — it should pass.
+
+**Bootstrapping new entries:** `node scripts/check-coverage-drift.js --bootstrap` adds any missing surface as `pending` (preserves existing entries). Use `--prune` to remove stale entries after a rename or removal.
+
 ### TypeScript
 
 - Strict mode with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "turbo run lint",
     "license-check": "node scripts/check-licenses.js",
     "publish-check": "node scripts/check-publish-manifest.js",
+    "coverage-drift-check": "node scripts/check-coverage-drift.js",
     "dev": "turbo run dev"
   },
   "devDependencies": {

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -1,0 +1,1509 @@
+{
+  "surfaces": {
+    "cli:packages/cli/src/commands/account.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/attachment.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/auth.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/add.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/trust.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/untrust.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/beneficiary/update.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/bulk-transfer/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/bulk-transfer/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/bulk-transfer/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/appearances.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/discard.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/iframe-url.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/lock.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/report.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/update-limits.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/update-nickname.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/update-options.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/card/update-restrictions.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/client-invoice.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/client.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/credit-note.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/einvoicing.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/insurance.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/internal-transfer.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-beneficiary/add.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-beneficiary/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-beneficiary/remove.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-beneficiary/requirements.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-beneficiary/update.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-currencies.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-eligibility.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-quote/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-transfer/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/intl-transfer/requirements.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/label.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/membership.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/org.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/payment-link.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/profile/add.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/profile/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/profile/remove.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/profile/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/profile/test.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/quote.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/recurring-transfer/cancel.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/recurring-transfer/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/recurring-transfer/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/recurring-transfer/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/approve.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/create-flash-card.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/create-multi-transfer.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/create-virtual-card.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/decline.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/request/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/sca-session/mock-decision.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/sca-session/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/statement.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/supplier-invoice/bulk-create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/supplier-invoice/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/supplier-invoice/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/team.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transaction/attachment.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transaction/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transaction/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/bulk-verify-payee.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/cancel.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/create.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/list.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/proof.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/show.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/transfer/verify-payee.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "cli:packages/cli/src/commands/webhook.ts": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#addTransactionAttachment": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#getAttachment": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#listTransactionAttachments": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#removeAllTransactionAttachments": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#removeTransactionAttachment": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/attachments/service.ts#uploadAttachment": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/auth/oauth-service.ts#exchangeCode": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/auth/oauth-service.ts#refreshAccessToken": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/auth/oauth-service.ts#revokeToken": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#buildBeneficiaryQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#createBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#getBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#listBeneficiaries": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#trustBeneficiaries": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#untrustBeneficiaries": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/beneficiaries/service.ts#updateBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/bulk-transfers/service.ts#createBulkTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/bulk-transfers/service.ts#getBulkTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/bulk-transfers/service.ts#listBulkTransfers": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#buildCardQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#bulkCreateCards": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#createCard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#discardCard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#getCard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#getCardIframeUrl": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#listCardAppearances": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#listCards": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#lockCard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#reportCardLost": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#reportCardStolen": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#unlockCard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#updateCardLimits": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#updateCardNickname": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#updateCardOptions": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/cards/service.ts#updateCardRestrictions": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#buildClientInvoiceQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#cancelClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#createClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#deleteClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#finalizeClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#getClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#getClientInvoiceUpload": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#listClientInvoices": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#markClientInvoicePaid": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#sendClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#unmarkClientInvoicePaid": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#updateClientInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/client-invoices/service.ts#uploadClientInvoiceFile": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/insurance-contracts/service.ts#createInsuranceContract": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/insurance-contracts/service.ts#getInsuranceContract": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/insurance-contracts/service.ts#removeInsuranceDocument": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/insurance-contracts/service.ts#updateInsuranceContract": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/insurance-contracts/service.ts#uploadInsuranceDocument": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/internal-transfers/service.ts#createInternalTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-beneficiaries/service.ts#createIntlBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-beneficiaries/service.ts#getIntlBeneficiaryRequirements": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-beneficiaries/service.ts#listIntlBeneficiaries": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-beneficiaries/service.ts#removeIntlBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-beneficiaries/service.ts#updateIntlBeneficiary": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-transfers/service.ts#createIntlTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international-transfers/service.ts#getIntlTransferRequirements": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international/service.ts#createIntlQuote": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international/service.ts#getIntlEligibility": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/international/service.ts#listIntlCurrencies": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/recurring-transfers/service.ts#cancelRecurringTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/recurring-transfers/service.ts#createRecurringTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/recurring-transfers/service.ts#getRecurringTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/recurring-transfers/service.ts#listRecurringTransfers": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/requests/service.ts#approveRequest": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/requests/service.ts#createFlashCardRequest": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/requests/service.ts#createMultiTransferRequest": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/requests/service.ts#createVirtualCardRequest": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/requests/service.ts#declineRequest": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/sca/sca-service.ts#getScaSession": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/sca/sca-service.ts#mockScaDecision": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/sca/sca-service.ts#pollScaSession": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/statements/service.ts#buildStatementQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/statements/service.ts#getStatement": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/statements/service.ts#listStatements": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/supplier-invoices/service.ts#buildSupplierInvoiceQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/supplier-invoices/service.ts#bulkCreateSupplierInvoices": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/supplier-invoices/service.ts#getSupplierInvoice": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/supplier-invoices/service.ts#listSupplierInvoices": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transactions/service.ts#buildTransactionQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transactions/service.ts#getTransaction": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transactions/service.ts#listTransactions": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#buildTransferQueryParams": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#bulkVerifyPayee": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#cancelTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#createTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#getTransfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#getTransferProof": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#listTransfers": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/transfers/service.ts#verifyPayee": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/webhooks/service.ts#createWebhook": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/webhooks/service.ts#deleteWebhook": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/webhooks/service.ts#getWebhook": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/webhooks/service.ts#listWebhooks": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "core:packages/core/src/webhooks/service.ts#updateWebhook": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_close": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_iban_certificate": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:account_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:attachment_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:attachment_upload": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_add": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_trust": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_untrust": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:beneficiary_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:bulk_transfer_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:bulk_transfer_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:bulk_transfer_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_appearances": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_bulk_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_discard": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_iframe_url": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_lock": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_report_lost": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_report_stolen": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_unlock": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_update_limits": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_update_nickname": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_update_options": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:card_update_restrictions": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_delete": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_cancel": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_delete": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_finalize": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_mark_paid": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_send": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_unmark_paid": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_upload": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_invoice_upload_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:client_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:credit_note_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:credit_note_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:einvoicing_settings": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:insurance_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:insurance_remove_document": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:insurance_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:insurance_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:insurance_upload_document": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:internal_transfer_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_beneficiary_add": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_beneficiary_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_beneficiary_remove": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_beneficiary_requirements": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_beneficiary_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_currencies": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_eligibility": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_quote_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_transfer_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:intl_transfer_requirements": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:label_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:label_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:membership_invite": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:membership_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:membership_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:org_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_connect": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_connection_status": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_deactivate": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_methods": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_payments": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:payment_link_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_delete": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_send": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:quote_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:recurring_transfer_cancel": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:recurring_transfer_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:recurring_transfer_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:recurring_transfer_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_approve": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_create_flash_card": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_create_multi_transfer": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_create_virtual_card": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_decline": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:request_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:sca_session_mock_decision": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:sca_session_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:statement_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:statement_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:supplier_invoice_bulk_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:supplier_invoice_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:supplier_invoice_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:team_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:team_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transaction_attachment_add": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transaction_attachment_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transaction_attachment_remove": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transaction_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transaction_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_bulk_verify_payee": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_cancel": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_proof": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:transfer_verify_payee": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:webhook_create": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:webhook_delete": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:webhook_list": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:webhook_show": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    },
+    "mcp:webhook_update": {
+      "status": "pending",
+      "tests": [],
+      "notes": ""
+    }
+  }
+}

--- a/scripts/check-coverage-drift.js
+++ b/scripts/check-coverage-drift.js
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Coverage drift detector for E2E tests.
+ *
+ * Inventories the public surfaces qontoctl ships (MCP tools, CLI command files,
+ * core service functions) and cross-references against the coverage manifest at
+ * `packages/e2e/coverage.json`. Fails CI when a new surface ships without a
+ * manifest entry, when a manifest entry references a surface that no longer
+ * exists, when a `covered` entry points to a missing test file, or when an
+ * `accepted_gap` entry lacks justification.
+ *
+ * Usage:
+ *   node scripts/check-coverage-drift.js              — validate; exit 1 on drift
+ *   node scripts/check-coverage-drift.js --bootstrap  — seed missing entries as `pending`
+ *   node scripts/check-coverage-drift.js --prune      — remove stale entries (run with care)
+ *
+ * Exit codes:
+ *   0 — manifest matches inventoried surfaces and references are valid
+ *   1 — drift detected (new surfaces, stale entries, broken refs, or missing notes)
+ *
+ * See CLAUDE.md § Coverage drift policy.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { basename, join, relative, dirname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), "..");
+const MANIFEST_PATH = join(ROOT, "packages", "e2e", "coverage.json");
+
+const VALID_STATUSES = new Set(["covered", "accepted_gap", "pending"]);
+
+// ---------------------------------------------------------------------------
+// File walking
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively list files under `dir` whose path satisfies `predicate`. Returns
+ * absolute paths.
+ */
+function walk(dir, predicate) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      results.push(...walk(full, predicate));
+    } else if (entry.isFile() && predicate(full)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Normalize a path to forward slashes regardless of platform, for stable
+ * manifest keys.
+ */
+function toPosix(p) {
+  return p.split(sep).join("/");
+}
+
+// ---------------------------------------------------------------------------
+// Surface inventory
+// ---------------------------------------------------------------------------
+
+/**
+ * Inventory MCP tools by parsing `server.registerTool("name", ...)` calls in
+ * `packages/mcp/src/tools/*.ts` (excluding test files).
+ */
+function inventoryMcpTools() {
+  const toolsDir = join(ROOT, "packages", "mcp", "src", "tools");
+  if (!existsSync(toolsDir)) return [];
+
+  const files = walk(toolsDir, (f) => f.endsWith(".ts") && !f.endsWith(".test.ts"));
+  const surfaces = [];
+  const pattern = /server\.registerTool\(\s*"([^"]+)"/g;
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      surfaces.push({
+        key: `mcp:${match[1]}`,
+        source: toPosix(relative(ROOT, file)),
+      });
+    }
+  }
+  return surfaces;
+}
+
+/**
+ * Inventory CLI commands at the file level. Each `.ts` source file under
+ * `packages/cli/src/commands/` is one surface (excluding `index.ts` aggregators
+ * and `*.test.ts`). Sub-commands within a file collapse to the file's surface;
+ * this is acceptable because the common drift pattern is "new command file"
+ * rather than "new sub-command in existing file".
+ */
+function inventoryCliCommands() {
+  const commandsDir = join(ROOT, "packages", "cli", "src", "commands");
+  if (!existsSync(commandsDir)) return [];
+
+  const files = walk(commandsDir, (f) => f.endsWith(".ts") && !f.endsWith(".test.ts") && basename(f) !== "index.ts");
+  return files.map((file) => ({
+    key: `cli:${toPosix(relative(ROOT, file))}`,
+    source: toPosix(relative(ROOT, file)),
+  }));
+}
+
+/**
+ * Inventory core service functions by parsing `export (async )?function NAME`
+ * declarations in `packages/core/src/**\/service.ts` (excluding test files).
+ */
+function inventoryCoreServiceFunctions() {
+  const coreDir = join(ROOT, "packages", "core", "src");
+  if (!existsSync(coreDir)) return [];
+
+  const files = walk(coreDir, (f) => {
+    if (f.endsWith(".test.ts")) return false;
+    const name = basename(f);
+    return name === "service.ts" || name.endsWith("-service.ts");
+  });
+  const surfaces = [];
+  const pattern = /^export\s+(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)/gm;
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+    const rel = toPosix(relative(ROOT, file));
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      surfaces.push({
+        key: `core:${rel}#${match[1]}`,
+        source: rel,
+      });
+    }
+  }
+  return surfaces;
+}
+
+/**
+ * Aggregate all inventoried surfaces into a Map keyed by surface key.
+ */
+function inventorySurfaces() {
+  const all = [...inventoryMcpTools(), ...inventoryCliCommands(), ...inventoryCoreServiceFunctions()];
+  const map = new Map();
+  for (const s of all) {
+    if (map.has(s.key)) {
+      throw new Error(
+        `Internal error: duplicate surface key ${s.key} (sources: ${map.get(s.key).source}, ${s.source})`,
+      );
+    }
+    map.set(s.key, s);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Manifest I/O
+// ---------------------------------------------------------------------------
+
+function readManifest() {
+  if (!existsSync(MANIFEST_PATH)) {
+    return { surfaces: {} };
+  }
+  const text = readFileSync(MANIFEST_PATH, "utf-8");
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed.surfaces === undefined || parsed.surfaces === null || typeof parsed.surfaces !== "object") {
+      throw new Error("manifest missing `surfaces` object");
+    }
+    return parsed;
+  } catch (err) {
+    throw new Error(`Failed to parse ${MANIFEST_PATH}: ${err.message}`);
+  }
+}
+
+function writeManifest(manifest) {
+  const sorted = Object.keys(manifest.surfaces)
+    .sort()
+    .reduce((acc, key) => {
+      const entry = manifest.surfaces[key];
+      acc[key] = {
+        status: entry.status,
+        tests: [...entry.tests].sort(),
+        notes: entry.notes ?? "",
+      };
+      return acc;
+    }, {});
+  const out = { surfaces: sorted };
+  writeFileSync(MANIFEST_PATH, JSON.stringify(out, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare inventoried surfaces against manifest entries and produce drift
+ * findings. Each finding is `{ kind, key, detail }`.
+ */
+function detectDrift(inventoryMap, manifest) {
+  const findings = [];
+  const manifestKeys = new Set(Object.keys(manifest.surfaces));
+  const inventoryKeys = new Set(inventoryMap.keys());
+
+  // NEW: surface in code but missing from manifest
+  for (const key of inventoryKeys) {
+    if (!manifestKeys.has(key)) {
+      findings.push({
+        kind: "NEW",
+        key,
+        detail: `surface exists in ${inventoryMap.get(key).source} but no manifest entry. Add an entry to packages/e2e/coverage.json with status: covered (with E2E test file) | pending (planned) | accepted_gap (with notes justification).`,
+      });
+    }
+  }
+
+  // STALE: manifest entry references surface no longer in code
+  for (const key of manifestKeys) {
+    if (!inventoryKeys.has(key)) {
+      findings.push({
+        kind: "STALE",
+        key,
+        detail: `manifest references a surface that no longer exists in code. Remove the entry from packages/e2e/coverage.json.`,
+      });
+    }
+  }
+
+  // Per-entry validation
+  for (const [key, entry] of Object.entries(manifest.surfaces)) {
+    if (!VALID_STATUSES.has(entry.status)) {
+      findings.push({
+        kind: "INVALID_STATUS",
+        key,
+        detail: `status is ${JSON.stringify(entry.status)}; expected one of: ${[...VALID_STATUSES].join(", ")}.`,
+      });
+      continue;
+    }
+    if (!Array.isArray(entry.tests)) {
+      findings.push({
+        kind: "INVALID_SHAPE",
+        key,
+        detail: "tests must be an array of file paths (use [] for non-covered surfaces).",
+      });
+      continue;
+    }
+
+    if (entry.status === "covered") {
+      if (entry.tests.length === 0) {
+        findings.push({
+          kind: "BROKEN_REF",
+          key,
+          detail:
+            "status is `covered` but tests array is empty. Add at least one E2E test file path, or change status to `pending`.",
+        });
+      } else {
+        for (const testPath of entry.tests) {
+          const abs = join(ROOT, testPath);
+          if (!existsSync(abs)) {
+            findings.push({
+              kind: "BROKEN_REF",
+              key,
+              detail: `test file does not exist: ${testPath}`,
+            });
+          }
+        }
+      }
+    }
+
+    if (entry.status === "accepted_gap") {
+      const notes = typeof entry.notes === "string" ? entry.notes.trim() : "";
+      if (notes.length === 0) {
+        findings.push({
+          kind: "MISSING_NOTE",
+          key,
+          detail:
+            "status is `accepted_gap` but notes field is empty. Document why the surface cannot be covered (e.g., Embed-partner-only endpoint).",
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap / prune
+// ---------------------------------------------------------------------------
+
+function bootstrap(inventoryMap, manifest) {
+  let added = 0;
+  for (const key of inventoryMap.keys()) {
+    if (!Object.prototype.hasOwnProperty.call(manifest.surfaces, key)) {
+      manifest.surfaces[key] = { status: "pending", tests: [], notes: "" };
+      added++;
+    }
+  }
+  return added;
+}
+
+function prune(inventoryMap, manifest) {
+  let removed = 0;
+  for (const key of Object.keys(manifest.surfaces)) {
+    if (!inventoryMap.has(key)) {
+      delete manifest.surfaces[key];
+      removed++;
+    }
+  }
+  return removed;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function reportFindings(findings) {
+  if (findings.length === 0) return;
+  const byKind = new Map();
+  for (const f of findings) {
+    if (!byKind.has(f.kind)) byKind.set(f.kind, []);
+    byKind.get(f.kind).push(f);
+  }
+  const kindOrder = ["NEW", "STALE", "BROKEN_REF", "MISSING_NOTE", "INVALID_STATUS", "INVALID_SHAPE"];
+  for (const kind of kindOrder) {
+    const items = byKind.get(kind);
+    if (!items || items.length === 0) continue;
+    process.stderr.write(`\n[${kind}] ${items.length} finding(s):\n`);
+    for (const f of items) {
+      process.stderr.write(`  - ${f.key}\n    ${f.detail}\n`);
+    }
+  }
+}
+
+function reportSummary(inventoryMap, manifest) {
+  const total = inventoryMap.size;
+  const stats = { covered: 0, accepted_gap: 0, pending: 0 };
+  for (const entry of Object.values(manifest.surfaces)) {
+    if (Object.prototype.hasOwnProperty.call(stats, entry.status)) {
+      stats[entry.status]++;
+    }
+  }
+  const pct = total > 0 ? ((stats.covered / total) * 100).toFixed(1) : "0.0";
+  process.stdout.write(
+    `Coverage manifest: ${total} surfaces tracked — ${stats.covered} covered (${pct}%), ${stats.accepted_gap} accepted gaps, ${stats.pending} pending.\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const isBootstrap = args.has("--bootstrap");
+  const isPrune = args.has("--prune");
+
+  const inventoryMap = inventorySurfaces();
+  const manifest = readManifest();
+
+  if (isBootstrap || isPrune) {
+    let mutated = false;
+    if (isBootstrap) {
+      const added = bootstrap(inventoryMap, manifest);
+      if (added > 0) {
+        process.stdout.write(`Bootstrap: added ${added} surface(s) as pending.\n`);
+        mutated = true;
+      } else {
+        process.stdout.write("Bootstrap: manifest already covers all inventoried surfaces.\n");
+      }
+    }
+    if (isPrune) {
+      const removed = prune(inventoryMap, manifest);
+      if (removed > 0) {
+        process.stdout.write(`Prune: removed ${removed} stale entry(ies).\n`);
+        mutated = true;
+      } else {
+        process.stdout.write("Prune: no stale entries found.\n");
+      }
+    }
+    if (mutated) writeManifest(manifest);
+    return;
+  }
+
+  const findings = detectDrift(inventoryMap, manifest);
+  reportSummary(inventoryMap, manifest);
+
+  if (findings.length > 0) {
+    process.stderr.write(`\nCoverage drift check FAILED: ${findings.length} finding(s).\n`);
+    reportFindings(findings);
+    process.stderr.write(
+      "\nResolution paths:\n" +
+        "  • New surface? Add an entry to packages/e2e/coverage.json.\n" +
+        "  • Renamed/removed surface? Delete the stale entry (or run with --prune).\n" +
+        "  • Endpoint genuinely untestable? Mark status: `accepted_gap` with a notes justification.\n" +
+        "  • See CLAUDE.md § Coverage drift policy.\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write("Coverage drift check passed.\n");
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds a CI-gated coverage drift detector that flags every new MCP tool, CLI command file, or core service function shipping without an explicit entry in the coverage manifest. Closes #462 (Group 10 of #449).

- **`scripts/check-coverage-drift.js`** — Node ESM script following the existing `check-licenses.js` / `check-publish-manifest.js` pattern. Three modes: default validate, `--bootstrap` (seed missing as pending), `--prune` (remove stale).
- **`packages/e2e/coverage.json`** — hand-editable JSON manifest, seeded with 301 currently-inventoried surfaces as `pending`. Future PRs flip them to `covered` (with E2E paths) or mark `accepted_gap` with a notes justification (e.g., Embed-partner endpoints per #449 Group 9).
- **CI wiring** — `pnpm coverage-drift-check` between `publish-check` and `test` in the ubuntu/macos/windows matrix. Blocking by design (per AC).
- **`CLAUDE.md` § Coverage Drift Policy** — policy statement, manifest schema, enforcement rules, developer workflow.

## How drift is detected

| Failure mode | What fires |
|---|---|
| NEW | A surface (MCP tool / CLI file / core export) exists in code but no manifest entry |
| STALE | A manifest entry references a surface that no longer exists |
| BROKEN_REF | A `covered` entry has empty `tests` or points to a non-existent file |
| MISSING_NOTE | An `accepted_gap` entry has empty `notes` |
| INVALID_STATUS | Unknown status value |

Every failure mode was adversarially verified locally.

## Surface taxonomy

- `mcp:<tool_name>` — every `server.registerTool("…", …)` in `packages/mcp/src/tools/`
- `cli:<rel-file-path>` — every non-`index.ts` source file under `packages/cli/src/commands/` (file-level granularity; sub-commands within one file collapse to the file's surface)
- `core:<rel-file-path>#<function-name>` — every `export function NAME` in `packages/core/src/**/service.ts`

## Test plan

- [x] `node scripts/check-coverage-drift.js` passes on bootstrap manifest
- [x] Adding a fake `server.registerTool("canary", …)` → script exits 1 with NEW finding
- [x] Adding ghost manifest entry → script exits 1 with STALE finding
- [x] `covered` with non-existent file path → BROKEN_REF
- [x] `covered` with empty `tests: []` → BROKEN_REF
- [x] `accepted_gap` with empty `notes` → MISSING_NOTE
- [x] Unknown status value → INVALID_STATUS
- [x] `--bootstrap` re-run is idempotent
- [x] `--prune` removes stale entries
- [x] `covered` with real existing E2E path → passes
- [x] `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all green

## Notes

- The drift detector validates manifest shape and surface↔manifest mapping; coverage status (`covered`/`pending`/`accepted_gap`) is set by humans. Pending entries are non-blocking, intended as a transient state as the rest of #449's groups close gaps.
- The initial 301-entry seed is generated via `--bootstrap`. Manually closing `pending` → `covered` (with test file paths) happens incrementally; no requirement to do it all in this PR.
- `packages/qontoctl/README.md` carries a pre-existing uncommitted change on `main` unrelated to this work; it has been deliberately excluded from this commit.