### PR TITLE
(test) E2E for OAuth flow (refresh + revoke against real OAuth server) (#460)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,6 @@ jobs:
         env:
           QONTOCTL_ORGANIZATION_SLUG: ${{ secrets.QONTOCTL_ORGANIZATION_SLUG }}
           QONTOCTL_SECRET_KEY: ${{ secrets.QONTOCTL_SECRET_KEY }}
-          # OAuth-flow E2E suite (auth/oauth-flow.e2e.test.ts). The suite
-          # gates itself capability-based (hasOAuthCredentials() &&
-          # hasStagingToken() && hasE2ERefreshToken()) so absent secrets
-          # materialize as empty strings and the suite skips. See
-          # docs/ci-oauth-secrets.md for the one-time-use rotation strategy.
-          QONTOCTL_CLIENT_ID: ${{ secrets.QONTOCTL_CLIENT_ID }}
-          QONTOCTL_CLIENT_SECRET: ${{ secrets.QONTOCTL_CLIENT_SECRET }}
-          QONTOCTL_STAGING_TOKEN: ${{ secrets.QONTOCTL_STAGING_TOKEN }}
-          QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG: ${{ secrets.QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG }}
 
   ci-gate:
     name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,15 @@ jobs:
         env:
           QONTOCTL_ORGANIZATION_SLUG: ${{ secrets.QONTOCTL_ORGANIZATION_SLUG }}
           QONTOCTL_SECRET_KEY: ${{ secrets.QONTOCTL_SECRET_KEY }}
+          # OAuth-flow E2E suite (auth/oauth-flow.e2e.test.ts). The suite
+          # gates itself capability-based (hasOAuthCredentials() &&
+          # hasStagingToken() && hasE2ERefreshToken()) so absent secrets
+          # materialize as empty strings and the suite skips. See
+          # docs/ci-oauth-secrets.md for the one-time-use rotation strategy.
+          QONTOCTL_CLIENT_ID: ${{ secrets.QONTOCTL_CLIENT_ID }}
+          QONTOCTL_CLIENT_SECRET: ${{ secrets.QONTOCTL_CLIENT_SECRET }}
+          QONTOCTL_STAGING_TOKEN: ${{ secrets.QONTOCTL_STAGING_TOKEN }}
+          QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG: ${{ secrets.QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG }}
 
   ci-gate:
     name: CI

--- a/docs/ci-oauth-secrets.md
+++ b/docs/ci-oauth-secrets.md
@@ -1,0 +1,147 @@
+# CI OAuth Secrets
+
+This guide documents the GitHub Actions secrets required to run the OAuth-flow
+E2E suite (`packages/e2e/src/auth/oauth-flow.e2e.test.ts`) and the operational
+strategy for rotating them.
+
+Most E2E suites in `packages/e2e/src/` run against the Qonto production API
+with api-key credentials (see [`docs/e2e-testing.md`](./e2e-testing.md)). The
+**OAuth-flow** suite is the exception: it exercises `refreshAccessToken` and
+`revokeToken` (`packages/core/src/auth/oauth-service.ts`) by round-tripping
+against the real Qonto sandbox OAuth server. This requires sandbox OAuth
+credentials AND a seed refresh token — neither of which CI carries by default.
+
+## Why a dedicated secrets surface
+
+`QONTOCTL_REFRESH_TOKEN` was removed as a runtime env var in [#495](https://github.com/alexey-pelykh/qontoctl/issues/495)
+because Qonto rotates refresh tokens on **every** `oauth/token` exchange — env
+overlay semantics would shadow the rotated value on subsequent reads, leaving
+qontoctl stuck on a burned token. The OAuth-flow E2E suite has the same
+constraint but a narrower scope: it consumes one refresh token per CI run and
+makes no claim that the seed is reusable.
+
+To keep the runtime contract clean while still enabling the E2E suite to run
+in CI, the suite reads a **dedicated** env var with a name that signals its
+intent — `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`. The `_LONG` suffix is a
+maintainer-facing reminder: this token lives in CI longer than typical runtime
+refresh tokens (until manually rotated), but is still consumed on every
+successful run.
+
+## Required GitHub Actions secrets
+
+To enable the OAuth-flow E2E suite in CI, configure these repository secrets:
+
+| Secret                                  | Source                                                                  | Notes                                               |
+| --------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------- |
+| `QONTOCTL_CLIENT_ID`                    | Sandbox OAuth app Client ID (from `developers-sandbox.qonto.com`)       | Static — does not rotate                            |
+| `QONTOCTL_CLIENT_SECRET`                | Sandbox OAuth app Client Secret                                         | Static — does not rotate                            |
+| `QONTOCTL_STAGING_TOKEN`                | Sandbox staging token (issued separately by Qonto)                      | Static — routes requests to sandbox endpoints       |
+| `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` | A sandbox refresh token freshly issued by `qontoctl auth login` locally | **Consumed on every successful CI run** — see below |
+
+When all four secrets are present, the OAuth-flow E2E suite runs against the
+sandbox. When any one is missing, the suite skips naturally — no `CI=true`
+check is needed (the gate is capability-based).
+
+## One-time-use rotation strategy
+
+The OAuth-flow E2E suite **does not** persist the rotated refresh token back
+into `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`. After every successful run, the
+seed token stored in GitHub Actions is invalid. This is the simpler of the two
+strategies allowed by [#460](https://github.com/alexey-pelykh/qontoctl/issues/460)
+AC ("persists rotated refresh back into CI secret **or** accepts one-time-use
+refresh strategy") — chosen because in-pipeline secret rotation requires the
+job to hold a GitHub PAT with `secrets:write`, which is operationally heavier
+than periodic manual rotation.
+
+**Operational consequence**: the OAuth-flow E2E job runs green at most ONCE
+between rotations. After a successful run, the maintainer must re-seed the
+secret. Failure to re-seed surfaces as the suite failing (or skipping if also
+absent) on subsequent runs.
+
+### How to rotate
+
+1. Locally, log in to the Qonto sandbox OAuth app via:
+
+    ```sh
+    qontoctl auth login --profile sandbox
+    ```
+
+    (Or whichever profile carries the sandbox OAuth credentials + staging token.)
+
+2. Read the freshly-issued refresh token from the profile:
+
+    ```sh
+    grep -A1 'refresh-token' ~/.qontoctl/sandbox.yaml | head -2
+    ```
+
+3. Update the GitHub secret:
+
+    ```sh
+    gh secret set QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG \
+        --body "<the-refresh-token-value>" \
+        --repo alexey-pelykh/qontoctl
+    ```
+
+4. Trigger the CI workflow on the relevant branch to verify the suite passes.
+
+### Recommended rotation cadence
+
+There is no automated reminder. Rotate:
+
+- **Reactively**: when the OAuth-flow CI job reports failure with `401`
+  / `invalid_grant`. The cost of failure is bounded — the E2E job is
+  informational (not part of the merge gate), so a stale seed never blocks
+  development.
+- **Proactively**: before any release candidate where end-to-end OAuth
+  coverage matters (release runbook in [`docs/release-runbook.md`](./release-runbook.md)).
+
+## Scope: what this enables and what stays excluded
+
+| OAuth function       | E2E coverage status              | Notes                                                                                              |
+| -------------------- | -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `refreshAccessToken` | Covered (this suite)             | Asserts new access token + rotated refresh token + positive expiry against sandbox token endpoint. |
+| `revokeToken`        | Covered (this suite)             | Asserts revoked access token returns 401 on subsequent sandbox API call.                           |
+| `exchangeCode`       | `accepted_gap` (no E2E coverage) | See [§ Why `exchangeCode` is not covered](#why-exchangecode-is-not-covered) below.                 |
+
+### Why `exchangeCode` is not covered
+
+The authorization-code flow requires browser interaction (user authentication
+and consent at the Qonto authorization endpoint). It cannot be automated
+headlessly without significant test infrastructure investment — either a mock
+OAuth server (which would exercise our HTTP layer but not the real Qonto
+authorization endpoint) or a headless-browser harness (operationally heavy for
+one code path).
+
+The runtime code path is exercised manually via `qontoctl auth login` during
+sandbox/production setup, and the shared `requestTokens` helper that
+`exchangeCode` uses is exercised by the `refreshAccessToken` suite — so the
+HTTP/parse layers stay covered even though the authorization-code-specific
+glue does not.
+
+## Local development
+
+For local development, the same suite reads `oauth.refresh-token` from
+`.qontoctl.yaml` as a fallback when the CI env var is absent. The typical
+local flow:
+
+```sh
+qontoctl auth login                  # populates oauth.refresh-token
+pnpm test:e2e                        # OAuth-flow suite picks up the token
+qontoctl auth login                  # re-issue after the test consumes it
+```
+
+This mirrors the CI rotation cadence but with `auth login` as the rotation
+operator instead of `gh secret set`.
+
+## Related
+
+- [`docs/e2e-testing.md`](./e2e-testing.md) — full E2E categorization and gates
+- [`docs/oauth-setup.md`](./oauth-setup.md) — OAuth app registration and the
+  runtime `auth login` flow
+- [`docs/sandbox-testing.md`](./sandbox-testing.md) — sandbox routing semantics
+  and the staging-token header
+- [#449](https://github.com/alexey-pelykh/qontoctl/issues/449) — umbrella issue
+  for E2E coverage of every Qonto API endpoint qontoctl uses
+- [#495](https://github.com/alexey-pelykh/qontoctl/issues/495) — why
+  `QONTOCTL_REFRESH_TOKEN` was removed as a runtime env var (the constraint
+  that motivates the dedicated `_LONG` secret surface)

--- a/docs/ci-oauth-secrets.md
+++ b/docs/ci-oauth-secrets.md
@@ -38,9 +38,45 @@ To enable the OAuth-flow E2E suite in CI, configure these repository secrets:
 | `QONTOCTL_STAGING_TOKEN`                | Sandbox staging token (issued separately by Qonto)                      | Static — routes requests to sandbox endpoints       |
 | `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` | A sandbox refresh token freshly issued by `qontoctl auth login` locally | **Consumed on every successful CI run** — see below |
 
-When all four secrets are present, the OAuth-flow E2E suite runs against the
-sandbox. When any one is missing, the suite skips naturally — no `CI=true`
-check is needed (the gate is capability-based).
+When all four secrets are present **and plumbed into the workflow env**, the
+OAuth-flow E2E suite runs against the sandbox. When any one is missing, the
+suite skips naturally — no `CI=true` check is needed (the gate is
+capability-based).
+
+### Workflow plumbing is intentionally deferred
+
+The `.github/workflows/ci.yml` `e2e` job currently passes ONLY the two api-key
+secrets (`QONTOCTL_ORGANIZATION_SLUG`, `QONTOCTL_SECRET_KEY`) to the test
+step's env. The four OAuth-flow secrets above are **not** yet plumbed — so
+even if you set them, the suite still skips in CI.
+
+This deferral is intentional. The existing OAuth-required E2E suites (cards,
+webhooks, intl-transfers, …) gate on `hasOAuthCredentials()`. The moment
+`QONTOCTL_CLIENT_ID` and `QONTOCTL_CLIENT_SECRET` are exported to the e2e
+step, those suites stop skipping and start failing — because CI has no
+working OAuth access/refresh token for the non-flow suites. The OAuth-flow
+suite has its own dedicated seed via `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`,
+but that token is consumed per run and isn't a viable runtime token for the
+other suites.
+
+To enable the OAuth-flow suite in CI, the maintainer must EITHER:
+
+1. **Per-step env scoping** — split the OAuth-flow suite into its own CI
+   job (or its own `pnpm test:e2e` invocation with a vitest `--include` filter)
+   so the OAuth-flow env vars are visible only to that job/step. Other OAuth
+   suites continue to skip naturally because their env scope still lacks the
+   client credentials.
+2. **Plumb everything and accept other failures** — add the four OAuth-flow
+   env vars to the `e2e` job env. The OAuth-flow suite passes (until its
+   token is consumed); the other OAuth-required suites fail. The `e2e` job is
+   not part of the merge gate (only `ci-gate` is), so this is operationally
+   acceptable as a transition state until those other suites get working CI
+   tokens (separate scope from #460).
+
+Option 1 is the cleaner path; option 2 is the expedient one. Both are
+deferred to a follow-up PR — #460 ships the test infrastructure, helpers,
+documentation, and coverage manifest updates. The maintainer activates CI
+when they're ready.
 
 ## One-time-use rotation strategy
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -95,11 +95,11 @@ repository secrets:
 | `QONTOCTL_ORGANIZATION_SLUG` | api-key org slug |
 | `QONTOCTL_SECRET_KEY`        | api-key secret   |
 
-To additionally enable the OAuth-flow suite (`auth/oauth-flow`), configure
-the four secrets documented in [`docs/ci-oauth-secrets.md`](./ci-oauth-secrets.md):
-`QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_STAGING_TOKEN`,
-`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`. Missing any of the four → the
-suite skips, and the rest of the e2e job runs unaffected.
+The OAuth-flow suite (`auth/oauth-flow`) is **not** wired to CI by default;
+its four required secrets are documented in
+[`docs/ci-oauth-secrets.md`](./ci-oauth-secrets.md), but the workflow does not
+yet export them to the e2e job (see that doc's § Workflow plumbing is
+intentionally deferred for the rationale and activation paths).
 
 > **Note on `QONTOCTL_REFRESH_TOKEN`**: this env var is **no longer read by
 > qontoctl at runtime** (see issue #495). Refresh tokens are runtime-mutable

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -47,7 +47,14 @@ commands/mcp-payment-links · quotes · recurring-transfers · teams · webhooks
 
 **OAuth + sandbox** (local-only, requires staging-token):
 
-sca-continuation
+sca-continuation · auth/oauth-flow
+
+> The `auth/oauth-flow` suite has an **additional** gate beyond the
+> standard OAuth + staging-token check: it requires a seed refresh token
+> (`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var or `oauth.refresh-token`
+> in `.qontoctl.yaml`). The seed is consumed on every successful run — see
+> [`docs/ci-oauth-secrets.md`](./ci-oauth-secrets.md) for the one-time-use
+> rotation strategy.
 
 **No credentials needed** (run anywhere):
 
@@ -80,22 +87,29 @@ merging.
 
 ### Required GitHub secrets
 
-To enable the `e2e` CI job, configure these repository secrets:
+To enable the `e2e` CI job's api-key-compatible suites, configure these
+repository secrets:
 
 | Secret                       | Purpose          |
 | ---------------------------- | ---------------- |
 | `QONTOCTL_ORGANIZATION_SLUG` | api-key org slug |
 | `QONTOCTL_SECRET_KEY`        | api-key secret   |
 
-Old OAuth-related secrets (`QONTOCTL_STAGING_TOKEN`, `QONTOCTL_CLIENT_ID`,
-`QONTOCTL_CLIENT_SECRET`, `QONTOCTL_ACCESS_TOKEN`) are no longer used by the
-CI workflow and can be removed from repository settings.
+To additionally enable the OAuth-flow suite (`auth/oauth-flow`), configure
+the four secrets documented in [`docs/ci-oauth-secrets.md`](./ci-oauth-secrets.md):
+`QONTOCTL_CLIENT_ID`, `QONTOCTL_CLIENT_SECRET`, `QONTOCTL_STAGING_TOKEN`,
+`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`. Missing any of the four → the
+suite skips, and the rest of the e2e job runs unaffected.
 
 > **Note on `QONTOCTL_REFRESH_TOKEN`**: this env var is **no longer read by
-> qontoctl** (see issue #495). Refresh tokens are runtime-mutable state and
-> were never compatible with env-overlay semantics — refresh would shadow
-> rotated values on subsequent reads. If your CI relied on it, switch to
-> api-key auth (above) or OAuth via file-based credentials.
+> qontoctl at runtime** (see issue #495). Refresh tokens are runtime-mutable
+> state and were never compatible with env-overlay semantics — refresh would
+> shadow rotated values on subsequent reads. If your CI relied on it for
+> runtime auth, switch to api-key auth (above) or OAuth via file-based
+> credentials. For the OAuth-flow E2E suite specifically, use the dedicated
+> `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` secret described in
+> [`docs/ci-oauth-secrets.md`](./ci-oauth-secrets.md), which is scoped to
+> tests only and is not read by the runtime.
 
 ## Running locally
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -275,6 +275,8 @@ export QONTOCTL_CLIENT_SECRET="sandbox-client-secret"
 
 When `oauth.staging-token` is configured (or the `QONTOCTL_STAGING_TOKEN` env var is set), sandbox URLs are used automatically. SCA writes against sandbox additionally need an `X-Qonto-2fa-Preference: mock` header — QontoCtl auto-applies this when a staging token is set. See [`sandbox-testing.md`](./sandbox-testing.md) for SCA-method overrides and the `qontoctl sca-session mock-decision` workflow.
 
+For running the OAuth-flow E2E suite (`refreshAccessToken` + `revokeToken` round-trip) against the sandbox in CI, see [`ci-oauth-secrets.md`](./ci-oauth-secrets.md), which documents the dedicated `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` secret and the one-time-use rotation strategy.
+
 The sandbox uses separate OAuth endpoints:
 
 |       | Production                      | Sandbox                                        |

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -441,19 +441,19 @@
       "notes": ""
     },
     "core:packages/core/src/auth/oauth-service.ts#exchangeCode": {
-      "status": "pending",
+      "status": "accepted_gap",
       "tests": [],
-      "notes": ""
+      "notes": "Authorization-code flow requires browser interaction (user authentication + consent at the Qonto authorization endpoint); cannot be automated headlessly without significant test infrastructure (mock OAuth server or headless-browser harness). The runtime path is covered by the `auth login` CLI command exercised manually during sandbox/production setup; `refreshAccessToken` and `revokeToken` exercise the same shared `requestTokens` helper (#460). See docs/ci-oauth-secrets.md for the documented gap."
     },
     "core:packages/core/src/auth/oauth-service.ts#refreshAccessToken": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/auth/oauth-flow.e2e.test.ts"],
+      "notes": "OAuth + sandbox + e2e refresh token gate; one-time-use refresh strategy (Qonto rotates on every refresh). See docs/ci-oauth-secrets.md."
     },
     "core:packages/core/src/auth/oauth-service.ts#revokeToken": {
-      "status": "pending",
-      "tests": [],
-      "notes": ""
+      "status": "covered",
+      "tests": ["packages/e2e/src/auth/oauth-flow.e2e.test.ts"],
+      "notes": "OAuth + sandbox + e2e refresh token gate; revoked access token is verified to return 401 on subsequent API call."
     },
     "core:packages/core/src/beneficiaries/service.ts#buildBeneficiaryQueryParams": {
       "status": "pending",

--- a/packages/e2e/src/auth/oauth-flow.e2e.test.ts
+++ b/packages/e2e/src/auth/oauth-flow.e2e.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  OAUTH_REVOKE_SANDBOX_URL,
+  OAUTH_TOKEN_SANDBOX_URL,
+  refreshAccessToken,
+  revokeToken,
+  SANDBOX_BASE_URL,
+} from "@qontoctl/core";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  getCredentials,
+  getE2ERefreshToken,
+  hasE2ERefreshToken,
+  hasOAuthCredentials,
+  hasStagingToken,
+} from "../sandbox.js";
+
+// -----------------------------------------------------------------------------
+// OAuth flow round-trip suite — exercises `refreshAccessToken` and `revokeToken`
+// against the real Qonto sandbox OAuth server. Closes #460 (Group 8 of #449).
+//
+// Gate: requires OAuth client credentials, a staging token (sandbox routing),
+// AND a seed refresh token (`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var
+// or `oauth.refresh-token` in `.qontoctl.yaml`). The seed token is consumed
+// on each successful run (Qonto rotates refresh tokens on every refresh) —
+// see `docs/ci-oauth-secrets.md` for the one-time-use rotation strategy.
+//
+// `exchangeCode` is intentionally NOT covered: the authorization-code flow
+// requires browser interaction (user authentication + consent) which cannot
+// be automated headlessly without significant test infrastructure. Documented
+// as `accepted_gap` in `packages/e2e/coverage.json`.
+// -----------------------------------------------------------------------------
+
+describe.skipIf(!hasOAuthCredentials() || !hasStagingToken() || !hasE2ERefreshToken())(
+  "OAuth flow against real OAuth server (e2e, sandbox)",
+  () => {
+    let clientId: string;
+    let clientSecret: string;
+    let stagingToken: string;
+    let seedRefreshToken: string;
+
+    // Access token from the refresh test, consumed by the revoke test. Vitest
+    // runs `it` blocks sequentially within a file, and the project pins
+    // `--concurrency=1` (see CLAUDE.md § E2E Testing), so the cross-test
+    // hand-off is deterministic. Sharing one access token across both tests
+    // is the only way to exercise revoke against a freshly-issued token
+    // without burning a second seed refresh token per run.
+    let freshAccessToken: string | undefined;
+
+    beforeAll(() => {
+      const creds = getCredentials();
+      if (!creds.clientId || !creds.clientSecret || !creds.stagingToken) {
+        throw new Error(
+          "E2E setup: expected OAuth client credentials and staging token (suite gate should have skipped)",
+        );
+      }
+      clientId = creds.clientId;
+      clientSecret = creds.clientSecret;
+      stagingToken = creds.stagingToken;
+      seedRefreshToken = getE2ERefreshToken();
+    });
+
+    // AC: Given a valid sandbox refresh token,
+    //     When `refreshAccessToken` is called against the sandbox token endpoint,
+    //     Then it returns a new access token, a (rotated) refresh token,
+    //     a positive `expires_in`, and a bearer token type.
+    it("refreshAccessToken returns rotated tokens against the sandbox", async () => {
+      const tokens = await refreshAccessToken(
+        OAUTH_TOKEN_SANDBOX_URL,
+        clientId,
+        clientSecret,
+        seedRefreshToken,
+        stagingToken,
+      );
+
+      expect(tokens.accessToken).toBeTruthy();
+      expect(typeof tokens.accessToken).toBe("string");
+      expect(tokens.tokenType.toLowerCase()).toBe("bearer");
+      expect(tokens.expiresIn).toBeGreaterThan(0);
+
+      // Qonto rotates refresh tokens on every refresh — the returned token
+      // MUST differ from the one we sent. This rotation is what makes
+      // CI-stored refresh tokens "burn on use" and motivates the
+      // one-time-use rotation strategy documented in
+      // `docs/ci-oauth-secrets.md`.
+      expect(tokens.refreshToken).toBeTruthy();
+      expect(tokens.refreshToken).not.toBe(seedRefreshToken);
+
+      freshAccessToken = tokens.accessToken;
+    });
+
+    // AC: Given a freshly-issued access token from `refreshAccessToken`,
+    //     When `revokeToken` is called against the sandbox revoke endpoint,
+    //     Then a subsequent API call carrying that access token returns 401.
+    it("revokeToken renders an access token unusable for API calls", async () => {
+      if (freshAccessToken === undefined) {
+        throw new Error("Cannot test revoke: refresh test did not produce an access token (check earlier failure)");
+      }
+
+      // Sanity check: the freshly-refreshed access token works against the
+      // sandbox API BEFORE we revoke it. This eliminates false negatives
+      // where the 401 was caused by something other than revocation.
+      const sanityCheck = await fetch(`${SANDBOX_BASE_URL}/v2/organization`, {
+        headers: {
+          Authorization: `Bearer ${freshAccessToken}`,
+          "X-Qonto-Staging-Token": stagingToken,
+        },
+      });
+      expect(sanityCheck.status).toBe(200);
+
+      await revokeToken(OAUTH_REVOKE_SANDBOX_URL, clientId, clientSecret, freshAccessToken, stagingToken);
+
+      const afterRevoke = await fetch(`${SANDBOX_BASE_URL}/v2/organization`, {
+        headers: {
+          Authorization: `Bearer ${freshAccessToken}`,
+          "X-Qonto-Staging-Token": stagingToken,
+        },
+      });
+      expect(afterRevoke.status).toBe(401);
+    });
+  },
+);

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -30,6 +30,7 @@ interface ConfigCredentials {
   readonly clientId?: string;
   readonly clientSecret?: string;
   readonly stagingToken?: string;
+  readonly refreshToken?: string;
 }
 
 /**
@@ -81,6 +82,9 @@ function readConfigFileCredentials(): ConfigCredentials | undefined {
         }
         if (typeof record["staging-token"] === "string") {
           (result as { stagingToken: string }).stagingToken = record["staging-token"];
+        }
+        if (typeof record["refresh-token"] === "string") {
+          (result as { refreshToken: string }).refreshToken = record["refresh-token"];
         }
       }
     }
@@ -187,6 +191,55 @@ export function getTransferProofId(): string {
     throw new Error("QONTOCTL_TRANSFER_PROOF_ID is not set (guard with hasTransferProofId())");
   }
   return id;
+}
+
+/**
+ * Check whether a sandbox OAuth refresh token is available for the
+ * OAuth-flow round-trip E2E suite — either via the
+ * `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var (the CI surface, kept
+ * distinct from runtime refresh-token env vars per #495) or via
+ * `oauth.refresh-token` in `.qontoctl.yaml` (local developer flow,
+ * populated by `qontoctl auth login`).
+ *
+ * Used by `describe.skipIf(... || !hasE2ERefreshToken())` on the
+ * OAuth-flow E2E suite. Pair with `!hasOAuthCredentials()` and
+ * `!hasStagingToken()` since the flow requires sandbox routing and
+ * client credentials in addition to the seed refresh token.
+ *
+ * The `_LONG` suffix on the env var name is operational: it signals to
+ * the maintainer that this is a dedicated, manually-rotated sandbox
+ * refresh token — distinct from runtime tokens that qontoctl rotates
+ * on every refresh. See [`docs/ci-oauth-secrets.md`](../../../docs/ci-oauth-secrets.md)
+ * for the one-time-use rotation strategy.
+ */
+export function hasE2ERefreshToken(): boolean {
+  if (process.env["QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG"]) {
+    return true;
+  }
+  return Boolean(readConfigFileCredentials()?.refreshToken);
+}
+
+/**
+ * Retrieve the sandbox OAuth refresh token for the OAuth-flow round-trip
+ * E2E suite. Resolution order: `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`
+ * env var, then `oauth.refresh-token` in `.qontoctl.yaml`.
+ *
+ * Throws if no refresh token is available — callers should be guarded by
+ * {@link hasE2ERefreshToken}.
+ */
+export function getE2ERefreshToken(): string {
+  const envToken = process.env["QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG"];
+  if (envToken) {
+    return envToken;
+  }
+  const fileToken = readConfigFileCredentials()?.refreshToken;
+  if (fileToken) {
+    return fileToken;
+  }
+  throw new Error(
+    "No E2E OAuth refresh token available " +
+      "(checked QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG env var and oauth.refresh-token in .qontoctl.yaml)",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #460 — Group 8 of #449 (OAuth flow E2E coverage). Adds a sandbox-gated E2E suite exercising `refreshAccessToken` and `revokeToken` against the real Qonto OAuth server; documents `exchangeCode` as `accepted_gap` (browser interaction inherent); documents the dedicated CI secrets and one-time-use rotation strategy.

## Changes

- **`packages/e2e/src/auth/oauth-flow.e2e.test.ts` (new)** — gated on `hasOAuthCredentials() && hasStagingToken() && hasE2ERefreshToken()`. Two tests:
  - `refreshAccessToken` returns new access token + rotated refresh token + positive expiry + bearer token type
  - `revokeToken` invalidates the freshly-issued access token; subsequent API call to `/v2/organization` returns 401 (with pre-revoke 200 sanity check to eliminate false negatives)
- **`packages/e2e/src/sandbox.ts`** — adds `hasE2ERefreshToken()` and `getE2ERefreshToken()` helpers reading `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var (CI) or `oauth.refresh-token` from `.qontoctl.yaml` (local fallback)
- **`packages/e2e/coverage.json`** — `refreshAccessToken` and `revokeToken` → `covered` (pointing at new test file); `exchangeCode` → `accepted_gap` with specific browser-interaction justification
- **`docs/ci-oauth-secrets.md` (new)** — documents the 4 required GitHub Actions secrets, the one-time-use rotation strategy (refresh tokens consumed per successful CI run; periodic re-seed via `gh secret set`), AND the deliberate decision to defer workflow plumbing to a follow-up (see § Workflow plumbing is intentionally deferred)
- **`docs/e2e-testing.md`**, **`docs/oauth-setup.md`** — cross-references and suite categorization (OAuth + sandbox + e2e refresh token)

**`.github/workflows/ci.yml` is NOT modified.** The initial commit plumbed the 4 OAuth-flow secrets into the e2e job env; that flipped `hasOAuthCredentials()` from false → true and de-skipped existing OAuth-required suites (webhooks, cards, intl-transfers) which then failed because CI has no working OAuth tokens for them. Second commit reverts the workflow change. The OAuth-flow suite ships local-only by default; the maintainer can plumb in CI via per-step env scoping (cleaner) or accept other-suite failures (expedient) — both documented.

## Design notes

- **One-time-use semantics** (per AC's allowed strategy): Qonto rotates refresh tokens on every refresh, so the seed token is consumed per successful run. The doc explains the operational consequence and provides a 4-step rotation procedure via `gh secret set`. Chosen over in-pipeline auto-rotation because the latter would require a PAT with `secrets:write` permission, operationally heavier.
- **Capability-based skip**: when any of the 4 OAuth-flow secrets is unset, the gate (truthy checks throughout) returns false and the suite skips cleanly — empty-string env vars do NOT leak through.
- **`exchangeCode` as `accepted_gap`**: authorization-code flow requires user authentication + consent at the Qonto authorization endpoint; cannot run headlessly without a mock OAuth server or headless-browser harness. The shared `requestTokens` helper that `exchangeCode` uses IS exercised by the `refreshAccessToken` suite, so HTTP/parse layers stay covered; the runtime path is exercised manually via `qontoctl auth login`.
- **Test sequencing**: vitest runs `it` blocks sequentially within a file, project pins `--concurrency=1`, so carrying a single freshly-issued access token across the two tests is safe and avoids burning a second seed refresh per run. The revoke test guards explicitly on `undefined` for clean failure mode if refresh fails first.

## Validation

- Fresh-context validation subprocess confirmed all 5 AC pass with concrete evidence (verdict: CLEAN)
- Fresh-context polish subprocess applied 3 quality improvements (rename `rotatedAccessToken` → `freshAccessToken`, comment fix, doc structure)
- `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm coverage-drift-check`, `pnpm test`, `pnpm license-check`: all green
- Existing `auth.e2e.test.ts` still passes (6 tests; no regression)
- **CI: all gates green** (CI required gate + E2E informational job both passing after the workflow revert)
- The new OAuth-flow test against the real sandbox surfaces auth errors correctly when seed token is stale (one-time-use semantics in action)

## Operator action required

1. **Pre-seed the CI secret**: `gh secret set QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG --body "<freshly-issued sandbox refresh token>" --repo alexey-pelykh/qontoctl` (and the 3 other OAuth-flow secrets — see `docs/ci-oauth-secrets.md`). The secrets can be configured now; activating them in CI requires a follow-up workflow change (see § Workflow plumbing is intentionally deferred).
2. **Optional: local green-path verification**: `qontoctl auth login --profile <sandbox>` then `pnpm test:e2e -- src/auth/oauth-flow.e2e.test.ts` — this PR's autonomous validation could only exercise the failure-detection path (local seed was already consumed); the operator's fresh login is the cleanest way to confirm green-path assertions.

## Test plan

- [x] CI required gate passes
- [x] E2E informational job passes (no regression to OAuth-required suites)
- [ ] Optional: operator runs `pnpm test:e2e -- src/auth/oauth-flow.e2e.test.ts` locally with a freshly-logged-in refresh token and confirms both tests pass green-path

🤖 Generated with [Claude Code](https://claude.com/claude-code)