### PR TITLE
(fix) accept null items in client-invoice schema (#575)

### DIFF
--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -350,4 +350,24 @@ describe("ClientInvoiceSchema", () => {
     expect(result).not.toHaveProperty("extra_field");
     expect(result.client).not.toHaveProperty("unknown_field");
   });
+
+  // Regression for #575: Qonto returns `items: null` for drafts with no line
+  // items (not `[]`). The schema must accept both shapes and expose `[]` to
+  // consumers, so downstream code can always treat `items` as `Item[]`.
+  it("normalizes items: null to [] (regression: #575)", () => {
+    const result = ClientInvoiceSchema.parse({ ...validInvoice, items: null });
+    expect(result.items).toEqual([]);
+  });
+
+  it("accepts items: [] and exposes it as-is (regression: #575)", () => {
+    const result = ClientInvoiceSchema.parse({ ...validInvoice, items: [] });
+    expect(result.items).toEqual([]);
+  });
+
+  it("accepts items: null through parseResponse wrapper (regression: #575)", () => {
+    const wrapped = { client_invoice: { ...validInvoice, items: null } };
+    const wrapperSchema = z.object({ client_invoice: ClientInvoiceSchema });
+    const result = parseResponse(wrapperSchema, wrapped, "/v2/client_invoices/inv-1");
+    expect(result.client_invoice.items).toEqual([]);
+  });
 });

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -119,7 +119,12 @@ export const ClientInvoiceSchema = z
     header: z.string().nullable(),
     footer: z.string().nullable(),
     discount: ClientInvoiceDiscountSchema.nullable().optional(),
-    items: z.array(ClientInvoiceItemSchema),
+    // Qonto returns `items: null` for drafts with no line items (not `[]`).
+    // Normalize at the schema boundary so consumers always see `ClientInvoiceItem[]`.
+    items: z
+      .array(ClientInvoiceItemSchema)
+      .nullable()
+      .transform((v) => v ?? []),
     client: ClientInvoiceClientSchema,
   })
   .strip() satisfies z.ZodType<ClientInvoice>;

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -196,4 +196,69 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
       }
     });
   });
+
+  // Regression for #575: Qonto returns `items: null` for drafts with no line
+  // items. Pre-fix, `client-invoice show` blew up with a Zod validation error
+  // on any such draft. This test creates an empty-items draft and shows it,
+  // exercising the schema-boundary normalization end-to-end through the CLI.
+  describe("client-invoice show empty-items draft (regression: #575)", () => {
+    let emptyDraftId: string | undefined;
+
+    it("creates a draft with no line items", () => {
+      // Get a client ID from existing clients
+      const clientListOutput = cli("--output", "json", "client", "list");
+      const clients = JSON.parse(clientListOutput) as { id: string }[];
+      if (clients.length === 0) {
+        return;
+      }
+
+      const clientId = (clients[0] as { id: string }).id;
+      const today = new Date().toISOString().split("T")[0] as string;
+      const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const body = JSON.stringify({
+        client_id: clientId,
+        issue_date: today,
+        due_date: dueDate,
+        currency: "EUR",
+        terms_and_conditions: "E2E #575 empty-items draft — safe to delete",
+        items: [],
+      });
+
+      try {
+        const output = cli("--output", "json", "client-invoice", "create", "--body", body);
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id");
+        expect(parsed).toHaveProperty("status", "draft");
+        emptyDraftId = parsed["id"] as string;
+      } catch {
+        // Sandbox/prod organizations may reject empty-items drafts (IBAN
+        // setup, business-rule constraints). Skip the show round-trip.
+      }
+    });
+
+    it("shows the empty-items draft and round-trips items as []", () => {
+      if (emptyDraftId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "show", emptyDraftId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      // Round-trip via the full schema — this is what blew up pre-#575.
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(emptyDraftId);
+      // Post-transform: API `null` is exposed to consumers as `[]`.
+      expect(invoice.items).toEqual([]);
+    });
+
+    it("cleans up the empty-items draft", () => {
+      if (emptyDraftId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "delete", emptyDraftId, "--yes");
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      expect(parsed).toHaveProperty("deleted", true);
+    });
+  });
 });


### PR DESCRIPTION
## Description

`client-invoice show` previously blew up with `Invalid input: expected array, received null` on any draft client-invoice that had no line items. The Qonto API returns `items: null` (not `[]`) in that case, but `ClientInvoiceSchema.items` was declared as `z.array(ClientInvoiceItemSchema)` with no nullable handling.

This PR normalizes `null → []` at the schema boundary:

```ts
items: z
  .array(ClientInvoiceItemSchema)
  .nullable()
  .transform((v) => v ?? []),
```

`ClientInvoice.items` stays typed as `readonly ClientInvoiceItem[]` (per `types.ts:117`), so consumers see no change — both shapes from the wire collapse to the same `[]` post-parse.

The deliberate divergence from `payment-link.schema.ts:45` (`.nullable()` only — consumer surface is `Item[] | null`) is by design: that schema's consumers are written for the nullable shape; client-invoice consumers expect a flat `Item[]`.

## Related Issue

Closes #575

## Testing

**Unit tests** (`packages/core/src/client-invoices/schemas.test.ts`) — 3 new regression tests:
- `normalizes items: null to [] (regression: #575)`
- `accepts items: [] and exposes it as-is (regression: #575)`
- `accepts items: null through parseResponse wrapper (regression: #575)` — mirrors the real `getClientInvoice` call path

```
pnpm --filter @qontoctl/core test schemas.test.ts -t "#575"
→ 3 passed | 238 skipped (241 total)
```

**E2E** (`packages/e2e/src/client-invoices/cli.e2e.test.ts`) — new describe block `client-invoice show empty-items draft (regression: #575)` with 3 lifecycle steps:
1. Create draft with `items: []` body
2. Show it, schema-parse the response, assert `items === []` post-transform
3. Delete

```
vitest run src/client-invoices/cli.e2e.test.ts
→ 15 passed (12 prior + 3 new)
```

**Live repro from the issue:**

```
node packages/qontoctl/dist/cli.js --auth api-key client-invoice show 019e1dcc-0085-71f6-bfa7-7e6f413b7d1e
→ Pre-fix: Invalid API response from /v2/client_invoices/019e1dcc-...: client_invoice.items: Invalid input
→ Post-fix: draft | Qonto Sandbox | 0.00 EUR (and `--output json` shows `items: []`)
```

**Full pre-PR validation:**
- `pnpm build` → 5/5 packages
- `pnpm test` → 766 CLI + 241 core + ... all pass
- `pnpm lint` → 8/8 packages
- `pnpm test:e2e` (full suite) → 340 passed, 5 skipped, 1 unrelated failure (`payment-link.e2e.test.ts > ensures a payment-link connection exists` — Qonto sandbox HTTP 500, different module)

## CLA Acknowledgment

- [x] I agree to the [Contributor License Agreement](https://github.com/alexey-pelykh/qontoctl/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla)