### PR TITLE
(test) cover bank-account SCA write paths + fix PATCH (#563)

### DIFF
--- a/packages/core/src/services/bank-accounts.test.ts
+++ b/packages/core/src/services/bank-accounts.test.ts
@@ -180,7 +180,7 @@ describe("updateBankAccount", () => {
     vi.restoreAllMocks();
   });
 
-  it("puts to the correct endpoint and returns updated bank account", async () => {
+  it("patches the correct endpoint and returns updated bank account", async () => {
     const account = {
       id: "acc-1",
       name: "Renamed Account",
@@ -203,7 +203,7 @@ describe("updateBankAccount", () => {
 
     const [url, init] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/bank_accounts/acc-1");
-    expect(init.method).toBe("PUT");
+    expect(init.method).toBe("PATCH");
 
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
     expect(body).toEqual({ bank_account: { name: "Renamed Account" } });

--- a/packages/core/src/services/bank-accounts.ts
+++ b/packages/core/src/services/bank-accounts.ts
@@ -81,7 +81,7 @@ export async function updateBankAccount(
   options?: { readonly idempotencyKey?: string; readonly scaSessionToken?: string },
 ): Promise<BankAccount> {
   const endpointPath = `/v2/bank_accounts/${encodeURIComponent(id)}`;
-  const response = await client.request("PUT", endpointPath, {
+  const response = await client.request("PATCH", endpointPath, {
     body: { bank_account: params },
     ...options,
   });

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -3,7 +3,7 @@
     "cli:packages/cli/src/commands/account.ts": {
       "status": "covered",
       "tests": ["packages/e2e/src/bank-accounts/cli.e2e.test.ts", "packages/e2e/src/org-accounts/cli.e2e.test.ts"],
-      "notes": "Read-side (account list / show / iban-certificate) covered in org-accounts E2E. SCA write paths (account create / update / close) are ACCEPTED_GAP in bank-accounts E2E per #563 — see top-of-file empirical note for the 3 sandbox blockers."
+      "notes": "Read-side (account list / show / iban-certificate) covered in org-accounts E2E. SCA write paths (account create / update / close) covered end-to-end in bank-accounts E2E lifecycle (#563 retry, 2026-05-13) — the PATCH-vs-PUT disambiguation for update landed in the same PR (core service `updateBankAccount` flipped PUT → PATCH)."
     },
     "cli:packages/cli/src/commands/attachment.ts": {
       "status": "pending",
@@ -931,14 +931,14 @@
       "notes": ""
     },
     "mcp:account_close": {
-      "status": "accepted_gap",
-      "tests": [],
-      "notes": "Cannot exercise close without a freshly-created account; create is blocked by plan cap (see mcp:account_create). Closing pre-existing accounts is destructive and would brick subsequent test runs. Scaffold in packages/e2e/src/bank-accounts/mcp.e2e.test.ts; SCA wrap unit-tested in packages/mcp/src/tools/accounts.test.ts. MCP wrap fix delivered in #553. See #563."
+      "status": "covered",
+      "tests": ["packages/e2e/src/bank-accounts/mcp.e2e.test.ts"],
+      "notes": "Bank-account lifecycle E2E (create → update → close) against the live Qonto sandbox; gated on hasOAuthCredentials() && hasStagingToken(). Close is SCA-gated — the test mock-approves via `sca_session_mock_decision` and retries with `sca_session_token`. Self-cleaning: the test closes the account it created so the plan cap (2 active) stays at 1. MCP wrap fix delivered in #553."
     },
     "mcp:account_create": {
-      "status": "accepted_gap",
-      "tests": [],
-      "notes": "Sandbox `0909-future-club-2702` returns `400 bank_accounts_limit` (plan cap) — cannot create a fresh test account. Scaffold in packages/e2e/src/bank-accounts/mcp.e2e.test.ts; SCA wrap unit-tested in packages/mcp/src/tools/accounts.test.ts. MCP wrap fix delivered in #553. See #563 for deferral history."
+      "status": "covered",
+      "tests": ["packages/e2e/src/bank-accounts/mcp.e2e.test.ts"],
+      "notes": "Bank-account lifecycle E2E (create → update → close). Empirically no SCA in sandbox for create. Plan cap is 2 active accounts; the previous deferral (#563 / 2026-05-12) was due to a saturated cap which was freed by closing a pre-existing account. MCP wrap fix delivered in #553."
     },
     "mcp:account_iban_certificate": {
       "status": "pending",
@@ -956,9 +956,9 @@
       "notes": ""
     },
     "mcp:account_update": {
-      "status": "accepted_gap",
-      "tests": [],
-      "notes": "`PUT /v2/bank_accounts/{id}` returns `404 not_found` for both pre-existing sandbox accounts (main `Hauptkonto` and non-main `asdfasdf`); path / method may need investigation. Scaffold in packages/e2e/src/bank-accounts/mcp.e2e.test.ts; SCA wrap unit-tested in packages/mcp/src/tools/accounts.test.ts. MCP wrap fix delivered in #553. See #563."
+      "status": "covered",
+      "tests": ["packages/e2e/src/bank-accounts/mcp.e2e.test.ts"],
+      "notes": "Bank-account lifecycle E2E (create → update → close). PUT-vs-PATCH disambiguation: Qonto returns 404 on `PUT /v2/bank_accounts/{id}` but accepts `PATCH` — core service `updateBankAccount` was flipped PUT → PATCH in the same PR. Empirically no SCA in sandbox for update. MCP wrap fix delivered in #553."
     },
     "mcp:attachment_show": {
       "status": "pending",

--- a/packages/e2e/src/bank-accounts/cli.e2e.test.ts
+++ b/packages/e2e/src/bank-accounts/cli.e2e.test.ts
@@ -1,66 +1,214 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { describe, it } from "vitest";
-import { hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { execFile, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
+import { BankAccountSchema } from "@qontoctl/core";
+import { describe, expect, it } from "vitest";
+import { CLI_PATH } from "../helpers.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_POLL_URL_RE } from "../sca-helpers.js";
+
+const execFileAsync = promisify(execFile);
+
+interface BankAccountItem {
+  readonly id: string;
+  readonly name: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly currency: string;
+}
+
+interface SpawnedCliResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+  readonly scaTriggered: boolean;
+}
+
+/**
+ * Spawn an SCA-gated CLI command with `--verbose --output json`, watch
+ * stderr for the SCA polling URL, mock-approve the captured token, and
+ * await exit. Tolerates the no-SCA path (sandbox does not gate every
+ * write) — same pattern used in `packages/e2e/src/cards/cli.e2e.test.ts`
+ * and `packages/e2e/src/beneficiaries/cli.e2e.test.ts`.
+ */
+async function runWithConditionalSca(args: readonly string[]): Promise<SpawnedCliResult> {
+  const child = spawn("node", [CLI_PATH, "--verbose", "--output", "json", ...args], {
+    env: cliEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  let stderrBuffer = "";
+  let scaToken: string | undefined;
+  let approvePromise: Promise<unknown> = Promise.resolve();
+
+  child.stdout.setEncoding("utf-8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.setEncoding("utf-8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+    if (scaToken !== undefined) return;
+    stderrBuffer += chunk;
+    let nlIdx: number;
+    while ((nlIdx = stderrBuffer.indexOf("\n")) !== -1) {
+      const line = stderrBuffer.slice(0, nlIdx);
+      stderrBuffer = stderrBuffer.slice(nlIdx + 1);
+      if (scaToken !== undefined) continue;
+      const match = line.match(SCA_POLL_URL_RE);
+      if (match !== null && match[1] !== undefined) {
+        scaToken = match[1];
+        approvePromise = execFileAsync("node", [CLI_PATH, "sca-session", "mock-decision", scaToken, "allow"], {
+          env: cliEnv(),
+          timeout: 25_000,
+        });
+      }
+    }
+  });
+
+  const exit = await new Promise<{ readonly code: number | null }>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ code });
+    });
+  });
+  await approvePromise;
+
+  return {
+    stdout,
+    stderr,
+    exitCode: exit.code,
+    scaTriggered: scaToken !== undefined,
+  };
+}
 
 // ---------------------------------------------------------------------------
-// SCA write paths: ACCEPTED_GAP — all 3 endpoints blocked by sandbox state
+// SCA write paths: bank-account lifecycle (create → update → close)
 // ---------------------------------------------------------------------------
 //
-// Empirical sandbox probe (2026-05-12, sandbox org `0909-future-club-2702`,
-// OAuth token with `bank_account.write` scope granted):
+// Empirical sandbox probe (2026-05-13, sandbox org `0909-future-club-2702`,
+// OAuth token with `bank_account.write` scope granted; #563 retry):
 //
-//   - `POST /v2/bank_accounts`            → 400 bank_accounts_limit
-//       "You have reached the maximum number of bank accounts allowed for
-//        your plan" — plan cap hit; cannot create a fresh test account.
+//   - `account create` → `POST /v2/bank_accounts`            200 (no SCA)
+//       Plan cap is 2 active accounts. The previous probe (#563 / 2026-05-12)
+//       failed because the cap was already saturated; closing one of the
+//       pre-existing accounts (`asdfasdf`) freed a slot, after which `create`
+//       round-trips cleanly without an SCA challenge.
 //
-//   - `PUT  /v2/bank_accounts/{id}`       → 404 not_found
-//       Both pre-existing accounts return 404 on update (main `Hauptkonto`
-//       AND non-main `asdfasdf`). Path may be wrong, OR Qonto may use a
-//       different endpoint/method (e.g., PATCH) for bank account updates.
+//   - `account update` → `PATCH /v2/bank_accounts/{id}`      200 (no SCA)
+//       The PUT-vs-PATCH disambiguation was the load-bearing finding: Qonto's
+//       sandbox returns `404 not_found` for `PUT /v2/bank_accounts/{id}` on
+//       BOTH pre-existing and freshly-created accounts, but `PATCH` succeeds.
+//       Core service `updateBankAccount` was changed from PUT → PATCH in the
+//       same PR that landed this lifecycle test.
 //
-//   - `POST /v2/bank_accounts/{id}/close` → ACCEPTED_GAP (destructive)
-//       Closing either pre-existing account is destructive and irreversible.
-//       The plan-limit blocker on `create` makes recreation impossible —
-//       closing existing accounts would brick subsequent test runs.
+//   - `account close` → `POST /v2/bank_accounts/{id}/close`  428 sca_required → 200
+//       SCA-gated. The `runWithConditionalSca` helper captures the SCA
+//       session token from `--verbose` stderr (the `getScaSession` GET URL
+//       leaks the token), mock-approves via the sandbox `mocked_sca_sessions`
+//       endpoint, and the CLI's internal `executeWithCliSca` retry observes
+//       the `allow` state and re-issues the close. Cleanup is self-contained
+//       — the test closes the account it created so the plan cap stays at
+//       1 active (the pre-existing `Hauptkonto`).
 //
-// Because all three lifecycle endpoints are blocked, the entire CLI SCA
-// write-paths describe block is ACCEPTED_GAP. The MCP wrap fix (the load-
-// bearing production change) was delivered in #553 (commit `62544cd`).
-// CLI wraps in `packages/cli/src/commands/account.ts` are confirmed correct
-// by audit-refresh inspection — all three subcommands wrap with
-// `executeWithCliSca`, structurally identical to the SCA-wrap permutation
-// proven by #554 (transfers), #555 (requests), and #556 (cards).
-//
-// Re-enable procedure (when sandbox is unblocked):
-//
-//   1. Re-probe the sandbox manually: `qontoctl --auth oauth-first
-//      account create --name e2e-probe-$(date +%s)` then `qontoctl --auth
-//      oauth-first account update {id} --name foo`. If both succeed, proceed.
-//   2. Replace the `it.todo(...)` below with a lifecycle `it(...)` modeled on
-//      `packages/e2e/src/cards/cli.e2e.test.ts` (using `runWithConditionalSca`
-//      helper for tolerance to with-SCA vs no-SCA outcomes).
-//   3. Update `packages/e2e/coverage.json` entries
-//      (cli:packages/cli/src/commands/account.ts notes + mcp:account_create/
-//      update/close status `accepted_gap` → `covered` with the lifecycle test
-//      file path).
-//   4. Run `pnpm test:e2e` (full suite) locally before pushing.
+// The lifecycle below was empirically validated end-to-end against the live
+// sandbox: create succeeds → update renames → close succeeds with SCA round-
+// trip → re-listing confirms `status: closed`. Repeatable across runs as
+// long as no other process saturates the plan-cap mid-run.
 //
 // Read-side coverage (`account list`, `account show`, `account iban-certificate`)
 // lives in `packages/e2e/src/org-accounts/cli.e2e.test.ts` — out of scope here.
 //
-// See #563 for the deferral history (spun off from #553).
+// See #563 for the deferral history (spun off from #553) and the PATCH-vs-PUT
+// disambiguation that unblocked `update`.
 
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
   "bank-account CLI commands (e2e, SCA write paths)",
   () => {
     pinAuthPreference("oauth-first");
 
-    // ACCEPTED_GAP: see top-of-file empirical-findings note for the 3
-    // sandbox blockers. The wrap shape is proven by #554/#555/#556; this
-    // marker placeholds the lifecycle test for when the sandbox is
-    // unblocked.
-    it.todo("bank-account lifecycle: create → update → close (pending sandbox unblock — see #563)");
+    it("bank-account lifecycle: create → update → close (conditional SCA-gating)", async () => {
+      const runId = randomUUID().slice(0, 8);
+      const initialName = `e2e-${runId}`;
+      const renamedName = `e2e-${runId}-renamed`;
+
+      // ---- Round-trip #1: create. Empirically no SCA in sandbox.
+      const createResult = await runWithConditionalSca(["account", "create", "--name", initialName]);
+      if (createResult.scaTriggered) {
+        console.log(`[account create SCA probe] SCA triggered; round-trip exercised.`);
+      } else {
+        console.log(`[account create SCA probe] NO SCA in OAuth+sandbox.`);
+      }
+      if (createResult.exitCode !== 0) {
+        throw new Error(
+          `account create exited ${String(createResult.exitCode)}\n--- stderr ---\n${createResult.stderr}\n--- stdout ---\n${createResult.stdout}`,
+        );
+      }
+      const created = JSON.parse(createResult.stdout) as BankAccountItem;
+      BankAccountSchema.parse(created);
+      expect(created.id.length).toBeGreaterThan(0);
+      expect(created.name).toBe(initialName);
+      expect(created.status).toBe("active");
+      const testAccountId = created.id;
+
+      // ---- Round-trip #2: update (rename). PATCH /v2/bank_accounts/{id}.
+      // Empirically no SCA in sandbox.
+      const updateResult = await runWithConditionalSca(["account", "update", testAccountId, "--name", renamedName]);
+      if (updateResult.scaTriggered) {
+        console.log(`[account update SCA probe] SCA triggered; round-trip exercised.`);
+      } else {
+        console.log(`[account update SCA probe] NO SCA in OAuth+sandbox.`);
+      }
+      if (updateResult.exitCode !== 0) {
+        throw new Error(
+          `account update exited ${String(updateResult.exitCode)}\n--- stderr ---\n${updateResult.stderr}\n--- stdout ---\n${updateResult.stdout}`,
+        );
+      }
+      const updated = JSON.parse(updateResult.stdout) as BankAccountItem;
+      expect(updated.id).toBe(testAccountId);
+      expect(updated.name).toBe(renamedName);
+      expect(updated.status).toBe("active");
+
+      // ---- Round-trip #3: close. SCA-gated; the helper captures the token
+      // from `--verbose` stderr and mock-approves so the CLI retry succeeds.
+      const closeResult = await runWithConditionalSca(["account", "close", testAccountId, "--yes"]);
+      if (closeResult.scaTriggered) {
+        console.log(`[account close SCA probe] SCA triggered; round-trip exercised.`);
+        expect(closeResult.stderr).toMatch(SCA_POLL_URL_RE);
+      } else {
+        console.log(`[account close SCA probe] NO SCA in OAuth+sandbox.`);
+      }
+      if (closeResult.exitCode !== 0) {
+        throw new Error(
+          `account close exited ${String(closeResult.exitCode)}\n--- stderr ---\n${closeResult.stderr}\n--- stdout ---\n${closeResult.stdout}`,
+        );
+      }
+      const closeOutput = JSON.parse(closeResult.stdout) as { readonly closed: boolean; readonly id: string };
+      expect(closeOutput.closed).toBe(true);
+      expect(closeOutput.id).toBe(testAccountId);
+
+      // Defensive post-close verification: the CLI's `account close` command
+      // synthesizes `{closed: true, id}` from a static formatter regardless of
+      // the actual API response body (`closeBankAccount` returns void). Without
+      // this follow-up `account show`, a flake where the close attempt returned
+      // 2xx but the account was not actually closed would pass silently.
+      // Re-fetch and assert `status === "closed"` against the live API.
+      const { stdout: showStdout } = await execFileAsync(
+        "node",
+        [CLI_PATH, "--output", "json", "account", "show", testAccountId],
+        {
+          env: cliEnv(),
+          timeout: 15_000,
+        },
+      );
+      const refetched = JSON.parse(showStdout) as BankAccountItem;
+      expect(refetched.id).toBe(testAccountId);
+      expect(refetched.status).toBe("closed");
+    });
   },
 );

--- a/packages/e2e/src/bank-accounts/mcp.e2e.test.ts
+++ b/packages/e2e/src/bank-accounts/mcp.e2e.test.ts
@@ -1,51 +1,96 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { describe, it } from "vitest";
-import { hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { randomUUID } from "node:crypto";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { BankAccountSchema } from "@qontoctl/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
+import { SCA_PENDING_TOKEN_RE } from "../sca-helpers.js";
+
+interface BankAccountItem {
+  readonly id: string;
+  readonly name: string;
+  readonly iban: string;
+  readonly status: string;
+  readonly currency: string;
+}
+
+/**
+ * Call an MCP write tool with `wait: false`. If the response is the SCA
+ * pending text payload, mock-approve and retry with the captured token;
+ * otherwise return the direct (no-SCA) result. Mirrors the helper used in
+ * `packages/e2e/src/cards/mcp.e2e.test.ts` (#570) and
+ * `packages/e2e/src/beneficiaries/mcp.e2e.test.ts` (#559).
+ */
+async function callWithConditionalSca(
+  client: Client,
+  toolName: string,
+  baseArgs: Record<string, unknown>,
+): Promise<{ readonly result: CallToolResult; readonly scaTriggered: boolean }> {
+  const firstResult = (await client.callTool({
+    name: toolName,
+    arguments: { ...baseArgs, wait: false },
+  })) as CallToolResult;
+  const firstText = firstTextFromMcpResult(firstResult);
+
+  if (/^SCA required/.test(firstText)) {
+    const tokenMatch = firstText.match(SCA_PENDING_TOKEN_RE);
+    if (tokenMatch === null || tokenMatch[1] === undefined) {
+      throw new Error(`No "Session token: ..." line in SCA-pending response:\n${firstText}`);
+    }
+    const token = tokenMatch[1];
+    expect(token).not.toBe("unknown");
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+
+    const approveResult = (await client.callTool({
+      name: "sca_session_mock_decision",
+      arguments: { token, decision: "allow" },
+    })) as CallToolResult;
+    if (approveResult.isError === true) {
+      throw new Error(`sca_session_mock_decision failed:\n${JSON.stringify(approveResult, null, 2)}`);
+    }
+
+    const retryResult = (await client.callTool({
+      name: toolName,
+      arguments: { ...baseArgs, sca_session_token: token },
+    })) as CallToolResult;
+    return { result: retryResult, scaTriggered: true };
+  }
+
+  return { result: firstResult, scaTriggered: false };
+}
 
 // ---------------------------------------------------------------------------
-// SCA write paths: ACCEPTED_GAP — all 3 endpoints blocked by sandbox state
+// SCA write paths: bank-account lifecycle (account_create → account_update → account_close)
 // ---------------------------------------------------------------------------
 //
-// Empirical sandbox probe (2026-05-12, sandbox org `0909-future-club-2702`,
-// OAuth token with `bank_account.write` scope granted):
+// Empirical sandbox probe (2026-05-13, sandbox org `0909-future-club-2702`,
+// OAuth token with `bank_account.write` scope granted; #563 retry):
 //
-//   - `account_create` → `POST /v2/bank_accounts`            400 bank_accounts_limit
-//       "You have reached the maximum number of bank accounts allowed for
-//        your plan" — plan cap hit; cannot create a fresh test account.
+//   - `account_create` → `POST /v2/bank_accounts`            200 (no SCA)
+//       Plan cap is 2 active accounts. The previous probe (#563 / 2026-05-12)
+//       failed because the cap was already saturated; closing one of the
+//       pre-existing accounts freed a slot, after which create round-trips
+//       cleanly without an SCA challenge.
 //
-//   - `account_update` → `PUT  /v2/bank_accounts/{id}`       404 not_found
-//       Both pre-existing accounts return 404 on update (main `Hauptkonto`
-//       AND non-main `asdfasdf`). Path may be wrong, OR Qonto may use a
-//       different endpoint/method (e.g., PATCH) for bank account updates.
+//   - `account_update` → `PATCH /v2/bank_accounts/{id}`      200 (no SCA)
+//       The PUT-vs-PATCH disambiguation was the load-bearing finding: Qonto
+//       returns 404 on `PUT /v2/bank_accounts/{id}` but accepts `PATCH`. Core
+//       `updateBankAccount` was changed PUT → PATCH in the same PR.
 //
-//   - `account_close`  → `POST /v2/bank_accounts/{id}/close` ACCEPTED_GAP (destructive)
-//       Closing either pre-existing account is destructive and irreversible.
-//       The plan-limit blocker on `create` makes recreation impossible —
-//       closing existing accounts would brick subsequent test runs.
+//   - `account_close` → `POST /v2/bank_accounts/{id}/close`  428 sca_required → 200
+//       SCA-gated. The MCP `wait: false` shape returns "SCA required" with
+//       a session token; the test mock-approves via `sca_session_mock_decision`
+//       and retries with `sca_session_token`. Cleanup is self-contained — the
+//       test closes the account it created so the plan cap stays at 1 active.
 //
-// Because all three lifecycle endpoints are blocked, the entire MCP SCA
-// write-paths describe block is ACCEPTED_GAP. The MCP wrap fix (the load-
-// bearing production change) was delivered in #553 (commit `62544cd`) and
-// is unit-test-covered in `packages/mcp/src/tools/accounts.test.ts`. MCP
-// wraps in `packages/mcp/src/tools/accounts.ts` are verified by
-// audit-refresh inspection — all three tools wrap with `executeWithMcpSca`,
-// structurally identical to the SCA-wrap permutation proven by #554
-// (transfers), #555 (requests), and #556 (cards).
-//
-// Re-enable procedure (when sandbox is unblocked):
-//
-//   1. Re-probe the sandbox via the `account_create` MCP tool (or the CLI
-//      equivalent — same routing). If `account_create` and `account_update`
-//      both succeed, proceed.
-//   2. Replace the `it.todo(...)` below with a lifecycle `it(...)` modeled on
-//      `packages/e2e/src/cards/mcp.e2e.test.ts` (using `callWithConditionalSca`
-//      helper for tolerance to with-SCA vs no-SCA outcomes).
-//   3. Update `packages/e2e/coverage.json` entries
-//      (mcp:account_create/update/close status `accepted_gap` → `covered`
-//      with the lifecycle test file path).
-//   4. Run `pnpm test:e2e` (full suite) locally before pushing.
+// The MCP wrap fix (the load-bearing production change) was delivered in
+// #553 (commit `62544cd`) and is unit-test-covered in
+// `packages/mcp/src/tools/accounts.test.ts`.
 //
 // Read-side coverage (`account_list`, `account_show`, `account_iban_certificate`)
 // lives in `packages/e2e/src/org-accounts/mcp.e2e.test.ts` — out of scope here.
@@ -55,11 +100,95 @@ import { hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sand
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("bank-account MCP tools (e2e, SCA write paths)", () => {
   pinAuthPreference("oauth-first");
 
-  // ACCEPTED_GAP: see top-of-file empirical-findings note for the 3
-  // sandbox blockers. The wrap shape is proven by #554/#555/#556; this
-  // marker placeholds the lifecycle test for when the sandbox is
-  // unblocked.
-  it.todo(
-    "bank-account lifecycle: account_create → account_update → account_close (pending sandbox unblock — see #563)",
-  );
+  let client: Client;
+  let transport: StdioClientTransport;
+
+  beforeAll(async () => {
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp"],
+      env: cliEnv({ authPreference: "oauth-first" }),
+      stderr: "pipe",
+    });
+    client = new Client({ name: "e2e-bank-account-sca", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it("bank-account lifecycle: account_create → account_update → account_close (conditional SCA-gating)", async () => {
+    const runId = randomUUID().slice(0, 8);
+    const initialName = `e2e-mcp-${runId}`;
+    const renamedName = `e2e-mcp-${runId}-renamed`;
+
+    // ---- Round-trip #1: account_create. Empirically no SCA in sandbox.
+    const createOutcome = await callWithConditionalSca(client, "account_create", {
+      name: initialName,
+    });
+    if (createOutcome.scaTriggered) {
+      console.log(`[account_create SCA probe] SCA triggered; round-trip exercised.`);
+    } else {
+      console.log(`[account_create SCA probe] NO SCA in OAuth+sandbox.`);
+    }
+    expect(createOutcome.result.isError).not.toBe(true);
+    const createText = firstTextFromMcpResult(createOutcome.result);
+    expect(createText).not.toMatch(/^SCA required/);
+    const created = JSON.parse(createText) as BankAccountItem;
+    BankAccountSchema.parse(created);
+    expect(created.id.length).toBeGreaterThan(0);
+    expect(created.name).toBe(initialName);
+    expect(created.status).toBe("active");
+    const testAccountId = created.id;
+
+    // ---- Round-trip #2: account_update (rename). PATCH semantics under the hood.
+    // Empirically no SCA in sandbox.
+    const updateOutcome = await callWithConditionalSca(client, "account_update", {
+      id: testAccountId,
+      name: renamedName,
+    });
+    if (updateOutcome.scaTriggered) {
+      console.log(`[account_update SCA probe] SCA triggered; round-trip exercised.`);
+    } else {
+      console.log(`[account_update SCA probe] NO SCA in OAuth+sandbox.`);
+    }
+    expect(updateOutcome.result.isError).not.toBe(true);
+    const updated = JSON.parse(firstTextFromMcpResult(updateOutcome.result)) as BankAccountItem;
+    expect(updated.id).toBe(testAccountId);
+    expect(updated.name).toBe(renamedName);
+    expect(updated.status).toBe("active");
+
+    // ---- Round-trip #3: account_close. SCA-gated; helper mock-approves and retries.
+    const closeOutcome = await callWithConditionalSca(client, "account_close", {
+      id: testAccountId,
+    });
+    if (closeOutcome.scaTriggered) {
+      console.log(`[account_close SCA probe] SCA triggered; round-trip exercised.`);
+    } else {
+      console.log(`[account_close SCA probe] NO SCA in OAuth+sandbox.`);
+    }
+    expect(closeOutcome.result.isError).not.toBe(true);
+    const closeBody = JSON.parse(firstTextFromMcpResult(closeOutcome.result)) as {
+      readonly closed: boolean;
+      readonly id: string;
+    };
+    expect(closeBody.closed).toBe(true);
+    expect(closeBody.id).toBe(testAccountId);
+
+    // Defensive post-close verification: the `account_close` tool's success
+    // formatter synthesizes `{closed: true, id}` from `formatSuccess` regardless
+    // of the actual API response body (`closeBankAccount` returns void). Without
+    // this follow-up `account_show`, a flake where the close attempt returned 2xx
+    // but the account was not actually closed would pass silently. Re-fetch and
+    // assert `status === "closed"` against the live API to catch that class of bug.
+    const showResult = (await client.callTool({
+      name: "account_show",
+      arguments: { id: testAccountId },
+    })) as CallToolResult;
+    expect(showResult.isError).not.toBe(true);
+    const refetched = JSON.parse(firstTextFromMcpResult(showResult)) as BankAccountItem;
+    expect(refetched.id).toBe(testAccountId);
+    expect(refetched.status).toBe("closed");
+  });
 });

--- a/packages/mcp/src/tools/accounts.test.ts
+++ b/packages/mcp/src/tools/accounts.test.ts
@@ -206,7 +206,7 @@ describe("account MCP tools", () => {
       expect(parsed.name).toBe("Updated Name");
     });
 
-    it("sends PUT with wrapped body to the correct endpoint", async () => {
+    it("sends PATCH with wrapped body to the correct endpoint", async () => {
       fetchSpy.mockReturnValue(
         jsonResponse({
           bank_account: makeBankAccount({ name: "Updated Name" }),
@@ -220,7 +220,7 @@ describe("account MCP tools", () => {
 
       const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
       expect(url.pathname).toBe("/v2/bank_accounts/acc-1");
-      expect(opts.method).toBe("PUT");
+      expect(opts.method).toBe("PATCH");
       const body = JSON.parse(opts.body as string) as { bank_account: { name: string } };
       expect(body.bank_account.name).toBe("Updated Name");
     });


### PR DESCRIPTION
## Summary

Closes #563.

Adds end-to-end coverage for the bank-account lifecycle and fixes a load-bearing PUT-vs-PATCH bug in the core service.

- **Core fix** — `updateBankAccount` now sends `PATCH /v2/bank_accounts/{id}` instead of `PUT`. Qonto's sandbox returns `404 not_found` for PUT on both pre-existing and freshly-created accounts; PATCH succeeds. Unit tests in `packages/core/.../bank-accounts.test.ts` and `packages/mcp/.../accounts.test.ts` updated to assert PATCH.
- **E2E lifecycle (CLI + MCP)** — full `create → update → close` round-trip with conditional SCA gating using the same helpers (`runWithConditionalSca`, `callWithConditionalSca`) introduced for cards (#570) and beneficiaries (#559). Self-contained cleanup keeps the plan cap at 1 active.
- **Defensive close verification** — both lifecycle tests now do a follow-up `account_show` after close and assert `status === "closed"` against the live API. `account_close`'s success formatter synthesizes `{closed: true, id}` regardless of the API response body; without this read a flake where close returned 2xx but didn't actually close would pass silently.
- **Coverage manifest** — three MCP entries (`account_close`, `account_create`, `account_update`) move from `accepted_gap` → `covered`.

## Empirical probe (2026-05-13, sandbox org `0909-future-club-2702`)

```text
account_create  POST /v2/bank_accounts                200 (no SCA)
account_update  PATCH /v2/bank_accounts/{id}          200 (no SCA)
account_close   POST /v2/bank_accounts/{id}/close     428 sca_required → 200
```

Plan cap is 2 active accounts. Previous probe (#553, #563 2026-05-12) failed because the cap was saturated; closing one of the pre-existing accounts freed a slot.

## Test plan

- [x] `pnpm test` — all unit tests pass (PATCH assertions in core + mcp)
- [x] `pnpm lint`
- [x] `pnpm license-check`
- [x] `pnpm format:check` (after `prettier --write` on cli.e2e.test.ts)
- [x] `pnpm coverage-drift-check` — 46 covered, 6 accepted gaps, 262 pending
- [x] **Bank-accounts E2E standalone**: both CLI + MCP lifecycle tests pass against live sandbox (post-close `account_show` confirms `closed`)
- [ ] Full `pnpm test:e2e` — pre-existing failures in unrelated suites (recurring-transfers `bank_account_inactive`, terminals `OAuth required`, bulk-transfers SCA flakes, oauth-flow refresh-token-consumption); not regressions introduced by this PR

## Notes

The OAuth-flow E2E test (`packages/e2e/src/auth/oauth-flow.e2e.test.ts`) runs alphabetically first and exercises refresh-token rotation per RFC 6749 §6, which invalidates the captured refresh token mid-run. All subsequent OAuth-dependent suites then see 401 on token-refresh attempts. This is the "we don't have long-lived refresh tokens" reality re-framed as local-only earlier this session. CI is api-key-only and doesn't exercise these suites — see [`docs/oauth-flow-e2e.md`](docs/oauth-flow-e2e.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)