### PR TITLE
(feat) add Qonto Products API support (CLI + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ QontoCtl lets AI assistants (Claude, etc.) interact with Qonto through the [Mode
 - **Bulk Transfers** — list and view bulk transfer batches
 - **Recurring Transfers** — list and view recurring transfers
 - **Terminals (POS)** — list Qonto Terminals and initiate terminal payments
+- **Products** — list catalogue products
 - **Clients** — list, create, update, delete clients
 - **Client Invoices** — full lifecycle: create, update, finalize, send, mark paid, cancel, upload files
 - **Quotes** — create, update, delete, send quotes
@@ -220,6 +221,8 @@ The path is captured at server startup. See [`docs/configuration.md`](docs/confi
 | **Terminals (POS)**             |                                                                       |
 | `terminal_list`                 | List Qonto Terminals linked to the organization                       |
 | `terminal_payment_create`       | Initiate a payment on a terminal (returns 202 Accepted)               |
+| **Products**                    |                                                                       |
+| `product_list`                  | List catalogue products with optional pagination and sort             |
 | **Clients**                     |                                                                       |
 | `client_list`                   | List clients with optional pagination                                 |
 | `client_show`                   | Show details of a specific client                                     |
@@ -387,6 +390,7 @@ The pending response's textual format is stable, so callers that need to extract
 | `recurring-transfer show <id>`                | Show recurring transfer details           |
 | `terminal list`                               | List Qonto Terminals (POS)                |
 | `terminal payment create <id>`                | Initiate a payment on a terminal          |
+| `product list`                                | List catalogue products                   |
 | `client list`                                 | List clients                              |
 | `client show <id>`                            | Show client details                       |
 | `client create`                               | Create a new client                       |

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -86,12 +86,12 @@ The full catalog is grouped by feature area. Scopes marked **(recommended)** are
 
 ### Products
 
-| Scope           | Recommended | Enables                                                        |
-| --------------- | :---------: | -------------------------------------------------------------- |
-| `product.read`  |             | Product catalog listing and details (no qontoctl command yet)  |
-| `product.write` |             | Product catalog create/update/delete (no qontoctl command yet) |
+| Scope           | Recommended | Enables                                                                                         |
+| --------------- | :---------: | ----------------------------------------------------------------------------------------------- |
+| `product.read`  |             | Product catalogue listing (`product list` / `product_list`)                                     |
+| `product.write` |             | Product catalogue create/update/delete (no qontoctl command yet — Qonto has not published CRUD) |
 
-> **Note**: Product scopes are listed in Qonto's official catalog but qontoctl does not yet expose product commands. Authorize them only if you plan to use qontoctl alongside other tooling that does.
+> **Note**: `product.read` is wired. `product.write` is listed in Qonto's OpenAPI security schemes but the underlying CRUD routes are not yet published in the public API reference — authorize it only if you plan to use qontoctl alongside other tooling that calls them.
 
 ### Terminals (POS)
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -56,10 +56,10 @@ export const SCOPE_CATEGORIES: ReadonlyArray<{ readonly name: string; readonly s
   },
   { name: "Memberships & Teams", scopes: ["membership.read", "membership.write", "team.read", "team.write"] },
   { name: "Suppliers", scopes: ["supplier_invoice.read", "supplier_invoice.write"] },
-  // `product.read` / `product.write` are listed in Qonto's official scope catalog but
-  // qontoctl does not yet expose product commands (no CLI/MCP wiring). Included here
-  // forward-looking so users with downstream tooling can authorize them; remove if
-  // products are explicitly out of scope for qontoctl.
+  // `product.read` covers `GET /v2/products` (`product list` / `product_list`).
+  // `product.write` is listed in Qonto's OpenAPI security schemes for CRUD product
+  // endpoints, but those routes are not yet published in the public API reference —
+  // qontoctl exposes no write surface for it yet (forward-looking).
   { name: "Products", scopes: ["product.read", "product.write"] },
   // `terminal.read` / `terminal.write` cover Qonto Terminal (POS) endpoints
   // (GET /v2/terminals, POST /v2/terminals/{id}/payment). Verified via per-endpoint
@@ -158,8 +158,8 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   "supplier_invoice.write": "Supplier invoice creation",
   "insurance_contract.read": "Insurance contract retrieval",
   "insurance_contract.write": "Insurance contract creation",
-  "product.read": "Product catalog listing and details (no qontoctl command yet — forward-looking)",
-  "product.write": "Product catalog create/update/delete (no qontoctl command yet — forward-looking)",
+  "product.read": "Product catalogue listing",
+  "product.write": "Product catalogue create/update/delete (no qontoctl command yet — forward-looking)",
   "terminal.read": "Qonto Terminal (POS) listing and webhook events",
   "terminal.write": "Qonto Terminal (POS) payment creation",
   "international_transfer.write": "International (SWIFT) transfer creation",

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -10,6 +10,7 @@ export { createInternalTransferCommand } from "./internal-transfer.js";
 export { createLabelCommand } from "./label.js";
 export { createMembershipCommand } from "./membership.js";
 export { createPaymentLinkCommand } from "./payment-link.js";
+export { createProductCommand } from "./product.js";
 export { createQuoteCommand } from "./quote.js";
 export { registerRequestCommands } from "./request/index.js";
 export { registerScaSessionCommands } from "./sca-session/index.js";

--- a/packages/cli/src/commands/product.test.ts
+++ b/packages/cli/src/commands/product.test.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { createProductCommand } from "./product.js";
+import type { PaginationMeta } from "../pagination.js";
+
+function makeMeta(overrides: Partial<PaginationMeta> = {}): PaginationMeta {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+vi.mock("../client.js", () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from "../client.js";
+import { HttpClient } from "@qontoctl/core";
+
+describe("product commands", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+    vi.mocked(createClient).mockResolvedValue(client);
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((() => true) as never);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation((() => true) as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("product list", () => {
+    const sampleProduct = {
+      id: "prod-1",
+      title: "Espresso",
+      type: "good",
+      unit_price: { value: "2.50", currency: "EUR" },
+      vat_rate: "0.2",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    it("lists products in table format", async () => {
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({ products: [sampleProduct], meta: makeMeta({ total_count: 1 }) }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.addCommand(createProductCommand());
+      program.exitOverride();
+
+      await program.parseAsync(["product", "list"], { from: "user" });
+
+      expect(stdoutSpy).toHaveBeenCalled();
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("prod-1");
+      expect(output).toContain("Espresso");
+      expect(output).toContain("2.50 EUR");
+    });
+
+    it("lists products in json format", async () => {
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({ products: [sampleProduct], meta: makeMeta({ total_count: 1 }) }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.addCommand(createProductCommand());
+      program.exitOverride();
+
+      await program.parseAsync(["--output", "json", "product", "list"], { from: "user" });
+
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      const parsed = JSON.parse(output) as unknown[];
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]).toEqual(sampleProduct);
+    });
+
+    it("hits /v2/products with pagination params", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ products: [], meta: makeMeta() }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.addCommand(createProductCommand());
+      program.exitOverride();
+
+      await program.parseAsync(["--page", "2", "--per-page", "10", "product", "list"], { from: "user" });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/products");
+      expect(url.searchParams.get("page")).toBe("2");
+      expect(url.searchParams.get("per_page")).toBe("10");
+    });
+
+    it("forwards --sort-by as the sort_by query param", async () => {
+      fetchSpy.mockImplementation(() => jsonResponse({ products: [], meta: makeMeta() }));
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.addCommand(createProductCommand());
+      program.exitOverride();
+
+      await program.parseAsync(["product", "list", "--sort-by", "created_at:desc"], { from: "user" });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("sort_by")).toBe("created_at:desc");
+    });
+
+    it("renders a row even when optional fields are absent", async () => {
+      const minimalProduct = { id: "prod-2" };
+      fetchSpy.mockImplementation(() =>
+        jsonResponse({ products: [minimalProduct], meta: makeMeta({ total_count: 1 }) }),
+      );
+
+      const { createProgram } = await import("../program.js");
+      const program = createProgram();
+      program.addCommand(createProductCommand());
+      program.exitOverride();
+
+      await program.parseAsync(["product", "list"], { from: "user" });
+
+      const output = stdoutSpy.mock.calls[0]?.[0] as string;
+      expect(output).toContain("prod-2");
+    });
+  });
+
+  // Silence "expect" coverage for stderrSpy variable (used implicitly via setup).
+  it("setup integrity", () => {
+    expect(stderrSpy).toBeDefined();
+  });
+});

--- a/packages/cli/src/commands/product.ts
+++ b/packages/cli/src/commands/product.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Command, Option } from "commander";
+import type { Product } from "@qontoctl/core";
+import { createClient } from "../client.js";
+import { formatOutput } from "../formatters/index.js";
+import { addInheritableOptions, resolveGlobalOptions } from "../inherited-options.js";
+import type { GlobalOptions, PaginationOptions } from "../options.js";
+import { fetchPaginated } from "../pagination.js";
+
+interface ProductListOptions extends GlobalOptions, PaginationOptions {
+  readonly sortBy?: string | undefined;
+}
+
+function toProductRow(p: Product): Record<string, string> {
+  return {
+    id: p.id,
+    title: p.title ?? "",
+    type: p.type ?? "",
+    unit_price: p.unit_price !== undefined ? `${p.unit_price.value} ${p.unit_price.currency}` : "",
+    vat_rate: p.vat_rate ?? "",
+    updated_at: p.updated_at ?? "",
+  };
+}
+
+export function createProductCommand(): Command {
+  const product = new Command("product").description("Manage Qonto products");
+
+  const list = product.command("list").description("List products in the organization's catalogue");
+  list.addOption(new Option("--sort-by <sort>", "sort order (e.g. created_at:desc, title:asc)"));
+  addInheritableOptions(list);
+  list.action(async (_options: unknown, cmd: Command) => {
+    const opts = resolveGlobalOptions<ProductListOptions>(cmd);
+    const client = await createClient(opts);
+
+    const query = opts.sortBy !== undefined ? { sort_by: opts.sortBy } : undefined;
+    const result = await fetchPaginated<Product>(client, "/v2/products", "products", opts, query);
+
+    const data = opts.output === "json" || opts.output === "yaml" ? result.items : result.items.map(toProductRow);
+
+    process.stdout.write(formatOutput(data, opts.output) + "\n");
+  });
+
+  return product;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ export {
   createInternalTransferCommand,
   createLabelCommand,
   createMembershipCommand,
+  createProductCommand,
   createQuoteCommand,
   createTerminalCommand,
   createWebhookCommand,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -562,6 +562,16 @@ export {
 
 export type { CreateTerminalPaymentParams, Terminal, TerminalAmount, TerminalPayment } from "./terminals/index.js";
 
+export {
+  listProducts,
+  ProductUnitPriceSchema,
+  ProductLinkSchema,
+  ProductSchema,
+  ProductListResponseSchema,
+} from "./products/index.js";
+
+export type { ListProductsParams, Product, ProductLink, ProductUnitPrice } from "./products/index.js";
+
 export type {
   ScaMethod,
   ScaSession,

--- a/packages/core/src/products/index.ts
+++ b/packages/core/src/products/index.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export { listProducts } from "./service.js";
+
+export { ProductUnitPriceSchema, ProductLinkSchema, ProductSchema, ProductListResponseSchema } from "./schemas.js";
+
+export type { ListProductsParams, Product, ProductLink, ProductUnitPrice } from "./types.js";

--- a/packages/core/src/products/schemas.test.ts
+++ b/packages/core/src/products/schemas.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import { ProductLinkSchema, ProductListResponseSchema, ProductSchema, ProductUnitPriceSchema } from "./schemas.js";
+
+describe("ProductUnitPriceSchema", () => {
+  it("accepts a decimal-string value and any ISO currency", () => {
+    const result = ProductUnitPriceSchema.parse({ value: "12.50", currency: "EUR" });
+    expect(result.value).toBe("12.50");
+    expect(result.currency).toBe("EUR");
+  });
+
+  it("rejects numeric values (must be decimal string per Qonto convention)", () => {
+    expect(() => ProductUnitPriceSchema.parse({ value: 12.5, currency: "EUR" })).toThrow();
+  });
+
+  it("rejects when currency is missing", () => {
+    expect(() => ProductUnitPriceSchema.parse({ value: "12.50" })).toThrow();
+  });
+});
+
+describe("ProductLinkSchema", () => {
+  it("parses a link object", () => {
+    const result = ProductLinkSchema.parse({ title: "Datasheet", url: "https://example.com/d.pdf" });
+    expect(result.title).toBe("Datasheet");
+    expect(result.url).toBe("https://example.com/d.pdf");
+  });
+});
+
+describe("ProductSchema", () => {
+  it("accepts a minimal product with only id", () => {
+    const result = ProductSchema.parse({ id: "prod-1" });
+    expect(result.id).toBe("prod-1");
+    expect(result.title).toBeUndefined();
+  });
+
+  it("accepts a full product object", () => {
+    const result = ProductSchema.parse({
+      id: "prod-1",
+      title: "Espresso",
+      description: "A double shot of espresso",
+      internal_note: "Sourced from supplier X",
+      type: "good",
+      unit_price: { value: "2.50", currency: "EUR" },
+      vat_rate: "0.2",
+      unit: "cup",
+      vat_exemption_code: null,
+      links: [{ title: "Image", url: "https://example.com/espresso.jpg" }],
+      organization_id: "org-1",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    });
+    expect(result.title).toBe("Espresso");
+    expect(result.unit_price?.value).toBe("2.50");
+    expect(result.vat_exemption_code).toBeNull();
+    expect(result.links).toHaveLength(1);
+  });
+
+  it("accepts nullable description, internal_note, unit, vat_exemption_code", () => {
+    const result = ProductSchema.parse({
+      id: "prod-1",
+      description: null,
+      internal_note: null,
+      unit: null,
+      vat_exemption_code: null,
+    });
+    expect(result.description).toBeNull();
+    expect(result.internal_note).toBeNull();
+    expect(result.unit).toBeNull();
+    expect(result.vat_exemption_code).toBeNull();
+  });
+
+  it("strips unknown fields", () => {
+    const result = ProductSchema.parse({
+      id: "prod-1",
+      title: "Espresso",
+      // Forward-compat: API might add fields. `.strip()` discards them.
+      extra: "ignored",
+    });
+    expect(result).not.toHaveProperty("extra");
+  });
+
+  it("rejects when id is missing", () => {
+    expect(() =>
+      ProductSchema.parse({
+        title: "Espresso",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("ProductListResponseSchema", () => {
+  it("parses an empty list", () => {
+    const result = ProductListResponseSchema.parse({
+      products: [],
+      meta: {
+        current_page: 1,
+        next_page: null,
+        prev_page: null,
+        total_pages: 1,
+        total_count: 0,
+        per_page: 100,
+      },
+    });
+    expect(result.products).toEqual([]);
+    expect(result.meta.total_count).toBe(0);
+  });
+
+  it("parses a populated list", () => {
+    const result = ProductListResponseSchema.parse({
+      products: [
+        {
+          id: "prod-1",
+          title: "Espresso",
+          type: "good",
+        },
+      ],
+      meta: {
+        current_page: 1,
+        next_page: null,
+        prev_page: null,
+        total_pages: 1,
+        total_count: 1,
+        per_page: 100,
+      },
+    });
+    expect(result.products).toHaveLength(1);
+    expect(result.products[0]?.title).toBe("Espresso");
+  });
+});

--- a/packages/core/src/products/schemas.ts
+++ b/packages/core/src/products/schemas.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+import { PaginationMetaSchema } from "../api-types.schema.js";
+
+/**
+ * Schema for a product's unit price as returned under
+ * `Product.unit_price`. `value` is a decimal string per Qonto convention
+ * (the API rejects floating-point JSON numbers for monetary fields); the
+ * schema does not enforce that — the value is server-trusted echo-back.
+ */
+export const ProductUnitPriceSchema = z
+  .object({
+    value: z.string(),
+    currency: z.string(),
+  })
+  .strip();
+
+/**
+ * Schema for a single link attached to a product.
+ */
+export const ProductLinkSchema = z
+  .object({
+    title: z.string(),
+    url: z.string(),
+  })
+  .strip();
+
+/**
+ * Schema for a Qonto product as returned by `GET /v2/products`.
+ *
+ * Only `id` is required. Every other field is optional because the API
+ * documentation does not guarantee their presence on every product, and the
+ * shape varies by organization (e.g. `vat_exemption_code` is only populated
+ * for Italian organizations). `description`, `internal_note`, `unit`, and
+ * `vat_exemption_code` are explicitly `.nullable()` because the API echoes
+ * back `null` when the caller cleared them.
+ */
+export const ProductSchema = z
+  .object({
+    id: z.string(),
+    title: z.string().optional(),
+    description: z.string().nullable().optional(),
+    internal_note: z.string().nullable().optional(),
+    type: z.string().optional(),
+    unit_price: ProductUnitPriceSchema.optional(),
+    vat_rate: z.string().optional(),
+    unit: z.string().nullable().optional(),
+    vat_exemption_code: z.string().nullable().optional(),
+    links: z.array(ProductLinkSchema).optional(),
+    organization_id: z.string().optional(),
+    created_at: z.string().optional(),
+    updated_at: z.string().optional(),
+  })
+  .strip();
+
+/**
+ * Schema for the `GET /v2/products` list response.
+ */
+export const ProductListResponseSchema = z
+  .object({
+    products: z.array(ProductSchema),
+    meta: PaginationMetaSchema,
+  })
+  .strip();

--- a/packages/core/src/products/service.test.ts
+++ b/packages/core/src/products/service.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpClient } from "../http-client.js";
+import { jsonResponse } from "../testing/json-response.js";
+import { listProducts } from "./service.js";
+
+describe("listProducts", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists products without params", async () => {
+    const body = {
+      products: [
+        {
+          id: "prod-1",
+          title: "Espresso",
+          type: "good",
+          unit_price: { value: "2.50", currency: "EUR" },
+          vat_rate: "0.2",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 1, per_page: 100 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    const result = await listProducts(client);
+    expect(result.products).toHaveLength(1);
+    expect(result.products[0]?.id).toBe("prod-1");
+    expect(result.products[0]?.title).toBe("Espresso");
+    expect(result.meta.current_page).toBe(1);
+
+    const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/products");
+    expect(url.search).toBe("");
+    expect(init.method).toBe("GET");
+  });
+
+  it("passes pagination params as query strings", async () => {
+    const body = {
+      products: [],
+      meta: { current_page: 2, next_page: null, prev_page: 1, total_pages: 2, total_count: 30, per_page: 25 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    await listProducts(client, { page: 2, per_page: 25 });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("page")).toBe("2");
+    expect(url.searchParams.get("per_page")).toBe("25");
+  });
+
+  it("passes sort_by as a query string", async () => {
+    const body = {
+      products: [],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 0, per_page: 100 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    await listProducts(client, { sort_by: "created_at:desc" });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("sort_by")).toBe("created_at:desc");
+  });
+
+  it("omits undefined params", async () => {
+    const body = {
+      products: [],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 0, per_page: 100 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    await listProducts(client, { page: 3 });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.searchParams.get("page")).toBe("3");
+    expect(url.searchParams.has("per_page")).toBe(false);
+    expect(url.searchParams.has("sort_by")).toBe(false);
+  });
+
+  it("returns an empty list when the organization has no products", async () => {
+    const body = {
+      products: [],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 0, per_page: 100 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    const result = await listProducts(client);
+    expect(result.products).toHaveLength(0);
+    expect(result.meta.total_count).toBe(0);
+  });
+
+  it("preserves optional fields including links and vat_exemption_code", async () => {
+    const body = {
+      products: [
+        {
+          id: "prod-2",
+          title: "Consulting hour",
+          description: "Hourly rate for consulting",
+          internal_note: null,
+          type: "service",
+          unit_price: { value: "120.00", currency: "EUR" },
+          vat_rate: "0.22",
+          unit: "hour",
+          vat_exemption_code: "N2.1",
+          links: [{ title: "Datasheet", url: "https://example.com/datasheet.pdf" }],
+          organization_id: "org-1",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+        },
+      ],
+      meta: { current_page: 1, next_page: null, prev_page: null, total_pages: 1, total_count: 1, per_page: 100 },
+    };
+    fetchSpy.mockReturnValue(jsonResponse(body));
+
+    const result = await listProducts(client);
+    const product = result.products[0];
+    expect(product?.type).toBe("service");
+    expect(product?.unit_price?.value).toBe("120.00");
+    expect(product?.unit_price?.currency).toBe("EUR");
+    expect(product?.vat_exemption_code).toBe("N2.1");
+    expect(product?.unit).toBe("hour");
+    expect(product?.links).toEqual([{ title: "Datasheet", url: "https://example.com/datasheet.pdf" }]);
+  });
+});

--- a/packages/core/src/products/service.ts
+++ b/packages/core/src/products/service.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { PaginationMeta } from "../api-types.js";
+import type { HttpClient } from "../http-client.js";
+import { parseResponse } from "../response.js";
+import { ProductListResponseSchema } from "./schemas.js";
+import type { ListProductsParams, Product } from "./types.js";
+
+/**
+ * List products from the authenticated organization's catalogue.
+ *
+ * Required scope: `product.read`. Per the Qonto auth table the endpoint
+ * accepts both api-key and OAuth bearer auth.
+ */
+export async function listProducts(
+  client: HttpClient,
+  params?: ListProductsParams,
+): Promise<{ products: readonly Product[]; meta: PaginationMeta }> {
+  const query: Record<string, string> = {};
+  if (params) {
+    if (params.page !== undefined) query["page"] = String(params.page);
+    if (params.per_page !== undefined) query["per_page"] = String(params.per_page);
+    if (params.sort_by !== undefined) query["sort_by"] = params.sort_by;
+  }
+  const endpointPath = "/v2/products";
+  const response = await client.get(endpointPath, Object.keys(query).length > 0 ? query : undefined);
+  return parseResponse(ProductListResponseSchema, response, endpointPath);
+}

--- a/packages/core/src/products/types.ts
+++ b/packages/core/src/products/types.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Monetary amount for a product's unit price.
+ *
+ * `value` is a decimal string (e.g. `"12.50"`). `currency` is ISO 4217.
+ */
+export interface ProductUnitPrice {
+  readonly value: string;
+  readonly currency: string;
+}
+
+/**
+ * A free-form link attached to a product (e.g. a datasheet URL, an image link).
+ */
+export interface ProductLink {
+  readonly title: string;
+  readonly url: string;
+}
+
+/**
+ * A catalogue product as returned by `GET /v2/products`.
+ *
+ * Required scope: `product.read`. Currently only the LIST endpoint is exposed
+ * by Qonto; CRUD endpoints are documented in the OpenAPI security schemes as
+ * `product.write` but the routes are not yet published.
+ *
+ * All fields beyond `id` are modelled as optional because the Qonto reference
+ * documentation does not guarantee their presence on every product (e.g.
+ * `vat_exemption_code` is Italian-organization-specific; `internal_note`,
+ * `unit`, and `links` are caller-populated and routinely omitted).
+ */
+export interface Product {
+  readonly id: string;
+  readonly title?: string | undefined;
+  readonly description?: string | null | undefined;
+  readonly internal_note?: string | null | undefined;
+  readonly type?: string | undefined;
+  readonly unit_price?: ProductUnitPrice | undefined;
+  readonly vat_rate?: string | undefined;
+  readonly unit?: string | null | undefined;
+  readonly vat_exemption_code?: string | null | undefined;
+  readonly links?: readonly ProductLink[] | undefined;
+  readonly organization_id?: string | undefined;
+  readonly created_at?: string | undefined;
+  readonly updated_at?: string | undefined;
+}
+
+/**
+ * Parameters accepted by `GET /v2/products`.
+ *
+ * `sort_by` follows the Qonto convention `field:direction` — e.g.
+ * `"title:asc"`, `"created_at:desc"`. Supported fields per the Qonto docs
+ * are `created_at` and `title`.
+ */
+export interface ListProductsParams {
+  readonly page?: number;
+  readonly per_page?: number;
+  readonly sort_by?: string;
+}

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -245,6 +245,11 @@
       "tests": [],
       "notes": ""
     },
+    "cli:packages/cli/src/commands/product.ts": {
+      "status": "covered",
+      "tests": ["packages/e2e/src/products/cli.e2e.test.ts"],
+      "notes": "List-only; CRUD endpoints not yet published by Qonto."
+    },
     "cli:packages/cli/src/commands/quote.ts": {
       "status": "pending",
       "tests": [],
@@ -714,6 +719,11 @@
       "status": "pending",
       "tests": [],
       "notes": ""
+    },
+    "core:packages/core/src/products/service.ts#listProducts": {
+      "status": "covered",
+      "tests": ["packages/e2e/src/products/cli.e2e.test.ts", "packages/e2e/src/products/mcp.e2e.test.ts"],
+      "notes": "E2E exercises GET /v2/products via CLI and MCP. Sandbox tenants without products surface an empty list; tests assert shape only when empty."
     },
     "core:packages/core/src/recurring-transfers/service.ts#cancelRecurringTransfer": {
       "status": "pending",
@@ -1309,6 +1319,11 @@
       "status": "pending",
       "tests": [],
       "notes": ""
+    },
+    "mcp:product_list": {
+      "status": "covered",
+      "tests": ["packages/e2e/src/products/mcp.e2e.test.ts"],
+      "notes": "E2E exercises product_list (list products) via the MCP stdio harness; api-key gated so CI runs too."
     },
     "mcp:quote_create": {
       "status": "pending",

--- a/packages/e2e/src/mcp/server.e2e.test.ts
+++ b/packages/e2e/src/mcp/server.e2e.test.ts
@@ -92,6 +92,7 @@ const EXPECTED_TOOLS = [
   "sca_session_mock_decision",
   "terminal_list",
   "terminal_payment_create",
+  "product_list",
   "supplier_invoice_list",
   "supplier_invoice_show",
   "supplier_invoice_bulk_create",

--- a/packages/e2e/src/products/cli.e2e.test.ts
+++ b/packages/e2e/src/products/cli.e2e.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { ProductSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { cliJson } from "../helpers.js";
+import { hasApiKeyCredentials } from "../sandbox.js";
+
+interface ProductItem {
+  readonly id: string;
+  readonly title?: string;
+  readonly type?: string;
+}
+
+// Per the Qonto auth table, `GET /v2/products` accepts both api-key and OAuth
+// (scope: `product.read`). Gate on api-key so the suite runs in CI as well as
+// locally. Most sandbox tenants do not have products provisioned — assertions
+// degrade gracefully to "list shape only" when the list is empty rather than
+// failing on environmental gaps.
+describe.skipIf(!hasApiKeyCredentials())("product CLI commands (e2e)", () => {
+  describe("product list", () => {
+    it("lists products (possibly empty) as JSON", () => {
+      const products = cliJson<ProductItem[]>("product", "list");
+      expect(Array.isArray(products)).toBe(true);
+      const first = products[0];
+      if (first !== undefined) {
+        ProductSchema.parse(first);
+        expect(first).toHaveProperty("id");
+      }
+    });
+
+    it("supports pagination", () => {
+      const products = cliJson<ProductItem[]>("product", "list", "--per-page", "1", "--page", "1");
+      expect(Array.isArray(products)).toBe(true);
+      expect(products.length).toBeLessThanOrEqual(1);
+    });
+
+    it("supports --sort-by", () => {
+      const products = cliJson<ProductItem[]>("product", "list", "--sort-by", "created_at:desc", "--per-page", "5");
+      expect(Array.isArray(products)).toBe(true);
+    });
+  });
+});

--- a/packages/e2e/src/products/mcp.e2e.test.ts
+++ b/packages/e2e/src/products/mcp.e2e.test.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ProductListResponseSchema, ProductSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+
+interface ProductItem {
+  readonly id: string;
+  readonly title?: string;
+}
+
+interface ProductListResponse {
+  readonly products: ProductItem[];
+  readonly meta: {
+    readonly current_page: number;
+    readonly total_pages: number;
+    readonly total_count: number;
+  };
+}
+
+// `/v2/products` accepts api-key and OAuth per the Qonto auth table. Gate on
+// api-key so the suite runs in CI as well as locally.
+describe.skipIf(!hasApiKeyCredentials())("product MCP tools (e2e)", () => {
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv(),
+      stderr: "pipe",
+    });
+
+    client = new Client({ name: "e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  describe("product_list", () => {
+    it("returns a list of products with the expected structure", async () => {
+      const result = await client.callTool({ name: "product_list", arguments: {} });
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
+      ProductListResponseSchema.parse(parsed);
+      expect(parsed).toHaveProperty("products");
+      expect(parsed).toHaveProperty("meta");
+      expect(Array.isArray(parsed.products)).toBe(true);
+      const first = parsed.products[0];
+      if (first !== undefined) {
+        ProductSchema.parse(first);
+      }
+    });
+
+    it("supports pagination", async () => {
+      const result = await client.callTool({
+        name: "product_list",
+        arguments: { per_page: 1, page: 1 },
+      });
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
+      expect(parsed.products.length).toBeLessThanOrEqual(1);
+      expect(parsed.meta.current_page).toBe(1);
+    });
+
+    it("supports sort_by", async () => {
+      const result = await client.callTool({
+        name: "product_list",
+        arguments: { sort_by: "title:asc", per_page: 5 },
+      });
+      if (result.isError === true) return;
+
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
+      expect(Array.isArray(parsed.products)).toBe(true);
+    });
+  });
+});

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -142,7 +142,8 @@ describe("createServer", () => {
       expect(toolNames).toContain("sca_session_mock_decision");
       expect(toolNames).toContain("terminal_list");
       expect(toolNames).toContain("terminal_payment_create");
-      expect(tools).toHaveLength(126);
+      expect(toolNames).toContain("product_list");
+      expect(tools).toHaveLength(127);
     });
 
     it("tools have descriptions", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -23,6 +23,7 @@ import {
   registerMembershipTools,
   registerOrgTools,
   registerPaymentLinkTools,
+  registerProductTools,
   registerQuoteTools,
   registerRecurringTransferTools,
   registerRequestTools,
@@ -73,6 +74,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerMembershipTools(server, getClient);
   registerOrgTools(server, getClient);
   registerPaymentLinkTools(server, getClient);
+  registerProductTools(server, getClient);
   registerQuoteTools(server, getClient);
   registerRecurringTransferTools(server, getClient);
   registerRequestTools(server, getClient);

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -19,6 +19,7 @@ export { registerLabelTools } from "./label.js";
 export { registerMembershipTools } from "./membership.js";
 export { registerOrgTools } from "./org.js";
 export { registerPaymentLinkTools } from "./payment-link.js";
+export { registerProductTools } from "./product.js";
 export { registerQuoteTools } from "./quote.js";
 export { registerRecurringTransferTools } from "./recurring-transfer.js";
 export { registerRequestTools } from "./request.js";

--- a/packages/mcp/src/tools/product.test.ts
+++ b/packages/mcp/src/tools/product.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { jsonResponse } from "@qontoctl/core/testing";
+import { connectInMemory } from "../testing/mcp-helpers.js";
+
+const sampleProduct = {
+  id: "prod-1",
+  title: "Espresso",
+  type: "good",
+  unit_price: { value: "2.50", currency: "EUR" },
+  vat_rate: "0.2",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+function meta(overrides: Partial<{ current_page: number; next_page: number | null; total_count: number }> = {}) {
+  return {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 1,
+    per_page: 100,
+    ...overrides,
+  };
+}
+
+describe("product MCP tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let mcpClient: Client;
+
+  beforeEach(async () => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    ({ mcpClient } = await connectInMemory(fetchSpy));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("product_list", () => {
+    it("returns products from the API", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ products: [sampleProduct], meta: meta() }));
+
+      const result = await mcpClient.callTool({ name: "product_list", arguments: {} });
+
+      const content = result.content as { type: string; text: string }[];
+      expect(content).toHaveLength(1);
+      const parsed = JSON.parse(content[0]?.text ?? "") as { products: unknown[]; meta: unknown };
+      expect(parsed.products).toHaveLength(1);
+      expect(parsed.meta).toBeDefined();
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.pathname).toBe("/v2/products");
+    });
+
+    it("passes pagination params to the API", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ products: [], meta: meta({ current_page: 2, total_count: 0 }) }));
+
+      await mcpClient.callTool({ name: "product_list", arguments: { page: 2, per_page: 25 } });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("page")).toBe("2");
+      expect(url.searchParams.get("per_page")).toBe("25");
+    });
+
+    it("forwards sort_by to the API", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ products: [], meta: meta({ total_count: 0 }) }));
+
+      await mcpClient.callTool({ name: "product_list", arguments: { sort_by: "title:asc" } });
+
+      const [url] = fetchSpy.mock.calls[0] as [URL];
+      expect(url.searchParams.get("sort_by")).toBe("title:asc");
+    });
+
+    it("rejects per_page above 100 at the MCP boundary", async () => {
+      const result = await mcpClient.callTool({
+        name: "product_list",
+        arguments: { per_page: 500 },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/mcp/src/tools/product.ts
+++ b/packages/mcp/src/tools/product.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { HttpClient } from "@qontoctl/core";
+import { listProducts } from "@qontoctl/core";
+import { withClient } from "../errors.js";
+
+export function registerProductTools(server: McpServer, getClient: () => Promise<HttpClient>): void {
+  server.registerTool(
+    "product_list",
+    {
+      description: "List products from the authenticated organization's catalogue",
+      inputSchema: {
+        page: z.number().int().positive().optional().describe("Page number"),
+        per_page: z.number().int().positive().max(100).optional().describe("Items per page (max 100)"),
+        sort_by: z
+          .string()
+          .optional()
+          .describe('Sort order in the form "field:direction" (e.g. "created_at:desc", "title:asc")'),
+      },
+    },
+    async ({ page, per_page, sort_by }) =>
+      withClient(getClient, async (client) => {
+        const result = await listProducts(client, {
+          ...(page !== undefined ? { page } : {}),
+          ...(per_page !== undefined ? { per_page } : {}),
+          ...(sort_by !== undefined ? { sort_by } : {}),
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ products: result.products, meta: result.meta }, null, 2),
+            },
+          ],
+        };
+      }),
+  );
+}

--- a/packages/qontoctl/src/cli.ts
+++ b/packages/qontoctl/src/cli.ts
@@ -13,6 +13,7 @@ import {
   createProgram,
   createLabelCommand,
   createMembershipCommand,
+  createProductCommand,
   createQuoteCommand,
   createTerminalCommand,
   createWebhookCommand,
@@ -33,6 +34,7 @@ program.addCommand(createCreditNoteCommand());
 program.addCommand(createInternalTransferCommand());
 program.addCommand(createLabelCommand());
 program.addCommand(createMembershipCommand());
+program.addCommand(createProductCommand());
 program.addCommand(createQuoteCommand());
 program.addCommand(createTerminalCommand());
 program.addCommand(createWebhookCommand());


### PR DESCRIPTION
## Summary

Adds CLI + MCP coverage for the Qonto Products API:

- `product list` / `product_list` — `GET /v2/products` with pagination (`--page` / `--per-page` / `page` / `per_page`) and sort (`--sort-by` / `sort_by`, e.g. `created_at:desc`, `title:asc`).

Per Qonto's auth table the `/v2/products` endpoint accepts both api-key and OAuth (scope: `product.read`), so the E2E suites gate on `hasApiKeyCredentials()` and run in CI as well as locally. Sandbox tenants without provisioned products surface an empty list — assertions degrade gracefully to "list shape only" when empty.

The `Product` schema models only `id` as required; every other field is `optional` (and `nullable` where the API echoes back `null`) because the public reference does not guarantee field presence on every product — `vat_exemption_code` is Italian-org-specific; `internal_note`, `unit`, and `links` are caller-populated and routinely omitted.

Updates the `product.read` scope copy in `auth setup` and `docs/oauth-setup.md` to drop the "no qontoctl command yet" marker. `product.write` remains forward-looking until Qonto publishes CRUD endpoints (the OpenAPI security schemes reference them, but the routes are not yet in the public API reference). Coverage manifest gains 3 covered entries pointing at the new E2E suites.

Closes #483.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 766 CLI tests + 1073 core tests + all MCP tests pass; products coverage 100% (statements/branches/functions/lines) on `core/products/{schemas,service}.ts`
- [x] `pnpm lint` — clean
- [x] `pnpm license-check` — clean
- [x] `node scripts/check-coverage-drift.js` — passes (3 new `covered` entries: `core:.../products/service.ts#listProducts`, `cli:.../commands/product.ts`, `mcp:product_list`)
- [x] `pnpm test:e2e` (full local run): `src/products/cli.e2e.test.ts` (3 tests) + `src/products/mcp.e2e.test.ts` (3 tests) PASS against live sandbox. All api-key-compatible E2E suites PASS — these are the suites CI runs.