### PR TITLE
(feat) add --sca-auto-approve flag for sandbox single-process SCA (#577)

### DIFF
--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -110,6 +110,45 @@ qontoctl sca-session mock-decision <token> allow
 
 The corresponding MCP tool is `sca_session_mock_decision`. Both are sandbox-only and refuse to run when no staging token is configured.
 
+### Auto-approving in a single CLI invocation
+
+The `--sca-auto-approve <decision>` flag (sandbox-only) tells the CLI to fire `mock-decision` against the captured SCA session token **before** polling begins, so SCA-gated writes complete in a single CLI invocation without external orchestration.
+
+```sh
+# Explicit:
+qontoctl --sca-auto-approve allow transfer create --beneficiary ben_… …
+qontoctl --sca-auto-approve deny  transfer create --beneficiary ben_… …  # tests the deny path
+```
+
+Behavior:
+
+- Values: `allow` (approves the challenge) or `deny` (rejects it). Commander enforces the enum at parse time.
+- **Auto-defaults to `allow`** when both conditions are true:
+  - A staging token is configured (`oauth.staging-token` or `QONTOCTL_STAGING_TOKEN`).
+  - The resolved `sca.method` is `"mock"` (the sandbox auto-default or an explicit setting).
+
+  Users who want to test the deny path opt in explicitly via `--sca-auto-approve deny`.
+- **Rejected against production paths.** Without a staging token, the flag throws up-front:
+
+  ```text
+  --sca-auto-approve is only available in the Qonto sandbox environment.
+  Configure `oauth.staging-token` in your config or set `QONTOCTL_STAGING_TOKEN`.
+  ```
+
+  This guarantees the flag cannot accidentally engage in production, where the `mocked_sca_sessions` endpoint does not exist.
+- **Hidden from `--help`** because end users in production should never need it; sandbox users get the auto-default behavior automatically.
+- **Not exposed via MCP** — like `--sca-method`, choosing the SCA outcome on a write is a threat-model risk in production and is intentionally not surfaced as a tool input.
+
+When the sandbox mock path is active, the CLI spinner copy switches from `"Waiting for SCA approval on your Qonto mobile app..."` to `"Waiting for SCA mock-decision..."` to disambiguate the flow from a real-device challenge.
+
+### Precedence
+
+Highest wins:
+
+1. `--sca-auto-approve <decision>` CLI flag
+2. Sandbox auto-default `"allow"` (only when a staging token is configured **and** the resolved `sca.method` is `"mock"`)
+3. Otherwise: no auto-approve — the CLI polls until the session is resolved externally (e.g., via `qontoctl sca-session mock-decision <token> allow` in another terminal).
+
 ## See also
 
 - [`oauth-setup.md`](./oauth-setup.md) — OAuth app registration, including sandbox setup

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -124,18 +124,20 @@ Behavior:
 
 - Values: `allow` (approves the challenge) or `deny` (rejects it). Commander enforces the enum at parse time.
 - **Auto-defaults to `allow`** when both conditions are true:
-  - A staging token is configured (`oauth.staging-token` or `QONTOCTL_STAGING_TOKEN`).
-  - The resolved `sca.method` is `"mock"` (the sandbox auto-default or an explicit setting).
+    - A staging token is configured (`oauth.staging-token` or `QONTOCTL_STAGING_TOKEN`).
+    - The resolved `sca.method` is `"mock"` (the sandbox auto-default or an explicit setting).
 
-  Users who want to test the deny path opt in explicitly via `--sca-auto-approve deny`.
+    Users who want to test the deny path opt in explicitly via `--sca-auto-approve deny`.
+
 - **Rejected against production paths.** Without a staging token, the flag throws up-front:
 
-  ```text
-  --sca-auto-approve is only available in the Qonto sandbox environment.
-  Configure `oauth.staging-token` in your config or set `QONTOCTL_STAGING_TOKEN`.
-  ```
+    ```text
+    --sca-auto-approve is only available in the Qonto sandbox environment.
+    Configure `oauth.staging-token` in your config or set `QONTOCTL_STAGING_TOKEN`.
+    ```
 
-  This guarantees the flag cannot accidentally engage in production, where the `mocked_sca_sessions` endpoint does not exist.
+    This guarantees the flag cannot accidentally engage in production, where the `mocked_sca_sessions` endpoint does not exist.
+
 - **Hidden from `--help`** because end users in production should never need it; sandbox users get the auto-default behavior automatically.
 - **Not exposed via MCP** — like `--sca-method`, choosing the SCA outcome on a write is a threat-model risk in production and is intentionally not surfaced as a tool input.
 

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -119,7 +119,11 @@ export function registerAccountCommands(program: Command): void {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data =
@@ -163,7 +167,11 @@ export function registerAccountCommands(program: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data =
@@ -210,7 +218,11 @@ export function registerAccountCommands(program: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/add.ts
+++ b/packages/cli/src/commands/beneficiary/add.ts
@@ -59,7 +59,11 @@ export function registerBeneficiaryAddCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/beneficiary/trust.ts
+++ b/packages/cli/src/commands/beneficiary/trust.ts
@@ -26,7 +26,11 @@ export function registerBeneficiaryTrustCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/untrust.ts
+++ b/packages/cli/src/commands/beneficiary/untrust.ts
@@ -26,7 +26,11 @@ export function registerBeneficiaryUntrustCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/beneficiary/update.ts
+++ b/packages/cli/src/commands/beneficiary/update.ts
@@ -58,7 +58,11 @@ export function registerBeneficiaryUpdateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/bulk-transfer/create.ts
+++ b/packages/cli/src/commands/bulk-transfer/create.ts
@@ -171,7 +171,11 @@ export function registerBulkTransferCreateCommand(parent: Command): void {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? bulkTransfer : [toTableRow(bulkTransfer)];

--- a/packages/cli/src/commands/card/create.ts
+++ b/packages/cli/src/commands/card/create.ts
@@ -152,7 +152,11 @@ export function registerCardCreateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -182,7 +186,11 @@ export function registerCardBulkCreateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data =

--- a/packages/cli/src/commands/card/discard.ts
+++ b/packages/cli/src/commands/card/discard.ts
@@ -35,7 +35,11 @@ export function registerCardDiscardCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/lock.ts
+++ b/packages/cli/src/commands/card/lock.ts
@@ -29,7 +29,11 @@ export function registerCardLockCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -51,7 +55,11 @@ export function registerCardUnlockCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/report.ts
+++ b/packages/cli/src/commands/card/report.ts
@@ -40,7 +40,11 @@ export function registerCardReportLostCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");
@@ -74,7 +78,11 @@ export function registerCardReportStolenCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/update-limits.ts
+++ b/packages/cli/src/commands/card/update-limits.ts
@@ -83,7 +83,11 @@ export function registerCardUpdateLimitsCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     process.stdout.write(formatOutput(formatCard(card, opts.output), opts.output) + "\n");

--- a/packages/cli/src/commands/card/update-nickname.ts
+++ b/packages/cli/src/commands/card/update-nickname.ts
@@ -29,7 +29,11 @@ export function registerCardUpdateNicknameCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/update-options.ts
+++ b/packages/cli/src/commands/card/update-options.ts
@@ -49,7 +49,11 @@ export function registerCardUpdateOptionsCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/card/update-restrictions.ts
+++ b/packages/cli/src/commands/card/update-restrictions.ts
@@ -51,7 +51,11 @@ export function registerCardUpdateRestrictionsCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data: unknown =

--- a/packages/cli/src/commands/internal-transfer.ts
+++ b/packages/cli/src/commands/internal-transfer.ts
@@ -63,7 +63,11 @@ export function createInternalTransferCommand(): Command {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? t : [internalTransferToTableRow(t)];

--- a/packages/cli/src/commands/intl-beneficiary/add.ts
+++ b/packages/cli/src/commands/intl-beneficiary/add.ts
@@ -65,7 +65,11 @@ export function registerIntlBeneficiaryAddCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-beneficiary/remove.ts
+++ b/packages/cli/src/commands/intl-beneficiary/remove.ts
@@ -38,7 +38,11 @@ export function registerIntlBeneficiaryRemoveCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/intl-beneficiary/update.ts
+++ b/packages/cli/src/commands/intl-beneficiary/update.ts
@@ -56,7 +56,11 @@ export function registerIntlBeneficiaryUpdateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? b : [toTableRow(b)];

--- a/packages/cli/src/commands/intl-transfer/create.ts
+++ b/packages/cli/src/commands/intl-transfer/create.ts
@@ -62,7 +62,11 @@ export function registerIntlTransferCreateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? transfer : [toTableRow(transfer)];

--- a/packages/cli/src/commands/recurring-transfer/cancel.ts
+++ b/packages/cli/src/commands/recurring-transfer/cancel.ts
@@ -38,7 +38,11 @@ export function registerRecurringTransferCancelCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/recurring-transfer/create.ts
+++ b/packages/cli/src/commands/recurring-transfer/create.ts
@@ -117,7 +117,11 @@ export function registerRecurringTransferCreateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? recurringTransfer : [toTableRow(recurringTransfer)];

--- a/packages/cli/src/commands/request/approve.ts
+++ b/packages/cli/src/commands/request/approve.ts
@@ -44,7 +44,11 @@ export function registerRequestApproveCommand(parent: Command): void {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/request/create-flash-card.ts
+++ b/packages/cli/src/commands/request/create-flash-card.ts
@@ -51,7 +51,11 @@ export function registerRequestCreateFlashCardCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/create-multi-transfer.ts
+++ b/packages/cli/src/commands/request/create-multi-transfer.ts
@@ -66,7 +66,11 @@ export function registerRequestCreateMultiTransferCommand(parent: Command): void
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/create-virtual-card.ts
+++ b/packages/cli/src/commands/request/create-virtual-card.ts
@@ -55,7 +55,11 @@ export function registerRequestCreateVirtualCardCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? request : [toTableRow(request)];

--- a/packages/cli/src/commands/request/decline.ts
+++ b/packages/cli/src/commands/request/decline.ts
@@ -44,7 +44,11 @@ export function registerRequestDeclineCommand(parent: Command): void {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/transfer/bulk-verify-payee.ts
+++ b/packages/cli/src/commands/transfer/bulk-verify-payee.ts
@@ -79,7 +79,11 @@ export function registerTransferBulkVerifyPayeeCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data =

--- a/packages/cli/src/commands/transfer/cancel.ts
+++ b/packages/cli/src/commands/transfer/cancel.ts
@@ -38,7 +38,11 @@ export function registerTransferCancelCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     if (opts.output === "json" || opts.output === "yaml") {

--- a/packages/cli/src/commands/transfer/create.ts
+++ b/packages/cli/src/commands/transfer/create.ts
@@ -149,7 +149,11 @@ export function registerTransferCreateCommand(parent: Command): void {
           idempotencyKey,
           ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
         }),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? transfer : [toTableRow(transfer)];

--- a/packages/cli/src/commands/transfer/verify-payee.ts
+++ b/packages/cli/src/commands/transfer/verify-payee.ts
@@ -45,7 +45,11 @@ export function registerTransferVerifyPayeeCommand(parent: Command): void {
             ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
           },
         ),
-      { verbose: opts.verbose === true || opts.debug === true, idempotencyKey: opts.idempotencyKey },
+      {
+        verbose: opts.verbose === true || opts.debug === true,
+        idempotencyKey: opts.idempotencyKey,
+        scaAutoApprove: opts.scaAutoApprove,
+      },
     );
 
     const data = opts.output === "json" || opts.output === "yaml" ? result : [toTableRow(result)];

--- a/packages/cli/src/inherited-options.test.ts
+++ b/packages/cli/src/inherited-options.test.ts
@@ -6,7 +6,7 @@ import { Command, Option } from "commander";
 import { addInheritableOptions, buildResolveOptions, resolveGlobalOptions } from "./inherited-options.js";
 
 describe("addInheritableOptions", () => {
-  it("adds --config, --profile, --verbose, --debug, and --sca-method to a command", () => {
+  it("adds --config, --profile, --verbose, --debug, --sca-method, and --sca-auto-approve to a command", () => {
     const cmd = new Command("test");
     addInheritableOptions(cmd);
 
@@ -16,6 +16,7 @@ describe("addInheritableOptions", () => {
     expect(optionNames).toContain("--verbose");
     expect(optionNames).toContain("--debug");
     expect(optionNames).toContain("--sca-method");
+    expect(optionNames).toContain("--sca-auto-approve");
   });
 
   it("adds -p as shorthand for --profile", () => {
@@ -32,6 +33,22 @@ describe("addInheritableOptions", () => {
 
     const scaOption = cmd.options.find((o) => o.long === "--sca-method");
     expect(scaOption?.hidden).toBe(true);
+  });
+
+  it("hides --sca-auto-approve from help", () => {
+    const cmd = new Command("test");
+    addInheritableOptions(cmd);
+
+    const scaAutoApproveOption = cmd.options.find((o) => o.long === "--sca-auto-approve");
+    expect(scaAutoApproveOption?.hidden).toBe(true);
+  });
+
+  it("restricts --sca-auto-approve to 'allow' or 'deny' via choices", () => {
+    const cmd = new Command("test");
+    addInheritableOptions(cmd);
+
+    const scaAutoApproveOption = cmd.options.find((o) => o.long === "--sca-auto-approve");
+    expect(scaAutoApproveOption?.argChoices).toEqual(["allow", "deny"]);
   });
 
   it("does NOT hide --config from help (visible flag)", () => {

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -24,10 +24,7 @@ export function addInheritableOptions(cmd: Command): Command {
     .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
     .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
     .addOption(
-      new Option(
-        "--sca-auto-approve <decision>",
-        "auto-fire SCA mock-decision in sandbox (testing only)",
-      )
+      new Option("--sca-auto-approve <decision>", "auto-fire SCA mock-decision in sandbox (testing only)")
         .choices(["allow", "deny"])
         .hideHelp(),
     )

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -10,8 +10,9 @@ import type { GlobalOptions } from "./options.js";
 
 /**
  * Adds inheritable global options to a command — currently `--config`, `--profile`,
- * `--verbose`, `--debug`, `--sca-method` (hidden), and `--auth`. These mirror the
- * program-level options so users can specify them after the subcommand.
+ * `--verbose`, `--debug`, `--sca-method` (hidden), `--sca-auto-approve` (hidden),
+ * and `--auth`. These mirror the program-level options so users can specify them
+ * after the subcommand.
  */
 export function addInheritableOptions(cmd: Command): Command {
   return cmd
@@ -22,6 +23,14 @@ export function addInheritableOptions(cmd: Command): Command {
     .addOption(new Option("--verbose", "enable verbose output"))
     .addOption(new Option("--debug", "enable debug output (implies --verbose)"))
     .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
+    .addOption(
+      new Option(
+        "--sca-auto-approve <decision>",
+        "auto-fire SCA mock-decision in sandbox (testing only)",
+      )
+        .choices(["allow", "deny"])
+        .hideHelp(),
+    )
     .addOption(
       new Option(
         "--auth <mode>",

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -38,6 +38,17 @@ export interface GlobalOptions {
    */
   readonly scaMethod?: string | undefined;
   /**
+   * Sandbox-only auto-approve preference for SCA mock-decision. Values:
+   * `"allow"` | `"deny"`. Hidden flag for sandbox testing — rejected in
+   * production paths (no staging-token). When unset and the sandbox mock SCA
+   * path is active (staging-token + resolved `sca.method === "mock"`),
+   * auto-defaults to `"allow"` so sandbox writes complete in a single CLI
+   * invocation without external `sca-session mock-decision` orchestration.
+   * Commander's `.choices(["allow", "deny"])` validates input at parse time.
+   * See `docs/sandbox-testing.md`.
+   */
+  readonly scaAutoApprove?: "allow" | "deny" | undefined;
+  /**
    * Auth precedence preference (`--auth` flag), one of `api-key`,
    * `api-key-first`, `oauth`, `oauth-first`. Highest-priority preference input —
    * overrides `QONTOCTL_AUTH` env var and `auth.preference` config field. When

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -334,6 +334,30 @@ describe("createProgram", () => {
       const helpText = program.helpInformation();
       expect(helpText).not.toContain("--sca-method");
     });
+
+    it("parses --sca-auto-approve option with 'allow'", () => {
+      const program = parseGlobalOptions(["--sca-auto-approve", "allow"]);
+      expect(program.opts()["scaAutoApprove"]).toBe("allow");
+    });
+
+    it("parses --sca-auto-approve option with 'deny'", () => {
+      const program = parseGlobalOptions(["--sca-auto-approve", "deny"]);
+      expect(program.opts()["scaAutoApprove"]).toBe("deny");
+    });
+
+    it("rejects --sca-auto-approve with invalid value at parse time", () => {
+      // Commander's .choices() enforces the enum at parse time so the runtime
+      // value is guaranteed to be "allow" | "deny" | undefined.
+      const program = createProgram();
+      program.exitOverride();
+      expect(() => program.parse(["--sca-auto-approve", "maybe"], { from: "user" })).toThrow();
+    });
+
+    it("does not include --sca-auto-approve in help output (hidden)", () => {
+      const program = createProgram();
+      const helpText = program.helpInformation();
+      expect(helpText).not.toContain("--sca-auto-approve");
+    });
   });
 
   describe("pagination options", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -49,6 +49,14 @@ export function createProgram(): Command {
     .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
     .addOption(
       new Option(
+        "--sca-auto-approve <decision>",
+        "auto-fire SCA mock-decision in sandbox (testing only)",
+      )
+        .choices(["allow", "deny"])
+        .hideHelp(),
+    )
+    .addOption(
+      new Option(
         "--auth <mode>",
         "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
       ).choices([...AUTH_PREFERENCES]),

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -48,10 +48,7 @@ export function createProgram(): Command {
     .addOption(new Option("--no-paginate", "disable auto-pagination"))
     .addOption(new Option("--sca-method <value>", "SCA method preference (advanced; for testing)").hideHelp())
     .addOption(
-      new Option(
-        "--sca-auto-approve <decision>",
-        "auto-fire SCA mock-decision in sandbox (testing only)",
-      )
+      new Option("--sca-auto-approve <decision>", "auto-fire SCA mock-decision in sandbox (testing only)")
         .choices(["allow", "deny"])
         .hideHelp(),
     )

--- a/packages/cli/src/sca.test.ts
+++ b/packages/cli/src/sca.test.ts
@@ -252,4 +252,214 @@ describe("executeWithCliSca", () => {
 
     expect(seenKeys).toEqual(["cli-supplied-key", "cli-supplied-key"]);
   });
+
+  describe("scaAutoApprove", () => {
+    function createSandboxClient(scaMethod?: string): TestableHttpClient {
+      return new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+        ...(scaMethod !== undefined ? { scaMethod } : {}),
+      });
+    }
+
+    it("throws synchronously when scaAutoApprove is set against a production (non-sandbox) client", async () => {
+      // AC #2: --sca-auto-approve must be rejected against production paths.
+      // The check fires BEFORE any wire request so the error reaches the user
+      // up-front instead of as a confusing 404 from Qonto.
+      const productionClient = client;
+      const mockSpin = createMockSpinner();
+
+      await expect(
+        executeWithCliSca(productionClient, async () => "should-not-run", {
+          poll: { sleep: noopSleep },
+          createSpinner: () => mockSpin,
+          scaAutoApprove: "allow",
+        }),
+      ).rejects.toThrow(/--sca-auto-approve is only available in the Qonto sandbox/);
+
+      // No wire request must be issued — the gate fires up-front.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // No spinner should be started either.
+      expect(mockSpin.start).not.toHaveBeenCalled();
+    });
+
+    it("explicit scaAutoApprove='allow' fires mock-decision then succeeds against sandbox", async () => {
+      // AC #1: --sca-auto-approve allow accepted; AC #5: end-to-end success.
+      const sandboxClient = createSandboxClient("mock");
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      // Sequence: 428 → POST allow (204) → poll allow (sandbox shape) → retry 200.
+      fetchSpy
+        .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 204 })))
+        .mockImplementationOnce(() => jsonResponse({ result: "allow" }));
+
+      const result = await executeWithCliSca(
+        sandboxClient,
+        async ({ scaSessionToken }) => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-explicit-allow");
+          }
+          return `retried-with-${scaSessionToken ?? "none"}`;
+        },
+        {
+          poll: { sleep: noopSleep },
+          createSpinner: () => mockSpin,
+          scaAutoApprove: "allow",
+        },
+      );
+
+      expect(result).toBe("retried-with-tok-explicit-allow");
+      const [decisionUrl, decisionInit] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(decisionUrl.pathname).toBe("/v2/mocked_sca_sessions/tok-explicit-allow/allow");
+      expect((decisionInit.method ?? "GET").toUpperCase()).toBe("POST");
+    });
+
+    it("auto-defaults to 'allow' when isMockSca is true and scaAutoApprove is undefined", async () => {
+      // AC #3: implicit --sca-auto-approve allow when staging-token + sca.method
+      // 'mock' are both active.
+      const sandboxMockClient = createSandboxClient("mock");
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      fetchSpy
+        .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 204 })))
+        .mockImplementationOnce(() => jsonResponse({ result: "allow" }));
+
+      await executeWithCliSca(
+        sandboxMockClient,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-auto-default");
+          }
+          return "ok";
+        },
+        { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+      );
+
+      // First wire call must be the mock-decision allow POST.
+      const [decisionUrl] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+      expect(decisionUrl.pathname).toBe("/v2/mocked_sca_sessions/tok-auto-default/allow");
+    });
+
+    it("does NOT auto-default when scaMethod is not 'mock' (sandbox without mock path)", async () => {
+      // Sandbox-routed but scaMethod resolved to 'paired-device' (or unset) —
+      // the user explicitly opted out of mock SCA, so auto-default must not fire.
+      // (Note: the sandbox POLL endpoint is still /v2/mocked_sca_sessions/<token>,
+      // because the SCA session itself is mocked in sandbox regardless of
+      // client.scaMethod. The thing that must NOT fire is the DECISION POST
+      // to /v2/mocked_sca_sessions/<token>/{allow,deny}.)
+      const sandboxNonMockClient = createSandboxClient("paired-device");
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      // Sandbox-shape poll response.
+      fetchSpy.mockImplementation(() => jsonResponse({ result: "allow" }));
+
+      await executeWithCliSca(
+        sandboxNonMockClient,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-no-auto");
+          }
+          return "ok";
+        },
+        { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+      );
+
+      // No DECISION POST should appear — only the poll(s) and the retry.
+      for (const call of fetchSpy.mock.calls) {
+        const [url, init] = call as [URL, RequestInit];
+        const isDecisionPost =
+          (init.method ?? "GET").toUpperCase() === "POST" &&
+          /\/v2\/mocked_sca_sessions\/[^/]+\/(allow|deny)$/.test(url.pathname);
+        expect(isDecisionPost).toBe(false);
+      }
+    });
+
+    it("does NOT auto-default in production when scaMethod is 'mock' (defensive — isMockSca already false)", async () => {
+      // Defensive layer: even if scaMethod somehow gets set to 'mock' on a
+      // production client (e.g., explicit override), `isMockSca` returns false
+      // because `isSandbox` is false. So auto-default must not engage.
+      const productionWithMockMethod = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        scaMethod: "mock",
+      });
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
+
+      await executeWithCliSca(
+        productionWithMockMethod,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-prod-no-auto");
+          }
+          return "ok";
+        },
+        { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+      );
+
+      for (const call of fetchSpy.mock.calls) {
+        const [url] = call as [URL, RequestInit];
+        expect(url.pathname).not.toContain("/mocked_sca_sessions/");
+      }
+    });
+
+    it("uses mock-decision spinner copy when isMockSca is true", async () => {
+      // AC #4: spinner copy disambiguates real-device vs mock paths.
+      const sandboxMockClient = createSandboxClient("mock");
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      fetchSpy
+        .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 204 })))
+        .mockImplementationOnce(() => jsonResponse({ result: "allow" }));
+
+      await executeWithCliSca(
+        sandboxMockClient,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-mock-copy");
+          }
+          return "ok";
+        },
+        { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+      );
+
+      expect(mockSpin.start).toHaveBeenCalledWith("Waiting for SCA mock-decision...");
+      // Real-device copy must NOT appear in the mock path.
+      expect(mockSpin.start).not.toHaveBeenCalledWith(expect.stringMatching(/Qonto mobile app/));
+    });
+
+    it("keeps real-device spinner copy when isMockSca is false (regression guard)", async () => {
+      // The existing real-device copy is the default for production and for
+      // sandbox-routed-but-not-mock paths. Don't regress it.
+      fetchSpy.mockImplementation(() => jsonResponse({ sca_session: { status: "allow" } }));
+      const mockSpin = createMockSpinner();
+      let called = false;
+
+      await executeWithCliSca(
+        client,
+        async () => {
+          if (!called) {
+            called = true;
+            throw new QontoScaRequiredError("tok-real-copy");
+          }
+          return "ok";
+        },
+        { poll: { sleep: noopSleep }, createSpinner: () => mockSpin },
+      );
+
+      expect(mockSpin.start).toHaveBeenCalledWith("Waiting for SCA approval on your Qonto mobile app...");
+    });
+  });
 });

--- a/packages/cli/src/sca.ts
+++ b/packages/cli/src/sca.ts
@@ -21,6 +21,26 @@ export interface CliScaOptions {
    * generated once and reused across both attempts (initial 428 + SCA retry).
    */
   readonly idempotencyKey?: string | undefined;
+  /**
+   * Sandbox-only auto-approve preference for SCA mock-decision.
+   *
+   * - When set to `"allow"` or `"deny"`: requires `client.isSandbox === true`
+   *   — otherwise throws to enforce the production-rejection contract from
+   *   `--sca-auto-approve`'s spec (#577). The supplied decision is POSTed to
+   *   `/v2/mocked_sca_sessions/{token}/{decision}` immediately after the SCA
+   *   challenge is created, so the next poll observes the resolved state
+   *   without external orchestration.
+   * - When unset AND `client.isMockSca === true` (staging-token configured +
+   *   resolved `sca.method === "mock"`): auto-defaults to `"allow"` so
+   *   sandbox writes complete in a single CLI invocation. Users opt into the
+   *   deny path explicitly.
+   * - When unset AND `client.isMockSca === false`: no auto-approve, the
+   *   wrapper polls normally for the user's real-device approval.
+   *
+   * Production paths (no staging-token, `client.isSandbox === false`) reject
+   * any non-undefined value at entry, before any wire requests are issued.
+   */
+  readonly scaAutoApprove?: "allow" | "deny" | undefined;
 }
 
 /**
@@ -28,6 +48,7 @@ export interface CliScaOptions {
  *
  * When SCA is triggered:
  * - Starts a spinner prompting the user to approve on their mobile app
+ *   (or "waiting for SCA mock-decision" when the sandbox mock path is active)
  * - Updates the spinner message with elapsed time on each poll
  * - On approval, stops the spinner with a success message
  * - On timeout, stops the spinner with an error message
@@ -41,13 +62,46 @@ export interface CliScaOptions {
  * @param client - HttpClient used for SCA session polling
  * @param operation - Function that performs the API operation. Receives a context
  *   with stable idempotency key and optional SCA session token (on retry).
- * @param options - Verbose flag, polling options, and optional idempotency key
+ * @param options - Verbose flag, polling options, optional idempotency key, and
+ *   optional `scaAutoApprove` (sandbox-only — see {@link CliScaOptions.scaAutoApprove}).
  */
 export async function executeWithCliSca<T>(
   client: HttpClient,
   operation: (context: ExecuteWithScaContext) => Promise<T>,
   options?: CliScaOptions,
 ): Promise<T> {
+  // Sandbox-only gate (AC #2): reject `--sca-auto-approve` against production
+  // clients up-front rather than waiting for Qonto to 404 the mock-decision
+  // endpoint. The check is on `client.isSandbox` (staging-token presence) so
+  // it covers both api-key and OAuth credentials routed through the sandbox.
+  if (options?.scaAutoApprove !== undefined && !client.isSandbox) {
+    throw new Error(
+      "--sca-auto-approve is only available in the Qonto sandbox environment. " +
+        "Configure `oauth.staging-token` in your config or set `QONTOCTL_STAGING_TOKEN`.",
+    );
+  }
+
+  // Resolve the effective auto-approve decision. Precedence:
+  //   1. Explicit `--sca-auto-approve allow|deny` from the caller.
+  //   2. Auto-default to `"allow"` when the sandbox mock SCA path is active
+  //      (AC #3) — i.e. staging-token configured AND resolved `sca.method`
+  //      is `"mock"`. This makes sandbox writes work out-of-the-box.
+  //   3. Otherwise: undefined (no auto-approve, normal polling for the
+  //      user's mobile-app approval).
+  const isMockSca = client.isMockSca;
+  const autoApprove: "allow" | "deny" | undefined =
+    options?.scaAutoApprove ?? (isMockSca ? "allow" : undefined);
+
+  // Disambiguate spinner copy (AC #4). The mock path runs against the
+  // sandbox `mocked_sca_sessions` endpoint, not the user's mobile app —
+  // the original copy was misleading there. The mock-path copy still
+  // applies even when `autoApprove` is set, because the first poll may
+  // observe `"waiting"` for a few hundred ms while the mock-decision POST
+  // propagates.
+  const waitingMessage = isMockSca
+    ? "Waiting for SCA mock-decision..."
+    : "Waiting for SCA approval on your Qonto mobile app...";
+
   let s: SpinnerResult | undefined;
 
   try {
@@ -59,16 +113,17 @@ export async function executeWithCliSca<T>(
         // structured payload (#491). stderr is the conventional channel for
         // progress indicators and is what interactive users already see.
         s = (options?.createSpinner ?? (() => spinner({ output: process.stderr })))();
-        s.start("Waiting for SCA approval on your Qonto mobile app...");
+        s.start(waitingMessage);
       },
       onPoll: (_attempt, elapsedMs) => {
         const seconds = Math.round(elapsedMs / 1000);
-        s?.message(`Waiting for SCA approval on your Qonto mobile app... (${seconds}s)`);
+        s?.message(`${waitingMessage} (${seconds}s)`);
       },
       onScaApproved: () => {
         s?.stop("SCA approved");
       },
       poll: options?.poll,
+      ...(autoApprove !== undefined ? { autoApprove } : {}),
       idempotencyKey: options?.idempotencyKey,
     });
   } catch (error: unknown) {

--- a/packages/cli/src/sca.ts
+++ b/packages/cli/src/sca.ts
@@ -89,8 +89,7 @@ export async function executeWithCliSca<T>(
   //   3. Otherwise: undefined (no auto-approve, normal polling for the
   //      user's mobile-app approval).
   const isMockSca = client.isMockSca;
-  const autoApprove: "allow" | "deny" | undefined =
-    options?.scaAutoApprove ?? (isMockSca ? "allow" : undefined);
+  const autoApprove: "allow" | "deny" | undefined = options?.scaAutoApprove ?? (isMockSca ? "allow" : undefined);
 
   // Disambiguate spinner copy (AC #4). The mock path runs against the
   // sandbox `mocked_sca_sessions` endpoint, not the user's mobile app —

--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -315,6 +315,54 @@ describe("HttpClient", () => {
       expect(client.isSandbox).toBe(true);
     });
 
+    it("isMockSca is false when no staging token is configured", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        scaMethod: "mock",
+      });
+
+      // scaMethod can be set in production for explicit override, but isMockSca
+      // requires sandbox routing — must not engage the sandbox-only mock SCA
+      // path in production.
+      expect(client.isMockSca).toBe(false);
+    });
+
+    it("isMockSca is false when staging token is set but scaMethod is not 'mock'", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+        scaMethod: "paired-device",
+      });
+
+      expect(client.isMockSca).toBe(false);
+    });
+
+    it("isMockSca is false when staging token is set but scaMethod is undefined", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+      });
+
+      // Defensive: sandbox without an explicit scaMethod means the auto-default
+      // hasn't been applied yet (`resolveScaMethod` is the resolver), so the
+      // header-level flag is undefined and isMockSca is false.
+      expect(client.isMockSca).toBe(false);
+    });
+
+    it("isMockSca is true when both staging token and scaMethod='mock' are configured", () => {
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty-sandbox.staging.qonto.co",
+        authorization: "slug:secret",
+        stagingToken: "tok-staging",
+        scaMethod: "mock",
+      });
+
+      expect(client.isMockSca).toBe(true);
+    });
+
     it("sends the staging token header when configured", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
       const client = new TestableHttpClient({

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -281,6 +281,23 @@ export class HttpClient {
   }
 
   /**
+   * Whether this client is configured for the sandbox mock SCA path.
+   *
+   * True when both:
+   *   - {@link isSandbox} is true (staging token configured), AND
+   *   - The resolved `scaMethod` is `"mock"` (sandbox-only auto-default or
+   *     explicit preference)
+   *
+   * Used by CLI/MCP wrappers to disambiguate spinner copy ("mock-decision"
+   * vs "mobile app") and to gate the sandbox-only `--sca-auto-approve`
+   * auto-default behavior. Production clients always return false here, so
+   * sandbox-only behavior cannot accidentally engage in production.
+   */
+  get isMockSca(): boolean {
+    return this.isSandbox && this.scaMethod === "mock";
+  }
+
+  /**
    * Sends an HTTP request and parses the response as JSON.
    *
    * **Trust boundary**: The parsed JSON is cast to `T` without runtime validation.

--- a/packages/core/src/sca/sca-handler.test.ts
+++ b/packages/core/src/sca/sca-handler.test.ts
@@ -295,4 +295,129 @@ describe("executeWithSca", () => {
     expect(initialHeaders["X-Qonto-Idempotency-Key"]).toBe("supplied-stable-key");
     expect(retryHeaders["X-Qonto-Idempotency-Key"]).toBe("supplied-stable-key");
   });
+
+  it("fires autoApprove mock-decision POST before polling when autoApprove='allow'", async () => {
+    // Sequence:
+    //   1. Operation: 428 SCA Required (token "tok-auto-allow").
+    //   2. autoApprove fires: POST /v2/mocked_sca_sessions/tok-auto-allow/allow
+    //      (status 204; mock-decision API has no body).
+    //   3. Poll: GET sca-session → status "allow".
+    //   4. Operation retry: 200 OK with the SCA token attached.
+    fetchSpy
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sca_session_token: "tok-auto-allow" }), {
+            status: 428,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      )
+      .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 204 })))
+      .mockImplementationOnce(() => jsonResponse({ sca_session: { status: "allow" } }))
+      .mockImplementationOnce(() => jsonResponse({ id: "tx-auto" }));
+
+    await executeWithSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        client.post(
+          "/v2/transfers",
+          { amount: 50 },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { autoApprove: "allow", poll: { sleep: noopSleep } },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    // The second wire call MUST be the auto-approve POST — proving auto-approve
+    // fires before polling. If polling fired first, fetch[1] would be the GET.
+    const [autoApproveUrl, autoApproveInit] = fetchSpy.mock.calls[1] as [URL, RequestInit];
+    expect(autoApproveUrl.pathname).toBe("/v2/mocked_sca_sessions/tok-auto-allow/allow");
+    expect((autoApproveInit.method ?? "GET").toUpperCase()).toBe("POST");
+    // And the third is the poll, fourth is the retry.
+    const [pollUrl] = fetchSpy.mock.calls[2] as [URL, RequestInit];
+    expect(pollUrl.pathname).toBe("/v2/sca/sessions/tok-auto-allow");
+  });
+
+  it("fires autoApprove mock-decision POST with 'deny' before polling, then propagates ScaDeniedError", async () => {
+    // autoApprove="deny" still fires the mock-decision (because the caller
+    // wants to exercise the deny path), and then polling observes "deny",
+    // which propagates as ScaDeniedError to the caller. The wrapper must
+    // NOT swallow the deny.
+    fetchSpy
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sca_session_token: "tok-auto-deny" }), {
+            status: 428,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      )
+      .mockImplementationOnce(() => Promise.resolve(new Response(null, { status: 204 })))
+      .mockImplementationOnce(() => jsonResponse({ sca_session: { status: "deny" } }));
+
+    const caught = await executeWithSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        client.post(
+          "/v2/transfers",
+          { amount: 50 },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { autoApprove: "deny", poll: { sleep: noopSleep } },
+    ).catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).name).toBe("ScaDeniedError");
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    // Verify the mock-decision call carried "/deny", not "/allow".
+    const [autoApproveUrl] = fetchSpy.mock.calls[1] as [URL, RequestInit];
+    expect(autoApproveUrl.pathname).toBe("/v2/mocked_sca_sessions/tok-auto-deny/deny");
+  });
+
+  it("skips autoApprove when undefined (existing flow unchanged)", async () => {
+    // Regression guard: when autoApprove is not supplied, the handler must
+    // poll without firing any mock-decision, so existing dual-process flows
+    // and production paths continue to work.
+    fetchSpy
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sca_session_token: "tok-no-auto" }), {
+            status: 428,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      )
+      .mockImplementationOnce(() => jsonResponse({ sca_session: { status: "allow" } }))
+      .mockImplementationOnce(() => jsonResponse({ id: "tx-no-auto" }));
+
+    await executeWithSca(
+      client,
+      async ({ scaSessionToken, idempotencyKey }) =>
+        client.post(
+          "/v2/transfers",
+          { amount: 50 },
+          {
+            idempotencyKey,
+            ...(scaSessionToken !== undefined ? { scaSessionToken } : {}),
+          },
+        ),
+      { poll: { sleep: noopSleep } },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    // Second call must be the poll, NOT a mock-decision POST.
+    const [pollUrl] = fetchSpy.mock.calls[1] as [URL, RequestInit];
+    expect(pollUrl.pathname).toBe("/v2/sca/sessions/tok-no-auto");
+    // No mock-decision URL should appear anywhere.
+    for (const call of fetchSpy.mock.calls) {
+      const [url] = call as [URL, RequestInit];
+      expect(url.pathname).not.toContain("/mocked_sca_sessions/");
+    }
+  });
 });

--- a/packages/core/src/sca/sca-handler.ts
+++ b/packages/core/src/sca/sca-handler.ts
@@ -4,7 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { QontoScaRequiredError } from "../http-client.js";
 import type { HttpClient } from "../http-client.js";
-import { pollScaSession, type PollScaSessionOptions } from "./sca-service.js";
+import { mockScaDecision, pollScaSession, type PollScaSessionOptions } from "./sca-service.js";
 
 export interface ExecuteWithScaCallbacks {
   /** Called when SCA is required, before polling starts. */
@@ -27,6 +27,19 @@ export interface ExecuteWithScaOptions extends ExecuteWithScaCallbacks {
    * create duplicate pending pre-SCA records on retry.
    */
   readonly idempotencyKey?: string | undefined;
+  /**
+   * Sandbox-only: automatically fire a `mockScaDecision` against the captured
+   * SCA session token before polling begins. When set, the supplied decision
+   * (`"allow"` or `"deny"`) is POSTed to `/v2/mocked_sca_sessions/{token}/{decision}`
+   * immediately after the SCA challenge is created, so the next poll observes
+   * the resolved state without external orchestration.
+   *
+   * Callers are responsible for restricting use to sandbox-routed clients
+   * (i.e. `client.isSandbox === true`). Outside sandbox, the mock-decision
+   * endpoint does not exist and the call will fail with a 404 propagated to
+   * the caller.
+   */
+  readonly autoApprove?: "allow" | "deny" | undefined;
 }
 
 /**
@@ -77,6 +90,10 @@ export async function executeWithSca<T>(
 
     const { scaSessionToken } = error;
     options?.onScaRequired?.(scaSessionToken);
+
+    if (options?.autoApprove !== undefined) {
+      await mockScaDecision(client, scaSessionToken, options.autoApprove);
+    }
 
     await pollScaSession(client, scaSessionToken, {
       ...options?.poll,

--- a/packages/e2e/src/sca-continuation/cli.e2e.test.ts
+++ b/packages/e2e/src/sca-continuation/cli.e2e.test.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
-import { cliJson } from "../helpers.js";
-import { hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { CLI_PATH, cliJson } from "../helpers.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 import { approveAndRetryCli, SCA_POLL_URL_RE, triggerScaCli } from "../sca-helpers.js";
+
+const execFileAsync = promisify(execFile);
 
 interface BeneficiaryItem {
   readonly id: string;
@@ -125,6 +129,52 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("SCA continuation 
     expect(exit.stderr).toMatch(SCA_POLL_URL_RE);
 
     const transfer = JSON.parse(exit.stdout) as Record<string, unknown>;
+    TransferSchema.parse(transfer);
+    expect(transfer).toHaveProperty("id");
+    expect(transfer).toHaveProperty("beneficiary_id", beneficiaryId);
+    expect(transfer).toHaveProperty("reference", reference);
+  });
+
+  it("transfer create with --sca-auto-approve allow succeeds in a single CLI invocation (no external mock-decision)", async () => {
+    // AC #5 (#577): exercise the auto-approve path end-to-end without external
+    // orchestration. The CLI must trigger SCA, fire `mock-decision allow`
+    // internally, observe the resolved state on the next poll, retry the
+    // operation, and exit 0 with the transfer JSON in stdout — all in a single
+    // process.
+    const reference = `e2e-sca-auto-${randomUUID().slice(0, 12)}`;
+
+    const { stdout, stderr } = await execFileAsync(
+      "node",
+      [
+        CLI_PATH,
+        "--verbose",
+        "--output",
+        "json",
+        "--sca-auto-approve",
+        "allow",
+        "transfer",
+        "create",
+        "--beneficiary",
+        beneficiaryId,
+        "--debit-account",
+        bankAccountId,
+        "--reference",
+        reference,
+        "--amount",
+        "1.50",
+        "--vop-proof-token",
+        vopProofToken,
+      ],
+      { env: cliEnv({ authPreference: "oauth-first" }), timeout: 30_000 },
+    );
+
+    // The SCA polling URL must still appear in verbose stderr — auto-approve
+    // is layered on top of the existing flow, not a bypass.
+    expect(stderr).toMatch(SCA_POLL_URL_RE);
+    // The mock-decision POST must appear in the wire log too (sandbox-only path).
+    expect(stderr).toMatch(/POST .*\/v2\/mocked_sca_sessions\/[A-Za-z0-9_-]+\/allow/);
+
+    const transfer = JSON.parse(stdout) as Record<string, unknown>;
     TransferSchema.parse(transfer);
     expect(transfer).toHaveProperty("id");
     expect(transfer).toHaveProperty("beneficiary_id", beneficiaryId);


### PR DESCRIPTION
Closes #577.

## Summary

Adds a hidden `--sca-auto-approve <allow|deny>` global flag that fires the sandbox `POST /v2/mocked_sca_sessions/{token}/<decision>` endpoint before polling begins, so SCA-gated CLI writes complete in a single process without external orchestration.

Auto-defaults to `allow` when both a staging token AND resolved `sca.method === "mock"` are active — i.e., the canonical sandbox setup — so the common test path "just works" out-of-the-box. Users opt into the deny path explicitly.

## Acceptance Criteria

- **AC #1** `--sca-auto-approve allow|deny` accepted globally and inheritable on every SCA-gated subcommand (plumbed through 30 commands; Commander enforces the enum at parse time).
- **AC #2** Rejected up-front (before any wire call) when `client.isSandbox === false`. Error message points users to `oauth.staging-token` / `QONTOCTL_STAGING_TOKEN`.
- **AC #3** Auto-defaults to `allow` when `client.isMockSca === true` (new getter: `isSandbox && scaMethod === "mock"`). Production paths with `scaMethod: "mock"` still return `isMockSca: false` defensively, so the auto-default cannot engage in production.
- **AC #4** Spinner copy switches from `Waiting for SCA approval on your Qonto mobile app...` → `Waiting for SCA mock-decision...` when the mock path is active.
- **AC #5** New CLI E2E test in `packages/e2e/src/sca-continuation/cli.e2e.test.ts` exercises the auto-approve path end-to-end in a single `execFile` invocation (asserts both the SCA poll URL and the mock-decision POST appear in verbose stderr).
- **AC #6** `docs/sandbox-testing.md` updated with usage, behavior, precedence, and the production-rejection contract.

## Design Notes

- **Layering**: `executeWithSca` in core gets the `autoApprove` option (pure mechanism); CLI wrapper `executeWithCliSca` resolves the effective decision (explicit > sandbox-mock auto-default > none) and owns the production-rejection gate. MCP intentionally does NOT pass `autoApprove` — like `--sca-method`, choosing the SCA outcome on a write is a threat-model risk in production and is not surfaced as a tool input.
- **PSD2 dynamic linking** is preserved: the `mockScaDecision` POST fires AFTER the original 428 captures the session token, so the original request parameters bind to the approved session.
- **Idempotency** carries through unchanged — the stable `idempotencyKey` plumbing from #491 already handles both attempts.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — new tests pass (3 core + 4 http-client + 7 CLI sca + 4 CLI program + inherited-options); pre-existing baseline failures in `packages/cli/src/commands/{bulk-transfer,profile}` and `packages/core/src/config/{loader,resolve,writer}` confirmed unrelated (verified by `git stash` baseline comparison).
- [x] `pnpm test:e2e` — SCA-continuation suites blocked at `beforeAll` by expired OAuth credentials in this worktree's `.qontoctl.yaml` (same failure on `git stash` baseline; api-key-compatible suites continue to pass).
- [x] Manual smoke: `qontoctl --sca-auto-approve invalid …` → Commander rejects with `Allowed choices are allow, deny`.
- [x] Manual smoke: `qontoctl --help` does NOT show `--sca-auto-approve` (hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)