### PR TITLE
(chore) record Embed-partner decision: mark trust/untrust + membership_invite as accepted_gap (#461)

### DIFF
--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -31,14 +31,14 @@
       "notes": ""
     },
     "cli:packages/cli/src/commands/beneficiary/trust.ts": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Embed-partner-only OAuth scope (`beneficiary.trust`). (a) Deferred: live-sandbox E2E exercising the trust call. (b) No verifiable risk: Qonto's authorization server rejects the scope for non-partner clients at consent time, and the endpoint returns 403 at request time — both surface as explicit typed errors, not silent failure. The Embed-partner requirement is flagged in CLI help text, MCP tool description (`packages/mcp/src/tools/beneficiary.ts`), service JSDoc (`packages/core/src/beneficiaries/service.ts`), and `docs/oauth-setup.md` § 'Restricted scopes (partner-gated)'; `packages/cli/src/commands/auth.ts` excludes the scope from the default `auth setup` picker via `RESTRICTED_SCOPES` (opt-in only via `--trusted-partner`). (c) Retrofit trigger: qontoctl maintainer (or a downstream user) gains Embed-partner status with the `beneficiary.trust` scope grant. Decision recorded in #461 (closes Group 9 of #449)."
     },
     "cli:packages/cli/src/commands/beneficiary/untrust.ts": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Embed-partner-only OAuth scope (`beneficiary.trust`). (a) Deferred: live-sandbox E2E exercising the untrust call. (b) No verifiable risk: Qonto's authorization server rejects the scope for non-partner clients at consent time, and the endpoint returns 403 at request time — both surface as explicit typed errors, not silent failure. The Embed-partner requirement is flagged in CLI help text, MCP tool description (`packages/mcp/src/tools/beneficiary.ts`), service JSDoc (`packages/core/src/beneficiaries/service.ts`), and `docs/oauth-setup.md` § 'Restricted scopes (partner-gated)'; `packages/cli/src/commands/auth.ts` excludes the scope from the default `auth setup` picker via `RESTRICTED_SCOPES` (opt-in only via `--trusted-partner`). (c) Retrofit trigger: qontoctl maintainer (or a downstream user) gains Embed-partner status with the `beneficiary.trust` scope grant. Decision recorded in #461 (closes Group 9 of #449)."
     },
     "cli:packages/cli/src/commands/beneficiary/update.ts": {
       "status": "pending",
@@ -986,14 +986,14 @@
       "notes": ""
     },
     "mcp:beneficiary_trust": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Embed-partner-only OAuth scope (`beneficiary.trust`). (a) Deferred: live-sandbox E2E exercising the `beneficiary_trust` MCP tool. (b) No verifiable risk: Qonto's authorization server rejects the scope for non-partner clients at consent time, and the endpoint returns 403 at request time — both surface as explicit typed errors, not silent failure. The MCP tool description explicitly warns that standard third-party apps will receive 403; service JSDoc (`packages/core/src/beneficiaries/service.ts`) documents the gate. Unit tests cover the parameter mapping and SCA flow. (c) Retrofit trigger: qontoctl maintainer (or a downstream user) gains Embed-partner status with the `beneficiary.trust` scope grant. Decision recorded in #461 (closes Group 9 of #449)."
     },
     "mcp:beneficiary_untrust": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Embed-partner-only OAuth scope (`beneficiary.trust`). (a) Deferred: live-sandbox E2E exercising the `beneficiary_untrust` MCP tool. (b) No verifiable risk: Qonto's authorization server rejects the scope for non-partner clients at consent time, and the endpoint returns 403 at request time — both surface as explicit typed errors, not silent failure. The MCP tool description explicitly warns that standard third-party apps will receive 403; service JSDoc (`packages/core/src/beneficiaries/service.ts`) documents the gate. Unit tests cover the parameter mapping and SCA flow. (c) Retrofit trigger: qontoctl maintainer (or a downstream user) gains Embed-partner status with the `beneficiary.trust` scope grant. Decision recorded in #461 (closes Group 9 of #449)."
     },
     "mcp:beneficiary_update": {
       "status": "pending",
@@ -1286,9 +1286,9 @@
       "notes": ""
     },
     "mcp:membership_invite": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Irreversible state mutation: `POST /v2/memberships` sends a real invitation email to the supplied address and creates a pending membership row in the live org. Qonto exposes no first-class dry-run primitive or disposable-test-org capability for this endpoint. (a) Deferred: live-sandbox E2E exercising the invite flow end-to-end. (b) No verifiable risk: the tool is a thin wrapper around a single typed `POST /v2/memberships` call whose request and response are both schema-validated by `MembershipResponseSchema`; failure modes (invalid role, duplicate invite, missing `membership.write` scope) surface as typed errors via the standard MCP error path. Unit tests cover the parameter mapping. The CLI counterpart (`packages/cli/src/commands/membership.ts` § invite, manifest entry `cli:packages/cli/src/commands/membership.ts`) shares the same underlying call and remains `pending` because it co-resides in a file whose `list` subcommand is api-key-testable. (c) Retrofit trigger: Qonto sandbox gains a dry-run mode for `POST /v2/memberships`, OR qontoctl test infrastructure gains a dedicated disposable org with automated pending-invite cleanup. Decision recorded in #461 (closes Group 9 of #449)."
     },
     "mcp:membership_list": {
       "status": "pending",


### PR DESCRIPTION
## Summary

Closes #461 (Group 9 of #449).

Records a maintainer decision and updates the E2E coverage manifest. Keeps all four commands, documents the partner / side-effect gates, and marks the surfaces that genuinely cannot be live-sandbox-tested as `accepted_gap` with surface-specific a/b/c justifications.

## Decision

**Option B (keep + document + accepted_gap), applied differentially** — consistent with PR #464, which already locked in the "keep + document" posture for `beneficiary trust`/`untrust` via JSDoc, CLI help text, MCP tool descriptions, `docs/oauth-setup.md` § "Restricted scopes (partner-gated)", and the `RESTRICTED_SCOPES` catalog with `--trusted-partner` opt-in.

The umbrella's Category B lumps two substantively different gates, so the treatment differs per surface:

| Surface | Manifest entry | Disposition | Why |
| --- | --- | --- | --- |
| `beneficiary trust` (CLI) | `cli:packages/cli/src/commands/beneficiary/trust.ts` | `accepted_gap` | Embed-partner-only OAuth scope (`beneficiary.trust`) |
| `beneficiary untrust` (CLI) | `cli:packages/cli/src/commands/beneficiary/untrust.ts` | `accepted_gap` | Embed-partner-only OAuth scope (`beneficiary.trust`) |
| `beneficiary_trust` (MCP) | `mcp:beneficiary_trust` | `accepted_gap` | Embed-partner-only OAuth scope (`beneficiary.trust`) |
| `beneficiary_untrust` (MCP) | `mcp:beneficiary_untrust` | `accepted_gap` | Embed-partner-only OAuth scope (`beneficiary.trust`) |
| `membership_invite` (MCP) | `mcp:membership_invite` | `accepted_gap` | Side-effect-bound: irreversibly emails a real invitee and creates a pending org row; no dry-run primitive on Qonto's side |
| `membership_show` (MCP) | `mcp:membership_show` | stays `pending` | Testable locally with OAuth; just needs a follow-up E2E (not Embed-partner-restricted despite the umbrella's category label) |
| `membership.ts` (CLI) | `cli:packages/cli/src/commands/membership.ts` | stays `pending` | File aggregates `list` (api-key-testable today), `show` (OAuth-testable), and `invite` (side-effect-bound); single-file entry can't be split |

Each `accepted_gap` note documents:
- **(a)** what is deferred (live-sandbox E2E of the specific call),
- **(b)** why it doesn't introduce verifiable risk (typed errors, schema validation, gate at consent/request time, not silent failure),
- **(c)** the retrofit trigger that would unblock live coverage (Embed-partner status grant, OR Qonto sandbox gaining dry-run / disposable-org primitives).

## Why not Option A (remove commands)

Removal would be irreversible, inconsistent with the project's posture of exposing the full Qonto API surface, and would contradict PR #464's precedent. The 403 from the API combined with `RESTRICTED_SCOPES` gating in `auth setup` (default picker excludes `beneficiary.trust`; `--trusted-partner` opt-in surfaces it) already provides a clear, self-explanatory failure path before and during the call.

## What's already in place (no churn needed)

These are pre-existing from #464 and earlier work, surfaced here only as supporting evidence:

- `packages/core/src/beneficiaries/service.ts` — JSDoc on `trustBeneficiaries` / `untrustBeneficiaries` documents the Embed-partner gate.
- `packages/cli/src/commands/beneficiary/{trust,untrust}.ts` — `.description(...)` text flags the gate in `--help`.
- `packages/mcp/src/tools/beneficiary.ts` — MCP tool descriptions explicitly warn that "standard third-party apps will receive 403".
- `packages/cli/src/commands/auth.ts` — `RESTRICTED_SCOPES = ["beneficiary.trust"]` excludes the scope from the default picker; `--trusted-partner` is the opt-in.
- `docs/oauth-setup.md` — § "Restricted scopes (partner-gated)" documents the gate, the `--trusted-partner` flag, and the workflow.

## Coverage manifest delta

Before: 22 covered, 0 accepted gaps, 292 pending.
After: 22 covered, 5 accepted gaps, 287 pending.

`node scripts/check-coverage-drift.js` passes.

## Test plan

- [x] `pnpm format:check` — passes
- [x] `pnpm lint` — 8/8 packages pass
- [x] `pnpm build` — 5/5 packages pass
- [x] `pnpm test` — all unit tests pass
- [x] `pnpm license-check` — 100 production deps, allowed licenses only
- [x] `node scripts/check-coverage-drift.js` — passes (5 accepted gaps, 0 stale entries, 0 broken refs, 0 missing notes)
- [x] No code, test, or harness changes — only `packages/e2e/coverage.json` metadata (status + notes for 5 entries). The drift-check script is the gate that protects this artifact; running the full E2E suite would add no validation signal for this change.