### PR TITLE
(test) E2E for client-invoice lifecycle state transitions (#457)

### DIFF
--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -591,14 +591,14 @@
       "notes": ""
     },
     "core:packages/core/src/client-invoices/service.ts#cancelClientInvoice": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457): unpaid → canceled (terminal). Exercised in both CLI and MCP suites as the final step of the create → finalize → mark-paid → unmark-paid → cancel chain. Schema-validated via ClientInvoiceSchema."
     },
     "core:packages/core/src/client-invoices/service.ts#createClientInvoice": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle E2E (#457) entry point; also exercised by CRUD lifecycle (#455) and upload round-trip blocks. Asserts status === 'draft' and ClientInvoiceSchema on response."
     },
     "core:packages/core/src/client-invoices/service.ts#deleteClientInvoice": {
       "status": "pending",
@@ -606,9 +606,9 @@
       "notes": ""
     },
     "core:packages/core/src/client-invoices/service.ts#finalizeClientInvoice": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457): draft → unpaid. Asserts status === 'unpaid' and invoice_number is assigned. Exercised in both CLI and MCP suites."
     },
     "core:packages/core/src/client-invoices/service.ts#getClientInvoice": {
       "status": "pending",
@@ -626,19 +626,19 @@
       "notes": ""
     },
     "core:packages/core/src/client-invoices/service.ts#markClientInvoicePaid": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457): unpaid → paid. Exercised in both CLI and MCP suites. Schema-validated via ClientInvoiceSchema."
     },
     "core:packages/core/src/client-invoices/service.ts#sendClientInvoice": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) AC #3: send path covered separately from the main state machine. Opt-in via QONTOCTL_E2E_SEND_EMAIL=true env var since the path requires email-safe sandbox config (a no-bounce test mailbox). Default behavior: describe block skips, leaving the test reachable but inert."
     },
     "core:packages/core/src/client-invoices/service.ts#unmarkClientInvoicePaid": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/cli.e2e.test.ts", "packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457): paid → unpaid (reversal). Exercised in both CLI and MCP suites. Schema-validated via ClientInvoiceSchema."
     },
     "core:packages/core/src/client-invoices/service.ts#updateClientInvoice": {
       "status": "pending",
@@ -1101,14 +1101,14 @@
       "notes": ""
     },
     "mcp:client_invoice_cancel": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) MCP: unpaid → canceled (terminal). Exercised as the final step of the create → finalize → mark-paid → unmark-paid → cancel chain. Also reused as cleanup in the send block."
     },
     "mcp:client_invoice_create": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle E2E (#457) entry point; also exercised by the upload round-trip block (#455). Asserts status === 'draft' and ClientInvoiceSchema on response."
     },
     "mcp:client_invoice_delete": {
       "status": "pending",
@@ -1116,9 +1116,9 @@
       "notes": ""
     },
     "mcp:client_invoice_finalize": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) MCP: draft → unpaid. Asserts status === 'unpaid' and invoice_number is assigned. Also exercised in the send block as a precondition."
     },
     "mcp:client_invoice_list": {
       "status": "pending",
@@ -1126,14 +1126,14 @@
       "notes": ""
     },
     "mcp:client_invoice_mark_paid": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) MCP: unpaid → paid. Schema-validated via ClientInvoiceSchema."
     },
     "mcp:client_invoice_send": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) AC #3 MCP: opt-in via QONTOCTL_E2E_SEND_EMAIL=true env var since the path requires email-safe sandbox config (a no-bounce test mailbox). Default behavior: describe block skips, leaving the test reachable but inert."
     },
     "mcp:client_invoice_show": {
       "status": "pending",
@@ -1141,9 +1141,9 @@
       "notes": ""
     },
     "mcp:client_invoice_unmark_paid": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/client-invoices/mcp.e2e.test.ts"],
+      "notes": "Lifecycle state-transitions E2E (#457) MCP: paid → unpaid (reversal). Schema-validated via ClientInvoiceSchema."
     },
     "mcp:client_invoice_update": {
       "status": "pending",

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -197,6 +197,205 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
     });
   });
 
+  // State-machine E2E for non-SCA write paths — closes #457 (umbrella #449
+  // Group 5). The state machine is:
+  //
+  //   create (draft) → finalize (draft → unpaid) → mark-paid (unpaid → paid)
+  //     → unmark-paid (paid → unpaid) → cancel (unpaid → canceled, terminal)
+  //
+  // Each transition is a separate `it` so a failure localizes to the broken
+  // transition rather than cascading through the whole lifecycle. The
+  // closure-shared `lifecycleInvoiceId` mirrors the CRUD lifecycle and upload
+  // round-trip patterns above; downstream transitions early-return when an
+  // upstream step failed (sandbox/prod orgs without a usable client + IBAN
+  // skip the entire chain gracefully).
+  //
+  // Cancellation is terminal — Qonto does not let the test reverse it, and
+  // canceled invoices cannot be deleted (delete is draft-only). Each
+  // successful run therefore leaves one canceled invoice in the test org.
+  // This is the explicit price of live state-machine coverage; the umbrella
+  // (#449 Group 5) accepted this trade-off in the original AC.
+  //
+  // The `send` path (AC #3) is exercised in a separate, env-var-gated block
+  // below — it requires email-safe sandbox config that the default test org
+  // does not necessarily provide.
+  describe("client-invoice lifecycle state transitions (#457)", () => {
+    let lifecycleInvoiceId: string | undefined;
+
+    it("creates a draft invoice as the lifecycle entry point", () => {
+      const clientListOutput = cli("--output", "json", "client", "list");
+      const clients = JSON.parse(clientListOutput) as { id: string }[];
+      if (clients.length === 0) {
+        return;
+      }
+
+      const clientId = (clients[0] as { id: string }).id;
+      const today = new Date().toISOString().split("T")[0] as string;
+      const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const body = JSON.stringify({
+        client_id: clientId,
+        issue_date: today,
+        due_date: dueDate,
+        currency: "EUR",
+        terms_and_conditions: "E2E #457 lifecycle test — safe to delete",
+        items: [
+          {
+            title: "E2E Lifecycle Test Service",
+            quantity: "1",
+            unit_price: { value: "100.00", currency: "EUR" },
+            vat_rate: "20",
+          },
+        ],
+      });
+
+      try {
+        const output = cli("--output", "json", "client-invoice", "create", "--body", body);
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+        const invoice = ClientInvoiceSchema.parse(parsed);
+        expect(invoice.status).toBe("draft");
+        lifecycleInvoiceId = invoice.id;
+      } catch {
+        // Org may lack a usable client + IBAN — skip the lifecycle.
+      }
+    });
+
+    it("transitions draft → unpaid via finalize", () => {
+      if (lifecycleInvoiceId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "finalize", lifecycleInvoiceId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("unpaid");
+      // Finalize assigns the invoice number — pre-finalize this is null.
+      expect(invoice.invoice_number).not.toBeNull();
+    });
+
+    it("transitions unpaid → paid via mark-paid", () => {
+      if (lifecycleInvoiceId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "mark-paid", lifecycleInvoiceId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("paid");
+    });
+
+    it("transitions paid → unpaid via unmark-paid", () => {
+      if (lifecycleInvoiceId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "unmark-paid", lifecycleInvoiceId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("unpaid");
+    });
+
+    it("transitions unpaid → canceled via cancel (terminal)", () => {
+      if (lifecycleInvoiceId === undefined) {
+        return;
+      }
+
+      const output = cli("--output", "json", "client-invoice", "cancel", lifecycleInvoiceId);
+      const parsed = JSON.parse(output) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("canceled");
+      // Terminal state — no cleanup; canceled invoices cannot be deleted.
+    });
+  });
+
+  // AC #3 of #457: `client-invoice send` is a separate path that requires
+  // email-safe sandbox config (a test client with a no-bounce mailbox).
+  // Skipped by default; opt in via `QONTOCTL_E2E_SEND_EMAIL=true`. When
+  // enabled, exercises create → finalize → send → cancel (cleanup); the
+  // send is the assertion under test, the surrounding lifecycle is
+  // scaffolding to reach a sendable state.
+  describe.skipIf(process.env["QONTOCTL_E2E_SEND_EMAIL"] !== "true")(
+    "client-invoice send (#457 AC #3, opt-in via QONTOCTL_E2E_SEND_EMAIL=true)",
+    () => {
+      let sendInvoiceId: string | undefined;
+
+      it("creates a draft invoice as a send precondition", () => {
+        const clientListOutput = cli("--output", "json", "client", "list");
+        const clients = JSON.parse(clientListOutput) as { id: string }[];
+        if (clients.length === 0) {
+          return;
+        }
+
+        const clientId = (clients[0] as { id: string }).id;
+        const today = new Date().toISOString().split("T")[0] as string;
+        const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+        const body = JSON.stringify({
+          client_id: clientId,
+          issue_date: today,
+          due_date: dueDate,
+          currency: "EUR",
+          terms_and_conditions: "E2E #457 send test — safe to delete",
+          items: [
+            {
+              title: "E2E Send Test Service",
+              quantity: "1",
+              unit_price: { value: "100.00", currency: "EUR" },
+              vat_rate: "20",
+            },
+          ],
+        });
+
+        try {
+          const output = cli("--output", "json", "client-invoice", "create", "--body", body);
+          const parsed = JSON.parse(output) as Record<string, unknown>;
+          expect(parsed).toHaveProperty("id");
+          expect(parsed).toHaveProperty("status", "draft");
+          sendInvoiceId = parsed["id"] as string;
+        } catch {
+          // Org may lack a usable client + IBAN — skip the send.
+        }
+      });
+
+      it("finalizes the draft to make it sendable", () => {
+        if (sendInvoiceId === undefined) {
+          return;
+        }
+
+        const output = cli("--output", "json", "client-invoice", "finalize", sendInvoiceId);
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("status", "unpaid");
+      });
+
+      it("sends the finalized invoice to the client via email", () => {
+        if (sendInvoiceId === undefined) {
+          return;
+        }
+
+        const output = cli("--output", "json", "client-invoice", "send", sendInvoiceId);
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("sent", true);
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+      });
+
+      it("cancels the sent invoice (cleanup)", () => {
+        if (sendInvoiceId === undefined) {
+          return;
+        }
+
+        const output = cli("--output", "json", "client-invoice", "cancel", sendInvoiceId);
+        const parsed = JSON.parse(output) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("status", "canceled");
+      });
+    },
+  );
+
   // Regression for #575: Qonto returns `items: null` for drafts with no line
   // items. Pre-fix, `client-invoice show` blew up with a Zod validation error
   // on any such draft. This test creates an empty-items draft and shows it,

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -218,4 +218,232 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       expect(result.isError).toBeFalsy();
     });
   });
+
+  // State-machine E2E for non-SCA write paths via MCP — mirrors the CLI
+  // suite's lifecycle block for #457. The state machine is:
+  //
+  //   client_invoice_create (draft) → client_invoice_finalize (draft → unpaid)
+  //     → client_invoice_mark_paid (unpaid → paid)
+  //     → client_invoice_unmark_paid (paid → unpaid)
+  //     → client_invoice_cancel (unpaid → canceled, terminal)
+  //
+  // Each transition is a separate `it` so a failure localizes to the broken
+  // transition. The closure-shared `lifecycleInvoiceId` mirrors the upload
+  // round-trip block above. Cancellation is terminal — canceled invoices
+  // cannot be deleted (delete is draft-only), so each successful run leaks
+  // one canceled invoice into the test org (accepted trade-off per #449
+  // Group 5).
+  describe("client_invoice lifecycle state transitions (#457, MCP)", () => {
+    let lifecycleInvoiceId: string | undefined;
+
+    it("creates a draft invoice as the lifecycle entry point", async () => {
+      const clientListResult = await client.callTool({
+        name: "client_list",
+        arguments: {},
+      });
+      if (clientListResult.isError === true) return;
+
+      const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
+        clients: { id: string }[];
+      };
+      if (clientsParsed.clients.length === 0) {
+        return;
+      }
+
+      const clientId = (clientsParsed.clients[0] as { id: string }).id;
+      const today = new Date().toISOString().split("T")[0] as string;
+      const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+      const createResult = await client.callTool({
+        name: "client_invoice_create",
+        arguments: {
+          client_id: clientId,
+          issue_date: today,
+          due_date: dueDate,
+          currency: "EUR",
+          terms_and_conditions: "E2E #457 lifecycle test (MCP) — safe to delete",
+          items: [
+            {
+              title: "E2E Lifecycle Test Service (MCP)",
+              quantity: "1",
+              unit_price: { value: "100.00", currency: "EUR" },
+              vat_rate: "20",
+            },
+          ],
+        },
+      });
+
+      // Invoice creation may fail if the organization lacks required setup
+      // (e.g., IBAN not configured) — skip downstream lifecycle when it does.
+      if (createResult.isError === true) return;
+
+      const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.status).toBe("draft");
+      lifecycleInvoiceId = invoice.id;
+    });
+
+    it("transitions draft → unpaid via client_invoice_finalize", async () => {
+      if (lifecycleInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_finalize",
+        arguments: { id: lifecycleInvoiceId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("unpaid");
+      // Finalize assigns the invoice number — pre-finalize this is null.
+      expect(invoice.invoice_number).not.toBeNull();
+    });
+
+    it("transitions unpaid → paid via client_invoice_mark_paid", async () => {
+      if (lifecycleInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_mark_paid",
+        arguments: { id: lifecycleInvoiceId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("paid");
+    });
+
+    it("transitions paid → unpaid via client_invoice_unmark_paid", async () => {
+      if (lifecycleInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_unmark_paid",
+        arguments: { id: lifecycleInvoiceId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("unpaid");
+    });
+
+    it("transitions unpaid → canceled via client_invoice_cancel (terminal)", async () => {
+      if (lifecycleInvoiceId === undefined) return;
+
+      const result = await client.callTool({
+        name: "client_invoice_cancel",
+        arguments: { id: lifecycleInvoiceId },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+      const invoice = ClientInvoiceSchema.parse(parsed);
+      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.status).toBe("canceled");
+      // Terminal state — no cleanup; canceled invoices cannot be deleted.
+    });
+  });
+
+  // AC #3 of #457 (MCP mirror): `client_invoice_send` is a separate path
+  // that requires email-safe sandbox config (a test client with a no-bounce
+  // mailbox). Skipped by default; opt in via `QONTOCTL_E2E_SEND_EMAIL=true`.
+  // When enabled, exercises create → finalize → send → cancel (cleanup);
+  // the send is the assertion under test, the surrounding lifecycle is
+  // scaffolding to reach a sendable state.
+  describe.skipIf(process.env["QONTOCTL_E2E_SEND_EMAIL"] !== "true")(
+    "client_invoice_send (#457 AC #3, MCP, opt-in via QONTOCTL_E2E_SEND_EMAIL=true)",
+    () => {
+      let sendInvoiceId: string | undefined;
+
+      it("creates a draft invoice as a send precondition", async () => {
+        const clientListResult = await client.callTool({
+          name: "client_list",
+          arguments: {},
+        });
+        if (clientListResult.isError === true) return;
+
+        const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
+          clients: { id: string }[];
+        };
+        if (clientsParsed.clients.length === 0) {
+          return;
+        }
+
+        const clientId = (clientsParsed.clients[0] as { id: string }).id;
+        const today = new Date().toISOString().split("T")[0] as string;
+        const dueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
+
+        const createResult = await client.callTool({
+          name: "client_invoice_create",
+          arguments: {
+            client_id: clientId,
+            issue_date: today,
+            due_date: dueDate,
+            currency: "EUR",
+            terms_and_conditions: "E2E #457 send test (MCP) — safe to delete",
+            items: [
+              {
+                title: "E2E Send Test Service (MCP)",
+                quantity: "1",
+                unit_price: { value: "100.00", currency: "EUR" },
+                vat_rate: "20",
+              },
+            ],
+          },
+        });
+
+        if (createResult.isError === true) return;
+
+        const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id");
+        expect(parsed).toHaveProperty("status", "draft");
+        sendInvoiceId = parsed["id"] as string;
+      });
+
+      it("finalizes the draft to make it sendable", async () => {
+        if (sendInvoiceId === undefined) return;
+
+        const result = await client.callTool({
+          name: "client_invoice_finalize",
+          arguments: { id: sendInvoiceId },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("status", "unpaid");
+      });
+
+      it("sends the finalized invoice to the client via email", async () => {
+        if (sendInvoiceId === undefined) return;
+
+        const result = await client.callTool({
+          name: "client_invoice_send",
+          arguments: { id: sendInvoiceId },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("sent", true);
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+      });
+
+      it("cancels the sent invoice (cleanup)", async () => {
+        if (sendInvoiceId === undefined) return;
+
+        const result = await client.callTool({
+          name: "client_invoice_cancel",
+          arguments: { id: sendInvoiceId },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
+        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("status", "canceled");
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- Adds live-sandbox E2E coverage for the client-invoice non-SCA state machine — `create → finalize → mark-paid → unmark-paid → cancel` — on both CLI and MCP surfaces, with each transition as a separate `it` for fail-localization.
- Ships the `send` path (AC #3) as a separate `describe.skipIf` block gated on `QONTOCTL_E2E_SEND_EMAIL=true` (default skip: 4 CLI + 4 MCP `it`s reachable but inert until the env var is set).
- Flips the 12 surfaces this PR directly exercises in `packages/e2e/coverage.json` from `pending` → `covered`.

Closes #457 (umbrella #449 Group 5).

## State machine

Each transition is its own `it`; downstream early-return when `lifecycleInvoiceId === undefined` (matches the precedent set by `client-invoice CRUD lifecycle` and upload round-trip blocks above):

| Step | CLI                       | MCP                                  | Assertion |
|------|---------------------------|--------------------------------------|-----------|
| 1    | `client-invoice create`   | `client_invoice_create`              | `status === "draft"` + `ClientInvoiceSchema` |
| 2    | `client-invoice finalize` | `client_invoice_finalize`            | `status === "unpaid"` + `invoice_number).not.toBeNull()` |
| 3    | `client-invoice mark-paid`| `client_invoice_mark_paid`           | `status === "paid"` |
| 4    | `client-invoice unmark-paid`| `client_invoice_unmark_paid`       | `status === "unpaid"` |
| 5    | `client-invoice cancel`   | `client_invoice_cancel`              | `status === "canceled"` (US spelling, canonical per #544) |

Cancellation is terminal — canceled invoices cannot be deleted (delete is draft-only), so successful runs leave one canceled invoice in the test org. The umbrella (#449 Group 5) accepted this trade-off up-front.

## Notes on AC wording

The issue body says `finalize (draft → pending)` but the canonical Qonto status enum (per merged #544) is `["draft", "unpaid", "paid", "canceled"]`. The tests assert `"unpaid"` accordingly — a documentation drift in the original issue, not a behavioral one.

## Unblock chain

The 2026-05-12 `/do-all` Wave 5 picked up this issue, hit the `client-invoice show` Zod schema crash, and corrected its own BLOCKED verdict the same day after surfacing the actual blocker. #575 / PR #579 (`accept null items in client-invoice schema`, merged 2026-05-12) was the unblock; this PR now lands the originally-scoped lifecycle E2E.

## Test plan

- [x] `pnpm format:check` — all matched files use Prettier code style
- [x] `pnpm lint` — 8/8 successful (Turbo full cache)
- [x] `pnpm build` — 5/5 successful
- [x] `pnpm coverage-drift-check` — 314 surfaces tracked, drift check passed
- [x] Scoped E2E (`vitest run … src/client-invoices/`) — 2 files, 32 passed + 8 designed skips (= 2 send-blocks × 4 `it`s), ~10s
- [x] Adversarial AC validation via fresh-context subprocess — verdict CLEAN
- [x] Polish via fresh-context subprocess — verdict CLEAN (2 fixes applied, no findings on re-scan)

CI is api-key-only against production; OAuth and sandbox suites skip naturally. The lifecycle block uses the same try/catch + closure-id pattern as the precedent in this file — when the target sandbox lacks a usable test client + IBAN, create silently catches and downstream transitions early-return (honest dormancy; sandbox-state issue, not test-design issue).