### PR TITLE
(test) E2E for getTransferProof via production-org gating (#565)

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -216,6 +216,70 @@ for the canonical implementation. (The shared helpers module exposes
 `firstTextFromMcpResult` to centralize the content-extraction
 boilerplate.)
 
+## Production-org-gated tests (sandbox-blocker pattern)
+
+A small number of Qonto endpoints behave correctly in production but cannot
+be exercised against the sandbox simulator at all — for example, `GET
+/v2/sepa/transfers/{id}/proof` returns `404 not_found` for **every**
+settled sandbox transfer (re-probed 2026-05-13 in #565). Skip-if-empty
+and skip-if-feature-unavailable cannot help here because the resource is
+provably absent across the entire sandbox surface; the only way to
+exercise the code path end-to-end is to point the test at a real
+production resource.
+
+For these endpoints we use a **dedicated env var** as the opt-in gate:
+
+```ts
+import { hasApiKeyCredentials, hasTransferProofId, getTransferProofId } from "../sandbox.js";
+
+describe.skipIf(!hasApiKeyCredentials() || !hasTransferProofId())(
+    "transfer CLI commands (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID)",
+    () => {
+        it("downloads a valid PDF", () => {
+            const id = getTransferProofId();
+            // ...exercise the endpoint, assert against the real production resource...
+        });
+    },
+);
+```
+
+**Properties of this gate:**
+
+- **CI never sets the env var** → the suite skips naturally in CI without
+  any CI-side configuration.
+- **Local devs without the env var** also skip naturally — no behavior
+  change for the default `pnpm test:e2e` flow.
+- **Local devs who opt in** export the env var with a real production
+  resource ID (e.g. `QONTOCTL_TRANSFER_PROOF_ID=01234567-...`) alongside
+  production credentials.
+- The dev is responsible for **routing to production** in the same shell
+  (i.e. unsetting `QONTOCTL_STAGING_TOKEN` or using a profile without one).
+  A sandbox-routed request will 404 deterministically.
+
+**When to use this pattern:** only when both of the following hold:
+
+1. Empirical probing has shown the endpoint is **uniformly broken** in
+   sandbox (not a per-org config issue, not a feature flag — the simulator
+   simply does not produce the resource).
+2. The production resource can be **read-only**, with no side effects —
+   safe to exercise repeatedly against a real org. Mutating endpoints
+   should never be production-org-gated.
+
+**Coverage manifest:** mark the surface as `covered` (the test exists and
+binds AC #2/AC #3) and mention the env var in `notes`. The opt-in nature
+is encoded in the test description and the env var name; the coverage
+detector does not need a separate state for this.
+
+**Helpers** (in [`packages/e2e/src/sandbox.ts`](../packages/e2e/src/sandbox.ts)):
+
+| Helper                 | Purpose                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `hasTransferProofId()` | True iff `QONTOCTL_TRANSFER_PROOF_ID` is set. Use as a `describe.skipIf` term. |
+| `getTransferProofId()` | Read the env var; throws if unset. Guard with `hasTransferProofId()` first.    |
+
+When adding a new production-org-gated endpoint, mirror this pair for the
+new env var (e.g. `hasFooBarId()` / `getFooBarId()`).
+
 ### Helpers reference
 
 [`packages/e2e/src/helpers.ts`](../packages/e2e/src/helpers.ts) exports the

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -391,9 +391,9 @@
       "notes": ""
     },
     "cli:packages/cli/src/commands/transfer/proof.ts": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/transfers/cli.e2e.test.ts"],
+      "notes": "Production-org-gated (opt-in via QONTOCTL_TRANSFER_PROOF_ID); Qonto sandbox returns 404 for all settled-transfer proofs (#565)."
     },
     "cli:packages/cli/src/commands/transfer/show.ts": {
       "status": "pending",
@@ -891,9 +891,9 @@
       "notes": ""
     },
     "core:packages/core/src/transfers/service.ts#getTransferProof": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/transfers/cli.e2e.test.ts", "packages/e2e/src/transfers/mcp.e2e.test.ts"],
+      "notes": "Production-org-gated (opt-in via QONTOCTL_TRANSFER_PROOF_ID); Qonto sandbox returns 404 for all settled-transfer proofs (#565)."
     },
     "core:packages/core/src/transfers/service.ts#listTransfers": {
       "status": "pending",
@@ -1531,9 +1531,9 @@
       "notes": ""
     },
     "mcp:transfer_proof": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/transfers/mcp.e2e.test.ts"],
+      "notes": "Production-org-gated (opt-in via QONTOCTL_TRANSFER_PROOF_ID); Qonto sandbox returns 404 for all settled-transfer proofs (#565)."
     },
     "mcp:transfer_show": {
       "status": "pending",

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -153,6 +153,43 @@ export function hasStagingToken(): boolean {
 }
 
 /**
+ * Check whether `QONTOCTL_TRANSFER_PROOF_ID` is set — a known-good
+ * production-org SEPA transfer UUID whose proof PDF the test harness
+ * may fetch.
+ *
+ * Used by `describe.skipIf(!hasTransferProofId())` guards on the
+ * `transfer proof` / `transfer_proof` E2E suites (#565). The Qonto
+ * sandbox simulator does NOT generate proof PDFs — `GET /v2/sepa/
+ * transfers/{id}/proof` returns `404 not_found` for ALL settled
+ * sandbox transfers (empirical re-probe 2026-05-13, refresh of the
+ * 2026-05-12 probe in #565). Coverage therefore requires routing the
+ * test against a production org with a dedicated, known-settled
+ * transfer whose proof has been generated post-settlement.
+ *
+ * This gate is opt-in: CI never sets `QONTOCTL_TRANSFER_PROOF_ID`, so
+ * proof tests skip in CI; local devs opt in by exporting the env var
+ * with a real production transfer UUID. The dev is responsible for
+ * routing to production (i.e., not configuring a staging token in the
+ * same shell), since a sandbox-routed request will 404 deterministically.
+ */
+export function hasTransferProofId(): boolean {
+  return Boolean(process.env["QONTOCTL_TRANSFER_PROOF_ID"]);
+}
+
+/**
+ * Return the production-org transfer UUID from
+ * `QONTOCTL_TRANSFER_PROOF_ID`. Throws if unset — callers must guard
+ * with `hasTransferProofId()`.
+ */
+export function getTransferProofId(): string {
+  const id = process.env["QONTOCTL_TRANSFER_PROOF_ID"];
+  if (!id) {
+    throw new Error("QONTOCTL_TRANSFER_PROOF_ID is not set (guard with hasTransferProofId())");
+  }
+  return id;
+}
+
+/**
  * Retrieve credentials from environment variables or `.qontoctl.yaml`.
  * Throws if no credentials are available (callers should be guarded by
  * `hasApiKeyCredentials()` or `hasOAuthCredentials()` as appropriate).

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -3,14 +3,22 @@
 
 import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
 import { CLI_PATH, cli, cliJson } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import {
+  cliEnv,
+  getTransferProofId,
+  hasApiKeyCredentials,
+  hasOAuthCredentials,
+  hasStagingToken,
+  hasTransferProofId,
+  pinAuthPreference,
+} from "../sandbox.js";
 import { approveAndRetryCli, SCA_POLL_URL_RE, triggerScaCli } from "../sca-helpers.js";
 
 const execFileAsync = promisify(execFile);
@@ -427,12 +435,44 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("transfer CLI comm
   });
 });
 
-// NOTE: `getTransferProof` (CLI: `transfer proof`, MCP: `transfer_proof`)
-// E2E coverage is deferred. Empirical probe against Qonto sandbox org
-// `0909-future-club-2702` on 2026-05-12: `GET /v2/sepa/transfers/{id}/proof`
-// returns `404 not_found` for ALL 10 most-recent `status: settled`
-// transfers. The proof PDF is reliably generated post-settlement in
-// production but the sandbox simulator does not produce it. The CLI and
-// MCP code paths are confirmed correct by code inspection and the audit
-// refresh — both delegate to `getTransferProof` → `client.getBuffer`,
-// which is not SCA-gated. Tracked as a follow-up to #554.
+// `getTransferProof` (CLI: `transfer proof`) is exercised against a
+// production-org transfer because the Qonto sandbox simulator does not
+// generate proof PDFs. Empirical probes against sandbox org
+// `0909-future-club-2702` on 2026-05-12 and refreshed 2026-05-13:
+// `GET /v2/sepa/transfers/{id}/proof` returned `404 not_found` for ALL
+// most-recent `status: settled` transfers. The proof PDF is reliably
+// generated post-settlement in production but not in sandbox.
+//
+// This block is opt-in: gated on `QONTOCTL_TRANSFER_PROOF_ID` (a
+// known-good production-org SEPA transfer UUID whose proof has been
+// generated). CI never sets the env var, so this block skips in CI;
+// local devs opt in by exporting the env var alongside production
+// credentials. See `docs/e2e-testing.md` § Production-org-gated tests.
+// Tracked as #565.
+describe.skipIf(!hasApiKeyCredentials() || !hasTransferProofId())(
+  "transfer CLI commands (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID)",
+  () => {
+    describe("transfer proof", () => {
+      it("downloads a valid PDF to --output-file", () => {
+        const id = getTransferProofId();
+        const tmpDir = mkdtempSync(join(tmpdir(), "qontoctl-transfer-proof-"));
+        const outputPath = join(tmpDir, "proof.pdf");
+        try {
+          // CLI prints `Downloaded: <path>` to stdout; we don't parse it,
+          // we read the file back and assert PDF magic bytes + min size.
+          cli("transfer", "proof", id, "--output-file", outputPath);
+          const buffer = readFileSync(outputPath);
+          // PDF magic bytes: %PDF- (0x25 0x50 0x44 0x46 0x2D) per ISO 32000-1 §7.5.2;
+          // the 6th byte is the version digit (e.g. "1" in "%PDF-1.7") which varies.
+          expect(buffer.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+          // 1 KiB lower bound — Qonto proof PDFs include rendered SEPA
+          // transfer details + branding; empirically several KiB. A
+          // truncation or HTML-error-page response would be much smaller.
+          expect(buffer.byteLength).toBeGreaterThan(1024);
+        } finally {
+          rmSync(tmpDir, { recursive: true, force: true });
+        }
+      });
+    });
+  },
+);

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -8,7 +8,15 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import {
+  cliEnv,
+  getTransferProofId,
+  hasApiKeyCredentials,
+  hasOAuthCredentials,
+  hasStagingToken,
+  hasTransferProofId,
+  pinAuthPreference,
+} from "../sandbox.js";
 import { approveAndRetryMcp, SCA_PENDING_TOKEN_RE, triggerScaMcp } from "../sca-helpers.js";
 
 interface TransferItem {
@@ -421,10 +429,70 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("transfer MCP tool
   });
 });
 
-// NOTE: `transfer_proof` E2E coverage is deferred — same blocker as the CLI
-// counterpart. Qonto sandbox `0909-future-club-2702` returns `404 not_found`
-// from `GET /v2/sepa/transfers/{id}/proof` for ALL settled transfers
-// (empirical 2026-05-12 probe of the 10 most-recent). The MCP tool path
-// is confirmed correct by code inspection — it delegates to `getTransferProof`
-// → `client.getBuffer`, wraps the buffer as a base64-encoded MCP resource,
-// and is not SCA-gated. Tracked as a follow-up to #554.
+// `transfer_proof` is exercised against a production-org transfer because
+// the Qonto sandbox simulator does not generate proof PDFs. Empirical
+// probes against sandbox `0909-future-club-2702` on 2026-05-12 and
+// refreshed 2026-05-13: `GET /v2/sepa/transfers/{id}/proof` returned
+// `404 not_found` for ALL most-recent `status: settled` transfers.
+//
+// This block is opt-in: gated on `QONTOCTL_TRANSFER_PROOF_ID` (a
+// known-good production-org SEPA transfer UUID whose proof has been
+// generated). CI never sets the env var, so this block skips in CI;
+// local devs opt in by exporting the env var alongside production
+// credentials. See `docs/e2e-testing.md` § Production-org-gated tests.
+// Tracked as #565.
+describe.skipIf(!hasApiKeyCredentials() || !hasTransferProofId())(
+  "transfer MCP tools (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID)",
+  () => {
+    let proofClient: Client;
+    let proofTransport: StdioClientTransport;
+
+    beforeAll(async () => {
+      proofTransport = new StdioClientTransport({
+        command: "node",
+        args: [CLI_PATH, "mcp"],
+        env: cliEnv(),
+        stderr: "pipe",
+      });
+
+      proofClient = new Client({
+        name: "e2e-test-client",
+        version: "0.0.0",
+      });
+
+      await proofClient.connect(proofTransport);
+    });
+
+    afterAll(async () => {
+      await proofClient.close();
+    });
+
+    describe("transfer_proof", () => {
+      it("returns a base64-encoded PDF resource with mimeType application/pdf", async () => {
+        const id = getTransferProofId();
+        const result = (await proofClient.callTool({
+          name: "transfer_proof",
+          arguments: { id },
+        })) as CallToolResult;
+
+        expect(result.isError).not.toBe(true);
+        const content = result.content[0];
+        if (content === undefined || content.type !== "resource") {
+          throw new Error(`Expected resource content, got: ${JSON.stringify(result.content)}`);
+        }
+        const resource = content.resource;
+        expect(resource.mimeType).toBe("application/pdf");
+        expect(resource.uri).toBe(`transfer-proof://${id}`);
+        if (typeof resource.blob !== "string") {
+          throw new Error(`Expected base64 blob string, got: ${typeof resource.blob}`);
+        }
+        const buffer = Buffer.from(resource.blob, "base64");
+        // PDF magic bytes: %PDF-
+        expect(buffer.subarray(0, 5).toString("latin1")).toBe("%PDF-");
+        // 1 KiB lower bound — Qonto proof PDFs are several KiB; a smaller
+        // buffer would suggest truncation or a non-PDF response.
+        expect(buffer.byteLength).toBeGreaterThan(1024);
+      });
+    });
+  },
+);


### PR DESCRIPTION
## Summary

- Adds opt-in production-org E2E coverage for `getTransferProof` — both CLI (`transfer proof <id> --output-file <path>`) and MCP (`transfer_proof`).
- Documents the "sandbox-blocker pattern" in `docs/e2e-testing.md` so future similar deferred items can follow the same shape.
- Flips three coverage manifest entries from `pending` to `covered` with notes referencing #565.

Closes #565.

## Why production-org gating

The Qonto sandbox simulator does not produce SEPA transfer proof PDFs. Re-probe 2026-05-13 against sandbox `0909-future-club-2702` confirmed `GET /v2/sepa/transfers/{id}/proof` returns `404 not_found` for all fresh `status: settled` transfers (3/3 most-recent probed, refreshing the 2026-05-12 probe in the issue body). The endpoint is not a feature flag or per-org config — the simulator simply doesn't generate the artifact.

Acceptance criterion #1 explicitly allows this resolution path: "exercise the proof endpoint against a production org with a dedicated test transfer (out of scope for the existing CI gate)".

## Gate design

```ts
describe.skipIf(!hasApiKeyCredentials() || !hasTransferProofId())(
  "transfer CLI commands (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID)",
  () => { ... }
);
```

- CI never sets `QONTOCTL_TRANSFER_PROOF_ID` → blocks skip naturally.
- Local devs without the env var → blocks skip naturally.
- Local devs who opt in export `QONTOCTL_TRANSFER_PROOF_ID=<production-org-transfer-uuid>` alongside production credentials.

The dev is responsible for routing to production (i.e., unsetting `QONTOCTL_STAGING_TOKEN` or using a profile without one) — a sandbox-routed request will 404 deterministically.

## Verification

- `pnpm format:check` — PASS
- `pnpm lint` — PASS
- `pnpm typecheck` — PASS
- `pnpm test` — PASS (789 unit tests)
- `pnpm coverage-drift-check` — PASS (314 surfaces — 25 covered, 0 accepted gaps, 289 pending)
- `pnpm --filter @qontoctl/e2e test:e2e --reporter=verbose src/transfers/` — new tests appear as `↓` (skipped), confirming gate behavior without the env var:
  - `transfer CLI commands (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID) > transfer proof > downloads a valid PDF to --output-file`
  - `transfer MCP tools (e2e, production-org proof — opt-in via QONTOCTL_TRANSFER_PROOF_ID) > transfer_proof > returns a base64-encoded PDF resource with mimeType application/pdf`

End-to-end PDF fetch against a real production transfer cannot be exercised by CI (no env var) — it is the explicit "out of scope for CI gate" caveat in AC #1. Validate locally before merge by setting `QONTOCTL_TRANSFER_PROOF_ID` to a known-good production-org transfer UUID and running `pnpm test:e2e` (per the project E2E policy).

## Test plan

- [ ] CI green (api-key-only suite — proof block skips, no other test affected).
- [ ] Local `pnpm test:e2e` with `QONTOCTL_TRANSFER_PROOF_ID=<prod-id>` set and no staging token: both CLI and MCP proof tests PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)