### PR TITLE
(fix) log Request headers after per-request additions (#576)

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -1016,14 +1016,69 @@ describe("HttpClient", () => {
       const headerLogCalls = logger.debug.mock.calls.filter(
         (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
       );
-      // The header log is emitted from buildHeaders before the SCA token is added in
-      // fetchWithRetry, so the SCA token isn't currently present in the captured log.
-      // The redaction map nonetheless covers the header name as defense-in-depth: any
-      // future log path that captures the assembled headers will redact it.
-      for (const call of headerLogCalls) {
-        const headerLog = call[0] as string;
-        expect(headerLog).not.toContain("retry-token-secret-ABC");
-      }
+      expect(headerLogCalls.length).toBeGreaterThan(0);
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).not.toContain("retry-token-secret-ABC");
+      expect(headerLog).toContain('"X-Qonto-Sca-Session-Token":"[REDACTED]"');
+    });
+
+    it("includes X-Qonto-2fa-Preference in Request headers debug log on writes when scaMethod is set (#576)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "123" }, { status: 201 }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        scaMethod: "paired-device",
+        logger,
+      });
+
+      await client.post("/v2/transfers", { amount: 100 });
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      expect(headerLogCalls.length).toBeGreaterThan(0);
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).toContain('"X-Qonto-2fa-Preference":"paired-device"');
+    });
+
+    it("includes X-Qonto-Idempotency-Key in Request headers debug log on writes (#576)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "123" }, { status: 201 }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/transfers", { amount: 100 }, { idempotencyKey: "00000000-0000-0000-0000-000000000001" });
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      expect(headerLogCalls.length).toBeGreaterThan(0);
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).toContain('"X-Qonto-Idempotency-Key":"00000000-0000-0000-0000-000000000001"');
+    });
+
+    it("does not include X-Qonto-2fa-Preference in Request headers debug log on GETs (#576)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        scaMethod: "paired-device",
+        logger,
+      });
+
+      await client.get("/v2/organizations");
+
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      expect(headerLogCalls.length).toBeGreaterThan(0);
+      const headerLog = headerLogCalls[0]?.[0] as string;
+      expect(headerLog).not.toContain("X-Qonto-2fa-Preference");
     });
 
     it("does not throw when logger is not provided", async () => {
@@ -1515,6 +1570,46 @@ describe("HttpClient", () => {
       const key2 = (calls[1]?.[1]?.headers as Record<string, string>)["X-Qonto-Idempotency-Key"];
       expect(key1).toBeDefined();
       expect(key1).toBe(key2);
+    });
+
+    it("preserves X-Qonto-2fa-Preference during fallback retry on write request and logs it (#576)", async () => {
+      fetchSpy
+        .mockReturnValueOnce(
+          jsonResponse({ errors: [{ code: "unauthorized", detail: "Unauthorized" }] }, { status: 401 }),
+        )
+        .mockReturnValue(jsonResponse({ id: "123" }, { status: 201 }));
+
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        // Function form mirrors the real OAuth bearer source (auto-refresh
+        // resolves it lazily). Exercising the function branch in `buildHeaders`
+        // alongside the string fallback gives this test coverage over the
+        // OAuth-routed path.
+        authorization: () => "Bearer oauth-token",
+        fallbackAuthorization: "slug:key",
+        scaMethod: "passkey",
+        logger,
+      });
+
+      await client.post("/v2/transfers", { amount: 100 });
+
+      // Transport: both attempts carry the SCA preference header.
+      const calls = fetchSpy.mock.calls as [URL, RequestInit][];
+      const primary = (calls[0]?.[1]?.headers as Record<string, string>)["X-Qonto-2fa-Preference"];
+      const fallback = (calls[1]?.[1]?.headers as Record<string, string>)["X-Qonto-2fa-Preference"];
+      expect(primary).toBe("passkey");
+      expect(fallback).toBe("passkey");
+
+      // Debug log: the SCA preference appears in BOTH Request headers entries
+      // (initial + fallback). Pre-#576 the log was emitted from buildHeaders
+      // before the per-request headers were added, so it was absent.
+      const headerLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].includes("Request headers"),
+      );
+      expect(headerLogCalls.length).toBe(2);
+      expect(headerLogCalls[0]?.[0] as string).toContain('"X-Qonto-2fa-Preference":"passkey"');
+      expect(headerLogCalls[1]?.[0] as string).toContain('"X-Qonto-2fa-Preference":"passkey"');
     });
 
     it("logs primary error body in debug mode before fallback", async () => {

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -485,6 +485,7 @@ export class HttpClient {
       this.logVerbose(
         `${method} ${url.toString()}${attempt > 0 ? ` (retry ${attempt})` : ""}${usingFallback ? " (fallback)" : ""}`,
       );
+      this.logDebug(`Request headers: ${JSON.stringify(redactSensitiveFields(headers))}`);
       if (body !== undefined) {
         this.logDebug(isFormData ? "Request body: [FormData]" : `Request body: ${body as string}`);
       }
@@ -553,6 +554,7 @@ export class HttpClient {
         }
 
         this.logVerbose(`${method} ${url.toString()} (fallback)`);
+        this.logDebug(`Request headers: ${JSON.stringify(redactSensitiveFields(fallbackHeaders))}`);
 
         const fallbackStart = performance.now();
         const fallbackResponse = await fetch(
@@ -638,8 +640,6 @@ export class HttpClient {
     if (this.stagingToken !== undefined) {
       headers[STAGING_TOKEN_HEADER] = this.stagingToken;
     }
-
-    this.logDebug(`Request headers: ${JSON.stringify(redactSensitiveFields(headers))}`);
 
     return headers;
   }


### PR DESCRIPTION
## Summary

Fixes #576.

The `Request headers` debug log inside `HttpClient.buildHeaders()` ran BEFORE `fetchWithRetry` added the per-request headers — `X-Qonto-Idempotency-Key`, `X-Qonto-2fa-Preference`, `X-Qonto-Sca-Session-Token`. So `--debug` output looked like the SCA-method header was missing on writes even when `resolveScaMethod` resolved a value (CLI flag / env / sandbox auto-default).

The transport itself was correct — the existing unit test at `packages/core/src/http-client.test.ts:1260` already asserted `init.headers["X-Qonto-2fa-Preference"]` was attached on writes. Only the debug visibility lied.

## Fix

Move the `logDebug("Request headers: ...")` call out of `buildHeaders` into `fetchWithRetry`, AFTER the per-request augmentations on both the initial path and the 401/403 fallback-retry path. Now the log reflects what's actually sent on the wire.

Empirical confirmation:

```
$ node packages/qontoctl/dist/cli.js card lock 00000000-0000-0000-0000-000000000000 --sca-method mock --debug
PUT https://thirdparty-sandbox.staging.qonto.co/v2/cards/00000000-…/lock
Request headers: {"Authorization":"[REDACTED]","User-Agent":"QontoCtl/…","Accept":"application/json","X-Qonto-Staging-Token":"[REDACTED]","X-Qonto-Idempotency-Key":"cfd24492-…","X-Qonto-2fa-Preference":"mock"}
```

(Pre-fix, the same command's log stopped at `X-Qonto-Staging-Token` and the per-request headers never appeared.)

## Acceptance criteria

- [x] `X-Qonto-2fa-Preference: <method>` appears in request headers when `resolveScaMethod` returns a non-undefined value — covered by existing test `packages/core/src/http-client.test.ts:1260`, unchanged.
- [x] Verified empirically via `--debug` for a card SCA-gated write (above).
- [x] Unit test asserts header presence in the debug log given a resolved method — added 4 new tests + strengthened 1 existing test.
- [x] Round-trip through the OAuth-routed path covered by the new fallback test (function-form `Authorization` mirrors real OAuth bearer source).

## Test plan

- [x] `pnpm --filter @qontoctl/core test -- --run http-client.test` — 111/111 pass (4 new + 1 strengthened).
- [x] `pnpm test` — 1080/1080 pass across all packages.
- [x] `pnpm lint` — clean.
- [x] `pnpm license-check` — clean.
- [x] `node scripts/check-coverage-drift.js` — clean (no new surfaces).
- [x] `pnpm test:e2e` — 277 passed locally; 59 failures are pre-existing (placeholder OAuth creds in local `.qontoctl.yaml` fail real-OAuth handshake; verified at HEAD with this PR stashed). CI is api-key-only so OAuth suites skip there per project CLAUDE.md § E2E in CI.

## Notes

- Side effect on 401/403 fallback writes: the `Request headers` log now fires twice (initial + fallback). This is correct — both attempts go on the wire with different auth and per-request state, so logging both is what debug users actually want. New fallback test asserts `headerLogCalls.length === 2`.
- The redaction map already covered `x-qonto-sca-session-token` defensively (lower-cased). After this fix, the strengthened existing test `redacts X-Qonto-Sca-Session-Token header in debug logs on retry with token` now meaningfully asserts the redacted form appears in the log instead of relying on the previous "absence is fine" pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)