### PR TITLE
(chore) clarify real client-invoice create blocker in E2E comments (#539)

### DIFF
--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -83,8 +83,17 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
         expect(parsed).toHaveProperty("status", "draft");
         createdInvoiceId = parsed["id"] as string;
       } catch {
-        // Invoice creation may fail if the organization lacks required setup
-        // (e.g., IBAN not configured). Skip downstream lifecycle tests.
+        // `client-invoice create` requires an org-level *invoicing IBAN* to be
+        // configured. This is distinct from bank-account IBANs (which can be
+        // present yet the API still returns HTTP 422 `invalid_iban: IBAN is
+        // empty`) and is NOT the same as `einvoicing.sending_status` returned
+        // by `GET /v2/einvoicing/settings` (that gates a different flow).
+        // The invoicing-IBAN setting is not exposed by the public Qonto API —
+        // it must be configured via the Qonto web UI or a Qonto support
+        // ticket. Without it the entire write-path lifecycle (create →
+        // update → upload → finalize → send → mark_paid → unmark_paid →
+        // cancel → delete) is unreachable, so downstream tests below are
+        // silently skipped (createdInvoiceId stays undefined). Tracked: #539.
       }
     });
 
@@ -232,8 +241,14 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
         expect(parsed).toHaveProperty("status", "draft");
         emptyDraftId = parsed["id"] as string;
       } catch {
-        // Sandbox/prod organizations may reject empty-items drafts (IBAN
-        // setup, business-rule constraints). Skip the show round-trip.
+        // Same blocker as the parent CRUD lifecycle: `client-invoice create`
+        // is gated on an org-level invoicing-IBAN configuration not exposed
+        // by the public Qonto API (#539). On orgs where that setting is
+        // missing the API rejects with HTTP 422 `invalid_iban: IBAN is empty`
+        // before any items-shape validation runs, so the empty-items round
+        // trip is silently skipped here. The schema fix from #575 is still
+        // exercised by the unit tests in `packages/core/src/client-invoices/
+        // schemas.test.ts` (`normalizes items: null to []` and siblings).
       }
     });
 


### PR DESCRIPTION
## Summary

Refs #539 (SPIKE — investigation, not implementation).

Updates the two `catch {}` comment blocks in `packages/e2e/src/client-invoices/cli.e2e.test.ts` that swallow `client-invoice create` failures. The previous text attributed the skip to "IBAN not configured" — a re-probe today against `0909-future-club-2702` shows that bank-account IBANs ARE configured yet the API still rejects creation. The actual blocker is a distinct *org-level invoicing-IBAN* setting that isn't exposed by the public Qonto API.

## What changed

- `packages/e2e/src/client-invoices/cli.e2e.test.ts` lines 85-97 (main CRUD lifecycle silent-catch): rewrote the comment to identify the real blocker, distinguish it from bank-account IBANs and from `einvoicing.sending_status`, and reference #539 for tracking.
- Same file lines 243-252 (#575 empty-items regression silent-catch): rewrote to share the same accurate diagnosis and explicitly point to the `core/src/client-invoices/schemas.test.ts` unit tests that exercise the #575 fix regardless of the live-API blocker.

Comment-only change. No test behavior change.

## Re-probe matrix (2026-05-13)

Against `0909-future-club-2702` (api-key + staging-token → sandbox):

| Probe | Result |
|---|---|
| `einvoicing settings` | `sending_status: disabled`, `receiving_status: disabled` (same as 2026-05-11, 2026-05-12) |
| `account list` | 2 bank accounts, both with IBANs (`DE54…584` main, `DE83…865`) |
| `client list` | 1 client `019df487-…d8a7` |
| `client-invoice create` (bare body) | HTTP 422 `invalid_iban: IBAN is empty` |
| `client-invoice create` + `bank_account_id` | Same 422 |
| `client-invoice create` + `iban` | Same 422 |
| `client-invoice create` + `invoicing_iban` | Same 422 |

The 2026-05-12 RE-PROBE comment on #539 (which claimed `client-invoice create` succeeded that day) is contradicted by today's probe. The draft it cited (`019e1dcc-…e1e`, `RE-2026-001-PROFORMA`, empty items, German Qonto-default header/footer, attachment_id present) has shape consistent with **Qonto web UI** creation, not CLI-API creation — i.e., that comment misobserved.

The actual blocker is consistent across 2026-05-11 and 2026-05-13.

## What this PR does NOT do

This SPIKE has six AC. Only AC #6 (update misleading comment) is fully closed by this PR. The others, with justification:

- **AC #1** (determine enablement requirements): closed by the investigation in this PR's commit message + re-probe matrix above + the issue comment that follows.
- **AC #2** (pick target org): trivially satisfied — sandbox `0909-future-club-2702` is the candidate.
- **AC #3** (open Qonto support ticket) and **AC #4** (verify E2E live): require a human action an autonomous subprocess cannot take. Surfaced as the unblock path.
- **AC #5** (convert to ACCEPTED_GAP if enablement is impossible): deferred to the issue owner. Enablement is not "impossible" — it's blocked on AC #3, which is still a valid option. Converting to ACCEPTED_GAP unilaterally would close off that path. Recommended: keep #539 open as the tracking issue; if AC #3 is declined, convert then.

The 2026-05-12 RE-PROBE comment's suggestion to add a `qontoctl org capabilities` probe command is also a reasonable follow-up but out of scope for this PR (separate work item).

## User next step

Open a Qonto support ticket asking them to enable e-invoicing / configure an invoicing IBAN on sandbox `0909-future-club-2702` (or a dedicated test org). If declined, convert #539 to `ACCEPTED_GAP` with retrofit trigger "re-evaluate when Qonto enables invoicing-IBAN configuration via API or for sandbox orgs."

## Test plan

- [x] Scoped E2E: `pnpm test:e2e packages/e2e/src/client-invoices/` — 22/22 pass (15 CLI + 7 MCP). Silent-skip behavior preserved (intentional; the comments describe it).
- [x] Full local `pnpm test:e2e` — `client-invoices/` suites both pass. Unrelated OAuth-required suites (beneficiaries, cards, recurring-transfers, teams, intl-transfers, payment-links, insurance, requests, bulk-transfers) fail locally due to expired OAuth refresh token in `.qontoctl.yaml` (verified `oauth einvoicing settings` returns `invalid_grant`). These failures are environmental, pre-existing, and unrelated to this comment-only change. CI runs api-key-only against prod, so these suites skip there per `docs/e2e-testing.md`.
- [x] `pnpm format:check` — all matched files use Prettier code style.
- [x] `pnpm lint` — 8 successful, 0 failures.
- [x] `pnpm --filter @qontoctl/e2e build` (tsc) — clean.