### PR TITLE
(docs) v2.0.0 pre-release sweep — CHANGELOG, READMEs, version pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,32 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-The next release is a coordinated bump across all four packages — `@qontoctl/core`, `@qontoctl/cli`, `@qontoctl/mcp`, and `qontoctl` (umbrella). **`@qontoctl/mcp` introduces a BREAKING change in the SCA response shape** for the eight write tools (see § Changed); **`qontoctl` (umbrella) inherits MAJOR**. See [`docs/release-runbook.md`](docs/release-runbook.md) for the full semver decision framework and worked example.
+The next release is a coordinated bump across all four packages — `@qontoctl/core`, `@qontoctl/cli`, `@qontoctl/mcp`, and `qontoctl` (umbrella). This is a **MAJOR** release driven by multiple BREAKING changes (see § Changed): `@qontoctl/mcp` SCA-required response shape (8 write-tool families); `@qontoctl/core` + `@qontoctl/cli` env-overlay scope tightening; `@qontoctl/core` bulk-transfer + recurring-transfer request shapes; `@qontoctl/core` deterministic config path resolution (CWD auto-discovery removed); `@qontoctl/core` bank-account update HTTP method (PUT → PATCH). **`qontoctl` (umbrella) inherits MAJOR**. See [`docs/release-runbook.md`](docs/release-runbook.md) for the semver decision framework and [§ Migration from v1.x](#migration-from-v1x) below for upgrade guidance.
 
 ### Added
 
 - **`@qontoctl/cli`**: `sca-session show <token>` subcommand to inspect SCA session status (#431).
 - **`@qontoctl/cli`**: `sca-session mock-decision <token> <allow|deny>` subcommand for sandbox-only SCA decision injection (#431).
+- **`@qontoctl/cli`**: `--config <path>` global flag for explicit configuration file selection. Highest-precedence resolution source; warns on stderr if it disagrees with `QONTOCTL_CONFIG_FILE` or `--profile` (#480).
+- **`@qontoctl/cli`**: `--sca-auto-approve` global flag for sandbox-only single-process SCA. When set against the sandbox, the CLI auto-approves the SCA challenge inline instead of returning a session token for two-step continuation. Production never auto-approves (#577).
+- **`@qontoctl/cli`** + **`@qontoctl/mcp`**: `qontoctl diagnose` CLI command and `diagnose` MCP tool — whole-integration health check covering credential resolution, sandbox routing, token expiry, OAuth scope catalog, optional connectivity probe, with PII redaction in output (#578).
+- **`@qontoctl/cli`** + **`@qontoctl/mcp`**: Qonto Terminals (POS) API support — `terminal list` and `terminal show` (CLI), `terminal_list` / `terminal_show` (MCP). New command/tool family (#484).
+- **`@qontoctl/cli`** + **`@qontoctl/mcp`**: Qonto Products API support — `product list` / `product show` (CLI), `product_list` / `product_show` (MCP). New command/tool family (fc9ddba).
 - **`@qontoctl/mcp`**: `sca_session_show` MCP tool to inspect SCA session status (#432).
 - **`@qontoctl/mcp`**: `sca_session_mock_decision` MCP tool for sandbox-only SCA decision injection (gated to sandbox mode) (#432).
 - **`@qontoctl/mcp`**: `executeWithMcpSca` wrapper module enabling bounded SCA polling (`wait` knob) and two-step `sca_session_token` continuation across MCP write tools (#433).
+- **`@qontoctl/mcp`**: `QONTOCTL_CONFIG_FILE` honored at MCP server startup as the only mechanism for pointing at a non-default config file (MCP has no CLI flags) (#482).
 - **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: `scaMethod` / `X-Qonto-2fa-Preference` exposure through `createClient`, the hidden `--sca-method` CLI flag, and MCP server config. Auto-defaults to `mock` when a sandbox staging token is present and no method is otherwise set; production never auto-defaults. The MCP server resolves the method from env/config only — it is intentionally not exposed as a tool input (#447).
+- **`@qontoctl/core`** + **`@qontoctl/cli`**: extended OAuth scope catalog (cards, teams, webhooks, e-invoicing, payment links, insurance, international transfers, recurring transfers, SCA flows) and improved auth UX in `auth setup` / `auth login` flows (#478).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: explicit auth precedence control via the `auth.preference` config field (`api-key` / `api-key-first` / `oauth` / `oauth-first`), the `--auth <mode>` CLI flag, and the `QONTOCTL_AUTH` env var. Default is `oauth-first` (OAuth primary with api-key fallback when OAuth fails). MCP server resolves from env/config only — not exposed as a tool input. See [`docs/configuration.md`](docs/configuration.md) § Authentication precedence (#523).
 - **Docs**: PSD2 Article 5 SCA token request-binding verification recorded in `docs/security/sca-token-binding.md` (#438).
 - **Docs**: Release runbook (`docs/release-runbook.md`) covering semver decision framework, npm publish flow, and Homebrew tap update (#435).
+- **Docs**: Canonical configuration reference at [`docs/configuration.md`](docs/configuration.md) covering deterministic resolution chain, per-field env overlay, profile semantics, and migration guidance (#482).
 
 ### Changed
 
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`** **(BREAKING)**: deterministic configuration-file resolution. The pre-`v2.0.0` CWD walk-up auto-discovery is **removed**. The resolver now uses (highest precedence first): `--config <path>` (CLI only) → `QONTOCTL_CONFIG_FILE` env var (CLI **and** MCP) → `~/.qontoctl/{profile}.yaml` (when `--profile <name>` is passed) → `~/.qontoctl.yaml` (home default). **Migration**: callers relying on a `.qontoctl.yaml` in the current working directory must adopt one of: (a) the `direnv` shim (`.envrc.example` → `.envrc` in the repo) that exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`; (b) pass `--config ./.qontoctl.yaml` per invocation; (c) move credentials to `~/.qontoctl.yaml` or `~/.qontoctl/{profile}.yaml`. Atomic writes + advisory file locking added on the writer path so a half-written config file is never observable; restrictive `0600` permissions enforced on writes. See [`docs/configuration.md`](docs/configuration.md) (#479, #480, #482).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`** **(BREAKING)**: `updateBankAccount` now uses `PATCH` (was incorrectly using `PUT`). The Qonto API endpoint for partial bank-account updates is `PATCH /v2/bank_accounts/:id`; the previous `PUT` request worked only because the sandbox happened to accept it. **Direct HTTP consumers** of the wire shape (i.e., users not going through `@qontoctl/core`) must update their request method (#563).
 - **`@qontoctl/core`** + **`@qontoctl/cli`** **(BREAKING)**: env-overlay scope tightened so env vars carry **inputs the tool reads**, never **runtime-mutable state the tool writes back**. `QONTOCTL_REFRESH_TOKEN` (and the profile-prefixed `QONTOCTL_{PROFILE}_REFRESH_TOKEN`) is **no longer read** — refresh tokens are rotated on every refresh, and env-overlay would shadow rotation on subsequent reads, so persistence anywhere was effectively defeated by env. `QONTOCTL_ACCESS_TOKEN` is **kept with read-only / discard-after-use semantics**: the env-supplied bearer is honored for the current invocation only — `oauth-authorization-factory` does not trigger proactive refresh and does not persist refreshed tokens to disk when the access token came from env (mirrors `AWS_SESSION_TOKEN`; if the token has expired the API surfaces a `401`). `applyEnvOverlay`'s parameter and return contract are narrowed via a new `EnvOverlayConfig` type that excludes runtime-mutable OAuth fields (`refreshToken`, `accessTokenExpiresAt`, `scopes`) — re-introducing a runtime-mutable env var now requires a deliberate type widening, not a runtime regression. `ConfigResult` gains a new `oauthAccessTokenFromEnv: boolean` field used by `@qontoctl/cli`'s `createClient` and `@qontoctl/mcp`'s `getClient` to thread the read-only signal into `createOAuthAuthorization`'s new `readOnly?: boolean` option. **Migration**: callers relying on `QONTOCTL_REFRESH_TOKEN` (which never worked correctly anyway — refresh results were discarded by env shadowing) must move to file-based OAuth credentials (`.qontoctl.yaml` or `~/.qontoctl/{profile}.yaml`) or use API-key env vars (`QONTOCTL_ORGANIZATION_SLUG` + `QONTOCTL_SECRET_KEY`) for CI. Council Verdict #2 (security / SRE / technical / CLI-conventions lenses) confirmed unanimous alignment with industry precedent: zero major CLI (`gh`, `aws`, `gcloud`, `kubectl`, `op`, `npm`, `docker`, `heroku`, `vercel`) accepts a refresh token via env var (#495).
 - **`@qontoctl/core`**: loader hygiene — an empty or comment-only CWD `.qontoctl.yaml` (whose YAML parses to `null`) now falls back to `~/.qontoctl.yaml` instead of short-circuiting on the empty CWD file. Subordinate to the env-overlay change above; previously the asymmetry could mask credential resolution surprises (#495).
 - **`@qontoctl/mcp`** **(BREAKING)**: SCA-required (HTTP 428) responses across the eight MCP write-tool families (`transfer_*`, `intl_transfer_*`, `internal_transfer_*`, `bulk_transfer_*`, `recurring_transfer_*`, `card_*`, `beneficiary_*`, `request_*` — every operation that triggers SCA) no longer return the legacy dead-end text response. Tools now accept optional `wait` (number 0–120, or `false`) and `sca_session_token` input parameters and return a structured SCA-pending response on poll-timeout that references the new `sca_session_show` and `sca_session_mock_decision` tools. Callers parsing the previous text response must adapt to the new shape (#428).
@@ -28,6 +39,9 @@ The next release is a coordinated bump across all four packages — `@qontoctl/c
 
 ### Fixed
 
+- **`@qontoctl/core`**: SCA-retry now skips `vop_proof_token` auto-resolution. The original (pre-SCA) request's `vop_proof_token` is reused verbatim on retry per PSD2 RTS Art. 5 dynamic linking (the token is bound to the original payment intent — re-resolving on retry would break the binding). CLI/MCP wrappers capture the auto-resolved token in a closure before the SCA challenge so the dynamic-linking property holds (#437).
+- **`@qontoctl/cli`**: `cards` CLI pagination loop now terminates correctly when the Qonto API response omits `next_page` (previously the loop could spin if `next_page` was undefined rather than explicitly `null`) (#489).
+- **`@qontoctl/mcp`**: `transfer_cancel` and `recurring_transfer_cancel` now wrapped in `executeWithMcpSca` for consistency with the rest of the MCP write-tool family — both endpoints can trigger SCA when the cancellation requires it (#500).
 - **`@qontoctl/core`**: SCA-retry idempotency-key drift in `executeWithSca` — both the original 428 attempt and the SCA-approved retry now carry the same `X-Qonto-Idempotency-Key` header. Without this fix, retries without an explicit `--idempotency-key` could create duplicate operations (#429).
 - **`@qontoctl/core`**: `mockScaDecision` URL corrected and request body removed to match the Qonto sandbox API (#446).
 - **`@qontoctl/core`**: `build428Error` now throws a typed error on unknown 428 response shape, surfacing clearer diagnostics instead of silently falling through (#445).
@@ -45,10 +59,102 @@ The next release is a coordinated bump across all four packages — `@qontoctl/c
 - **`@qontoctl/core`**: `cancelRecurringTransfer` now uses `requestVoid` instead of `client.post` to handle the API's `204 No Content` response shape. Previously `cancel` would throw `Unexpected end of JSON input` on success because `client.post` unconditionally tries to parse the empty body as JSON (#486).
 - **`@qontoctl/core`**: `cancelTransfer` (single SEPA transfer) now uses `requestVoid` instead of `client.post` to handle the API's `204 No Content` response shape — same defect pattern as the `cancelRecurringTransfer` fix in #486. Previously `cancel` would throw `Unexpected end of JSON input` on success; the existing unit test masked this by mocking `jsonResponse({})` (a valid empty-object JSON body) instead of a true 204 No Content response (#499).
 - **`@qontoctl/core`**: `RecurringTransfer` schema now treats `note`, `status` as optional and `next_execution_date` as nullable. The Qonto sandbox is observed to omit `note`/`status` from `POST /v2/sepa/recurring_transfers` responses and to return `next_execution_date: null` after a successful cancel; the previous strict-string schema caused `Invalid API response` errors against valid live responses. The `RecurringTransfer` TypeScript type is updated accordingly (`note?: string`, `status?: string`, `next_execution_date: string | null`) (#486).
+- **`@qontoctl/core`**: align international transfer Zod schemas with actual sandbox API response shapes — relaxes previously over-strict fields that caused `Invalid API response` errors against valid live data. Additive (loosens parser); no caller break (#488).
+- **`@qontoctl/core`**: `ClientSchema` now accepts individual (non-company) clients where the `name` field is absent. Additive (loosens parser) (#496).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: align `insurance-contracts` Zod schemas and CLI/MCP surface with actual Qonto API responses. Additive (loosens parser) (#509).
+- **`@qontoctl/core`**: align `Membership`, `Beneficiary`, `CreditNote`, and `ClientInvoice` schemas with actual API response shapes — fields previously typed as required-string are now optional/nullable where the API may omit them. Additive (loosens parser) (#514).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: align webhook Zod schema and CLI/MCP surface with the actual Qonto API. Additive (loosens parser) (2005b22).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: align internal-transfer Zod schema and CLI/MCP surface with actual Qonto API. Additive (loosens parser) (8d40fa6).
+- **`@qontoctl/core`** + **`@qontoctl/cli`** + **`@qontoctl/mcp`**: align attachment upload Zod schema and CLI/MCP surface with the actual Qonto `POST /v2/attachments` response. Additive (loosens parser) (9af3cb3).
+- **`@qontoctl/core`**: align `client-invoice` list `status` enum with the Qonto canonical set. Strict-enum schemas now accept the full set of values the API may return (#544).
+- **`@qontoctl/mcp`**: wrap `intl_beneficiary_add` / `intl_beneficiary_update` / `intl_beneficiary_remove` in `executeWithMcpSca` so these write paths participate in the unified SCA-pending → continuation flow (#552).
+- **`@qontoctl/mcp`**: wrap `account_create` / `account_update` / `account_close` in `executeWithMcpSca` so bank-account write paths participate in the unified SCA-pending → continuation flow (#553).
+- **`@qontoctl/core`**: `client-invoice` schema now accepts `null` items (the Qonto API was observed to return `null` for some line-item slots) (#575).
+- **`@qontoctl/core`**: debug logging of HTTP request headers now happens AFTER per-request additions (SCA preference, staging-token, etc.) so the logged headers reflect what's actually sent (#576).
 
 ### Security
 
 - **`@qontoctl/core`**: SCA session token redacted from error messages and debug logs. `QontoScaRequiredError`, `ScaTimeoutError`, and `ScaDeniedError` no longer embed the token in their `.message` strings (token remains accessible via the dedicated `.scaSessionToken` field). The `sca_session_token` request-body field and `X-Qonto-Sca-Session-Token` header are added to `redactSensitiveFields` (#430).
+
+### Migration from v1.x
+
+This release introduces the following breaking changes. Each section below lists who is affected and the migration path.
+
+#### 1. Configuration-file resolution: CWD auto-discovery removed (#479)
+
+**Affected**: Users who relied on QontoCtl picking up `./.qontoctl.yaml` from the current working directory (or any parent directory).
+
+**What changed**: The resolver no longer walks up from CWD. The new precedence chain is (highest first):
+
+1. `--config <path>` (CLI only)
+2. `QONTOCTL_CONFIG_FILE` env var (CLI **and** MCP)
+3. `~/.qontoctl/{profile}.yaml` (when `--profile <name>` is passed)
+4. `~/.qontoctl.yaml` (home default)
+
+**Migration paths** (pick one):
+
+- **Direnv shim** (recommended for repo-local configs): copy `.envrc.example` → `.envrc` in your repo (gitignored), then `direnv allow`. This exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` automatically when you `cd` into the repo.
+- **Per-shell export**: `export QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` in your shell profile or before invoking `qontoctl`.
+- **Per-invocation flag**: `qontoctl --config ./.qontoctl.yaml ...` on every call.
+- **Move credentials**: copy `./.qontoctl.yaml` to `~/.qontoctl.yaml` (or a named profile at `~/.qontoctl/{profile}.yaml` and call with `--profile {name}`).
+
+The MCP server (`qontoctl mcp` or the standalone `@qontoctl/mcp` binary) has no CLI flags, so `QONTOCTL_CONFIG_FILE` is its only mechanism for pointing at a non-default file. Set the env var in your MCP client configuration (e.g. `mcpServers.qontoctl.env.QONTOCTL_CONFIG_FILE` in Claude Desktop's `claude_desktop_config.json`).
+
+See [`docs/configuration.md`](docs/configuration.md) for the full reference.
+
+#### 2. Bank-account update HTTP method: PUT → PATCH (#563)
+
+**Affected**: Direct HTTP consumers of `PUT /v2/bank_accounts/{id}`. Users going through `@qontoctl/core` / `@qontoctl/cli` / `@qontoctl/mcp` are migrated transparently.
+
+**What changed**: `updateBankAccount` (core service), `account update` (CLI), and `account_update` (MCP tool) now send `PATCH` instead of `PUT`. The Qonto API's canonical method for partial bank-account updates is `PATCH`; the previous `PUT` worked only because the sandbox happened to accept it.
+
+**Migration**: direct API consumers must change their request method from `PUT` to `PATCH`. No request-body or response-shape changes.
+
+#### 3. OAuth env-overlay scope: `QONTOCTL_REFRESH_TOKEN` no longer read (#495)
+
+**Affected**: CI / scripted setups relying on the `QONTOCTL_REFRESH_TOKEN` env var. The profile-prefixed `QONTOCTL_{PROFILE}_REFRESH_TOKEN` is also no longer read.
+
+**What changed**: Refresh tokens rotate on every refresh. The env-overlay would have shadowed the rotation on subsequent reads, defeating persistence — so the env var was effectively broken before; it now fails closed rather than silently misbehaving. `QONTOCTL_ACCESS_TOKEN` is **kept** with read-only / discard-after-use semantics (mirrors `AWS_SESSION_TOKEN`).
+
+**Migration paths**:
+
+- Use file-based OAuth credentials at `~/.qontoctl.yaml` or `~/.qontoctl/{profile}.yaml`.
+- For CI scenarios where file persistence isn't viable, use API-key env vars (`QONTOCTL_ORGANIZATION_SLUG` + `QONTOCTL_SECRET_KEY`) — note that api-key auth doesn't cover all endpoints (cards, teams, webhooks, e-invoicing, etc., are OAuth-only per the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction)).
+- For one-shot scripted invocations against an already-valid bearer, use `QONTOCTL_ACCESS_TOKEN`.
+
+#### 4. MCP SCA-required (HTTP 428) response shape (#428)
+
+**Affected**: MCP clients (Claude Desktop, Cursor, etc.) that parse the previous text-only response from the eight MCP write-tool families: `transfer_*`, `intl_transfer_*`, `internal_transfer_*`, `bulk_transfer_*`, `recurring_transfer_*`, `card_*`, `beneficiary_*`, `request_*`.
+
+**What changed**: When the Qonto API returns HTTP 428 (SCA required), the MCP tools now return a structured **SCA-pending response** referencing `sca_session_show` and `sca_session_mock_decision` (sandbox), plus accept optional `wait` (number 0–120, or `false`) and `sca_session_token` input parameters for bounded polling and two-step continuation.
+
+**Migration**: MCP-tool callers that parsed the previous dead-end text response must adapt to the new shape. The new flow is:
+
+1. First call → returns either the success body OR an SCA-pending response with `sca_session_token`.
+2. (Optional) Inspect via `sca_session_show <token>`.
+3. (Sandbox) Approve via `sca_session_mock_decision <token> allow`. (Production) The user completes SCA on their paired device.
+4. Re-call the original tool with `sca_session_token` set to the token from step 1 to retrieve the completed result.
+
+See [`docs/security/sca-token-binding.md`](docs/security/sca-token-binding.md) for the PSD2 Article 5 dynamic-linking properties this flow preserves.
+
+#### 5. Bulk-transfer request shape: flat, with required per-item `client_transfer_id` (#487)
+
+**Affected**: Direct callers of `@qontoctl/core` `createBulkTransfer`; CLI/MCP users supplying JSON input files for `bulk-transfer create`.
+
+**What changed**: Request body is now `{ bank_account_id, bulk_transfers, vop_proof_token }` (flat, no `bulk_transfer:` envelope). Per-item changes: `client_transfer_id` (UUID) is now **required** (auto-generated by CLI/MCP when omitted); `amount` is a decimal string; `reference` required; the previous `currency` per-item field is removed (currency is dictated by the source bank account).
+
+**Migration**: regenerate the request body per the new shape. CLI gains required `--debit-account <id>` and optional `--vop-proof-token <token>` (auto-resolved via `bulk_verify_payee` when omitted). MCP `bulk_transfer_create` schema gains `bank_account_id` and `vop_proof_token` (auto-resolved when omitted, except on SCA retry per PSD2 dynamic linking).
+
+#### 6. Recurring-transfer request shape: `amount` as string, `vop_proof_token` required (#486)
+
+**Affected**: Direct callers of `@qontoctl/core` `createRecurringTransfer`. CLI/MCP users are migrated transparently.
+
+**What changed**:
+
+- `CreateRecurringTransferParams.amount` is now `string` (was `number`). The Qonto API rejects numeric amounts with `not_a_string: amount must be a string`.
+- `CreateRecurringTransferParams.vop_proof_token` is now a required `string` field at the top level of the request body (alongside the `recurring_transfer` envelope). The Qonto API rejects requests missing the token with `401 vop_proof_token_missing`.
+
+**Migration**: convert `amount` with `String(amount)` or `amount.toFixed(2)`; supply `vop_proof_token` from `verifyPayee` against the beneficiary's IBAN/name. CLI/MCP wrappers auto-resolve when omitted, except on SCA retry where PSD2 RTS Art. 5 dynamic linking requires the caller to supply the original token.
 
 ## [1.0.0] — 2026-03-26
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,23 +16,31 @@ You should receive a response within 48 hours. Please include:
 
 ### API Credential Handling
 
-QontoCtl manages Qonto API credentials (API keys) on behalf of the user.
+QontoCtl manages Qonto API credentials (API keys + OAuth tokens) on behalf of the user.
 Credentials are stored in YAML configuration files on the local filesystem.
 
-**Credential storage locations:**
+**Credential storage locations (resolution precedence, highest first):**
 
-| Location                     | Purpose                     |
-| ---------------------------- | --------------------------- |
-| `~/.qontoctl.yaml`           | Default profile credentials |
-| `~/.qontoctl/<profile>.yaml` | Named profile credentials   |
-| `.qontoctl.yaml` (CWD)       | Project-scoped credentials  |
+| Source                                            | Purpose                                                                           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `--config <path>` (CLI flag)                      | Explicit per-invocation override                                                  |
+| `QONTOCTL_CONFIG_FILE` (env var, CLI **and** MCP) | Explicit override (the only mechanism for the MCP server, which has no CLI flags) |
+| `~/.qontoctl/<profile>.yaml`                      | Named profile credentials (when `--profile <name>` is passed)                     |
+| `~/.qontoctl.yaml`                                | Default profile credentials                                                       |
+
+**Note**: prior to v2.0.0, `.qontoctl.yaml` in the current working directory was auto-discovered. This walk-up behavior was removed in v2.0.0 (#479) — for repo-local configs, use the `direnv` shim (`.envrc.example` → `.envrc`) that exports `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"`, or pass `--config ./.qontoctl.yaml`. See [CHANGELOG § Migration from v1.x](CHANGELOG.md#migration-from-v1x).
+
+**On-disk file permissions**: when QontoCtl writes a config file (e.g. after OAuth login or token refresh), it is created with restrictive `0600` permissions (owner read/write only), atomically (via temp-file + rename), and under advisory file lock to prevent concurrent-write races.
+
+**OAuth env-overlay scope**: `QONTOCTL_REFRESH_TOKEN` is **not read** from the environment (refresh tokens rotate; env-overlay would shadow rotation). `QONTOCTL_ACCESS_TOKEN` is honored as a one-shot bearer with read-only / discard-after-use semantics (no proactive refresh, no disk persist).
 
 **Threat model assumptions:**
 
-| Assumption                   | Rationale                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------- |
-| The local machine is trusted | Credentials are stored as plaintext YAML files readable by the local user |
-| The Qonto API is trusted     | All API calls are made over HTTPS to `thirdparty.qonto.com`               |
+| Assumption                                | Rationale                                                                                                                                                             |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The local machine is trusted              | Credentials are stored as plaintext YAML files readable by the local user (0600)                                                                                      |
+| The Qonto API is trusted                  | All API calls are made over HTTPS to `thirdparty.qonto.com` (production) or `thirdparty-sandbox.staging.qonto.co` (sandbox, gated by the `oauth.staging-token` field) |
+| The OAuth authorization server is trusted | Token exchange/refresh/revocation use HTTPS to the configured OAuth endpoints                                                                                         |
 
 ### MCP Trust Model
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -90,10 +90,12 @@ Move the date to the same line as the heading; preserve the `### Added` / `### C
 
 Verify each entry references a merged PR or issue. Confirm the per-package grouping convention (`**\`@qontoctl/<pkg>\`\*\*: ...`) is applied consistently.
 
+Also bump `server.json` (`version` AND `packages[0].version`) to the same release version — the MCP Registry uses an explicit per-submission version (see § 4.5 below). `smithery.yaml` is unpinned (resolves `npx -y qontoctl` to `latest`) and does NOT need editing.
+
 Commit on `main`:
 
 ```sh
-git add CHANGELOG.md
+git add CHANGELOG.md server.json
 git commit -m "(docs) promote [Unreleased] to [2.0.0]"
 git push origin main
 ```
@@ -142,6 +144,20 @@ gh run watch <run-id> --repo alexey-pelykh/qontoctl
 ```
 
 If the run fails before publish, investigate, push a fix to `main`, delete the failed release+tag, and re-cut. If it fails mid-publish (some packages published, others not), **do not unpublish** (npm forbids re-publishing the same version after unpublish). Cut a patch release with the missing packages instead — see § Rollback.
+
+### 4.5. Update MCP Registry & Smithery (manual)
+
+QontoCtl's MCP server is listed in two additional distribution channels beyond npm + Homebrew. Their pre-release coordination differs:
+
+**Smithery** (`smithery.yaml`): Uses `npx -y qontoctl mcp` (no version pin). After npm publish completes, the Smithery channel automatically resolves to `latest` on the next user installation — no per-release action needed.
+
+**MCP Registry** (`server.json`): The MCP Registry uses an explicit `version` per submission. Before tagging:
+
+1. Confirm `server.json` `version` and `packages[0].version` both reflect the version being released (these are stamped manually as part of the CHANGELOG-promotion commit in § 2 above — verify they match the tag about to be cut).
+2. After npm publish completes, re-submit `server.json` to the MCP Registry using the credentials stored at `.mcpregistry_github_token` and `.mcpregistry_registry_token` (gitignored). The submission API/CLI is the official MCP Registry's. If this is the first time submitting after a registry-token rotation, refresh the token first.
+3. Verify by querying the MCP Registry for `io.github.alexey-pelykh/qontoctl` and confirming the live `version` matches.
+
+If the MCP Registry submission step is forgotten, the registry will keep advertising the previous version even though npm has the new one. There is no automation for this today — consider folding the `server.json` stamp + re-submit into `.github/workflows/release.yml` as a follow-up enhancement.
 
 ### 5. Update Homebrew tap (manual trigger)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,89 +16,117 @@ npm install @qontoctl/cli
 
 ## Commands
 
-| Command                                       | Description                               |
-| --------------------------------------------- | ----------------------------------------- |
-| `org show`                                    | Show organization details                 |
-| `account list`                                | List bank accounts                        |
-| `account show <id>`                           | Show bank account details                 |
-| `account iban-certificate <id>`               | Download IBAN certificate PDF             |
-| `account create`                              | Create a new bank account                 |
-| `account update <id>`                         | Update a bank account                     |
-| `account close <id>`                          | Close a bank account                      |
-| `transaction list`                            | List transactions with filters            |
-| `transaction show <id>`                       | Show transaction details                  |
-| `transaction attachment list <id>`            | List attachments for a transaction        |
-| `transaction attachment add <id> <file>`      | Attach a file to a transaction            |
-| `transaction attachment remove <id> [att-id]` | Remove attachment(s) from a transaction   |
-| `statement list`                              | List bank statements                      |
-| `statement show <id>`                         | Show statement details                    |
-| `statement download <id>`                     | Download statement PDF                    |
-| `label list`                                  | List all labels                           |
-| `label show <id>`                             | Show label details                        |
-| `membership list`                             | List organization memberships             |
-| `membership show`                             | Show current user's membership            |
-| `membership invite`                           | Invite a new member                       |
-| `beneficiary list`                            | List SEPA beneficiaries                   |
-| `beneficiary show <id>`                       | Show beneficiary details                  |
-| `beneficiary add`                             | Create a new beneficiary                  |
-| `beneficiary update <id>`                     | Update a beneficiary                      |
-| `beneficiary trust <id...>`                   | Trust one or more beneficiaries           |
-| `beneficiary untrust <id...>`                 | Untrust one or more beneficiaries         |
-| `transfer list`                               | List SEPA transfers                       |
-| `transfer show <id>`                          | Show SEPA transfer details                |
-| `transfer create`                             | Create a SEPA transfer                    |
-| `transfer cancel <id>`                        | Cancel a pending SEPA transfer            |
-| `transfer proof <id>`                         | Download SEPA transfer proof PDF          |
-| `transfer verify-payee`                       | Verify a payee (VoP)                      |
-| `transfer bulk-verify-payee`                  | Bulk verify payees from CSV               |
-| `internal-transfer create`                    | Create an internal transfer               |
-| `bulk-transfer list`                          | List bulk transfers                       |
-| `bulk-transfer show <id>`                     | Show bulk transfer details                |
-| `recurring-transfer list`                     | List recurring transfers                  |
-| `recurring-transfer show <id>`                | Show recurring transfer details           |
-| `client list`                                 | List clients                              |
-| `client show <id>`                            | Show client details                       |
-| `client create`                               | Create a new client                       |
-| `client update <id>`                          | Update a client                           |
-| `client delete <id>`                          | Delete a client                           |
-| `client-invoice list`                         | List client invoices                      |
-| `client-invoice show <id>`                    | Show client invoice details               |
-| `client-invoice create`                       | Create a draft client invoice             |
-| `client-invoice update <id>`                  | Update a draft client invoice             |
-| `client-invoice delete <id>`                  | Delete a draft client invoice             |
-| `client-invoice finalize <id>`                | Finalize client invoice and assign number |
-| `client-invoice send <id>`                    | Send client invoice to client via email   |
-| `client-invoice mark-paid <id>`               | Mark client invoice as paid               |
-| `client-invoice unmark-paid <id>`             | Unmark client invoice paid status         |
-| `client-invoice cancel <id>`                  | Cancel a finalized client invoice         |
-| `client-invoice upload <id> <file>`           | Upload a file to a client invoice         |
-| `client-invoice upload-show <id> <upload-id>` | Show upload details for a client invoice  |
-| `quote list`                                  | List quotes                               |
-| `quote show <id>`                             | Show quote details                        |
-| `quote create`                                | Create a new quote                        |
-| `quote update <id>`                           | Update a quote                            |
-| `quote delete <id>`                           | Delete a quote                            |
-| `quote send <id>`                             | Send quote to client via email            |
-| `credit-note list`                            | List credit notes                         |
-| `credit-note show <id>`                       | Show credit note details                  |
-| `supplier-invoice list`                       | List supplier invoices                    |
-| `supplier-invoice show <id>`                  | Show supplier invoice details             |
-| `supplier-invoice bulk-create`                | Create supplier invoices from files       |
-| `einvoicing settings`                         | Show e-invoicing settings                 |
-| `request list`                                | List all requests                         |
-| `attachment upload <file>`                    | Upload an attachment file                 |
-| `attachment show <id>`                        | Show attachment details                   |
-| `auth setup`                                  | Configure OAuth client credentials        |
-| `auth login`                                  | Start OAuth login flow                    |
-| `auth status`                                 | Display OAuth token status                |
-| `auth refresh`                                | Refresh the OAuth access token            |
-| `auth revoke`                                 | Revoke OAuth consent and clear tokens     |
-| `profile add <name>`                          | Create a named profile                    |
-| `profile list`                                | List all profiles                         |
-| `profile show <name>`                         | Show profile details (secrets redacted)   |
-| `profile remove <name>`                       | Remove a named profile                    |
-| `profile test`                                | Test credentials                          |
-| `completion`                                  | Generate shell completion scripts         |
+| Command                                                                                                           | Description                                                  |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `org show`                                                                                                        | Show organization details                                    |
+| `account list`                                                                                                    | List bank accounts                                           |
+| `account show <id>`                                                                                               | Show bank account details                                    |
+| `account iban-certificate <id>`                                                                                   | Download IBAN certificate PDF                                |
+| `account create`                                                                                                  | Create a new bank account                                    |
+| `account update <id>`                                                                                             | Update a bank account                                        |
+| `account close <id>`                                                                                              | Close a bank account                                         |
+| `transaction list`                                                                                                | List transactions with filters                               |
+| `transaction show <id>`                                                                                           | Show transaction details                                     |
+| `transaction attachment list <id>`                                                                                | List attachments for a transaction                           |
+| `transaction attachment add <id> <file>`                                                                          | Attach a file to a transaction                               |
+| `transaction attachment remove <id> [att-id]`                                                                     | Remove attachment(s) from a transaction                      |
+| `statement list`                                                                                                  | List bank statements                                         |
+| `statement show <id>`                                                                                             | Show statement details                                       |
+| `statement download <id>`                                                                                         | Download statement PDF                                       |
+| `label list`                                                                                                      | List all labels                                              |
+| `label show <id>`                                                                                                 | Show label details                                           |
+| `membership list`                                                                                                 | List organization memberships                                |
+| `membership show`                                                                                                 | Show current user's membership                               |
+| `membership invite`                                                                                               | Invite a new member                                          |
+| `beneficiary list`                                                                                                | List SEPA beneficiaries                                      |
+| `beneficiary show <id>`                                                                                           | Show beneficiary details                                     |
+| `beneficiary add`                                                                                                 | Create a new beneficiary                                     |
+| `beneficiary update <id>`                                                                                         | Update a beneficiary                                         |
+| `beneficiary trust <id...>`                                                                                       | Trust one or more beneficiaries                              |
+| `beneficiary untrust <id...>`                                                                                     | Untrust one or more beneficiaries                            |
+| `transfer list`                                                                                                   | List SEPA transfers                                          |
+| `transfer show <id>`                                                                                              | Show SEPA transfer details                                   |
+| `transfer create`                                                                                                 | Create a SEPA transfer                                       |
+| `transfer cancel <id>`                                                                                            | Cancel a pending SEPA transfer                               |
+| `transfer proof <id>`                                                                                             | Download SEPA transfer proof PDF                             |
+| `transfer verify-payee`                                                                                           | Verify a payee (VoP)                                         |
+| `transfer bulk-verify-payee`                                                                                      | Bulk verify payees from CSV                                  |
+| `internal-transfer create`                                                                                        | Create an internal transfer                                  |
+| `bulk-transfer list`                                                                                              | List bulk transfers                                          |
+| `bulk-transfer show <id>`                                                                                         | Show bulk transfer details                                   |
+| `recurring-transfer list`                                                                                         | List recurring transfers                                     |
+| `recurring-transfer show <id>`                                                                                    | Show recurring transfer details                              |
+| `recurring-transfer create`                                                                                       | Create a recurring transfer (SCA-gated)                      |
+| `recurring-transfer cancel <id>`                                                                                  | Cancel a recurring transfer (SCA-gated)                      |
+| `bulk-transfer create`                                                                                            | Create a bulk transfer (SCA-gated)                           |
+| `card list`                                                                                                       | List cards (OAuth-only)                                      |
+| `card show <id>`                                                                                                  | Show card details (OAuth-only)                               |
+| `card create`                                                                                                     | Create a new card (SCA-gated, OAuth-only)                    |
+| `card update-{nickname,limits,options,restrictions}`                                                              | Update card properties (SCA-gated)                           |
+| `card lock <id>` / `card unlock <id>`                                                                             | Lock or unlock a card (SCA-gated)                            |
+| `card iframe-url <id>`                                                                                            | Get a secure iframe URL for card details                     |
+| `card report <id>`                                                                                                | Report a card lost/stolen                                    |
+| `card discard <id>`                                                                                               | Discard a card                                               |
+| `card appearances`                                                                                                | List available card appearances                              |
+| `terminal list` / `terminal show <id>`                                                                            | Qonto Terminals (POS) listing                                |
+| `product list` / `product show <id>`                                                                              | Qonto Products (catalogue) listing                           |
+| `team list` / `team create` / `team show`                                                                         | Team management (OAuth-only)                                 |
+| `webhook list` / `show` / `create` / `update` / `delete`                                                          | Webhook subscription management (OAuth-only)                 |
+| `payment-link list` / `show` / `create` / `deactivate` / `connect` / `connection-status` / `methods` / `payments` | Payment link management (OAuth-only)                         |
+| `insurance show` / `create` / `update` / `upload-document` / `remove-document`                                    | Insurance contract management (OAuth-only)                   |
+| `intl-transfer create`                                                                                            | International (SWIFT) transfer (SCA-gated, OAuth-only)       |
+| `intl-transfer requirements`                                                                                      | International transfer requirements                          |
+| `intl-beneficiary list` / `show` / `add` / `update` / `remove`                                                    | International beneficiary management (SCA-gated, OAuth-only) |
+| `intl-beneficiary requirements`                                                                                   | International beneficiary requirements                       |
+| `intl-quote create`                                                                                               | International transfer quote                                 |
+| `intl-currencies`                                                                                                 | List supported international currencies                      |
+| `intl-eligibility`                                                                                                | Check international transfer eligibility                     |
+| `request approve` / `decline` / `create-flash-card` / `create-virtual-card` / `create-multi-transfer`             | Request management (OAuth-only)                              |
+| `sca-session show <token>`                                                                                        | Inspect SCA session status                                   |
+| `sca-session mock-decision <token> <allow\|deny>`                                                                 | Inject SCA decision (sandbox only)                           |
+| `client list`                                                                                                     | List clients                                                 |
+| `client show <id>`                                                                                                | Show client details                                          |
+| `client create`                                                                                                   | Create a new client                                          |
+| `client update <id>`                                                                                              | Update a client                                              |
+| `client delete <id>`                                                                                              | Delete a client                                              |
+| `client-invoice list`                                                                                             | List client invoices                                         |
+| `client-invoice show <id>`                                                                                        | Show client invoice details                                  |
+| `client-invoice create`                                                                                           | Create a draft client invoice                                |
+| `client-invoice update <id>`                                                                                      | Update a draft client invoice                                |
+| `client-invoice delete <id>`                                                                                      | Delete a draft client invoice                                |
+| `client-invoice finalize <id>`                                                                                    | Finalize client invoice and assign number                    |
+| `client-invoice send <id>`                                                                                        | Send client invoice to client via email                      |
+| `client-invoice mark-paid <id>`                                                                                   | Mark client invoice as paid                                  |
+| `client-invoice unmark-paid <id>`                                                                                 | Unmark client invoice paid status                            |
+| `client-invoice cancel <id>`                                                                                      | Cancel a finalized client invoice                            |
+| `client-invoice upload <id> <file>`                                                                               | Upload a file to a client invoice                            |
+| `client-invoice upload-show <id> <upload-id>`                                                                     | Show upload details for a client invoice                     |
+| `quote list`                                                                                                      | List quotes                                                  |
+| `quote show <id>`                                                                                                 | Show quote details                                           |
+| `quote create`                                                                                                    | Create a new quote                                           |
+| `quote update <id>`                                                                                               | Update a quote                                               |
+| `quote delete <id>`                                                                                               | Delete a quote                                               |
+| `quote send <id>`                                                                                                 | Send quote to client via email                               |
+| `credit-note list`                                                                                                | List credit notes                                            |
+| `credit-note show <id>`                                                                                           | Show credit note details                                     |
+| `supplier-invoice list`                                                                                           | List supplier invoices                                       |
+| `supplier-invoice show <id>`                                                                                      | Show supplier invoice details                                |
+| `supplier-invoice bulk-create`                                                                                    | Create supplier invoices from files                          |
+| `einvoicing settings`                                                                                             | Show e-invoicing settings                                    |
+| `request list`                                                                                                    | List all requests                                            |
+| `attachment upload <file>`                                                                                        | Upload an attachment file                                    |
+| `attachment show <id>`                                                                                            | Show attachment details                                      |
+| `auth setup`                                                                                                      | Configure OAuth client credentials                           |
+| `auth login`                                                                                                      | Start OAuth login flow                                       |
+| `auth status`                                                                                                     | Display OAuth token status                                   |
+| `auth refresh`                                                                                                    | Refresh the OAuth access token                               |
+| `auth revoke`                                                                                                     | Revoke OAuth consent and clear tokens                        |
+| `profile add <name>`                                                                                              | Create a named profile                                       |
+| `profile list`                                                                                                    | List all profiles                                            |
+| `profile show <name>`                                                                                             | Show profile details (secrets redacted)                      |
+| `profile remove <name>`                                                                                           | Remove a named profile                                       |
+| `profile test`                                                                                                    | Test credentials                                             |
+| `completion`                                                                                                      | Generate shell completion scripts                            |
 
 ### Global Options
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -59,8 +59,9 @@ const org = await getOrganization(client);
 
 - **`HttpClient`** — HTTP client for the Qonto API with rate-limit handling
 - **`QontoApiError`** — typed error for Qonto API error responses
-- **`QontoRateLimitError`** — error for rate-limit (429) responses
-- **`QontoScaRequiredError`** — error for SCA-required (403) responses
+- **`QontoRateLimitError`** — error for rate-limit (HTTP 429) responses
+- **`QontoScaRequiredError`** — error for SCA-required (HTTP 428) responses
+- **`QontoScaNotEnrolledError`** — error for HTTP 428 with `code: "sca_not_enrolled"` (distinct from `sca_required`)
 
 ### SCA (Strong Customer Authentication)
 
@@ -154,16 +155,18 @@ Other: `Quote`, `QuoteAddress`, `QuoteAmount`, `QuoteClient`, `QuoteDiscount`, `
 
 ## Configuration Resolution
 
-QontoCtl resolves credentials in this order:
+`resolveConfig` resolves the configuration **file** in this order (highest precedence first):
 
-1. `QONTOCTL_*` environment variables (highest priority)
-2. `.qontoctl.yaml` in the current directory
-3. `~/.qontoctl.yaml` (home default)
+1. `options.configFile` (programmatic — equivalent to the CLI `--config <path>` flag)
+2. `QONTOCTL_CONFIG_FILE` environment variable
+3. `~/.qontoctl/{profile}.yaml` (when `options.profile` is set)
+4. `~/.qontoctl.yaml` (home default)
 
-With `--profile <name>`:
+There is **no** current-working-directory walk-up (removed in v2.0.0 — see [CHANGELOG migration note](https://github.com/alexey-pelykh/qontoctl/blob/main/CHANGELOG.md#1-configuration-file-resolution-cwd-auto-discovery-removed-479)). For repo-local configs, set `QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml"` (e.g. via `direnv`).
 
-1. `QONTOCTL_<NAME>_*` environment variables
-2. `~/.qontoctl/<name>.yaml`
+After the file is loaded, `QONTOCTL_*` environment variables overlay individual fields (or `QONTOCTL_{PROFILE}_*` with profile prefix). `QONTOCTL_REFRESH_TOKEN` is no longer read (refresh tokens rotate, so env-overlay can't persist correctly); `QONTOCTL_ACCESS_TOKEN` is honored as a one-shot bearer with read-only / discard-after-use semantics (no proactive refresh, no disk persist).
+
+Auth-method precedence between the two configured methods is controlled by `config.auth.preference` — one of `api-key`, `api-key-first`, `oauth`, `oauth-first` (default).
 
 ## Requirements
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -31,96 +31,163 @@ Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 ## Available Tools
 
-| Tool                            | Description                                                       |
-| ------------------------------- | ----------------------------------------------------------------- |
-| **Organization**                |                                                                   |
-| `org_show`                      | Show organization details including name, slug, and bank accounts |
-| **Accounts**                    |                                                                   |
-| `account_list`                  | List all bank accounts for the organization                       |
-| `account_show`                  | Show details of a specific bank account                           |
-| `account_iban_certificate`      | Download IBAN certificate PDF for a bank account                  |
-| `account_create`                | Create a new bank account                                         |
-| `account_update`                | Update an existing bank account                                   |
-| `account_close`                 | Close a bank account                                              |
-| **Transactions**                |                                                                   |
-| `transaction_list`              | List transactions for a bank account with optional filters        |
-| `transaction_show`              | Show details of a specific transaction                            |
-| `transaction_attachment_list`   | List attachments for a transaction                                |
-| `transaction_attachment_add`    | Attach a file to a transaction                                    |
-| `transaction_attachment_remove` | Remove attachment(s) from a transaction                           |
-| **Statements**                  |                                                                   |
-| `statement_list`                | List bank statements with optional filters                        |
-| `statement_show`                | Show details of a specific bank statement                         |
-| **Labels**                      |                                                                   |
-| `label_list`                    | List all labels in the organization                               |
-| `label_show`                    | Show details of a specific label                                  |
-| **Memberships**                 |                                                                   |
-| `membership_list`               | List all memberships in the organization                          |
-| `membership_show`               | Show the current authenticated user's membership                  |
-| `membership_invite`             | Invite a new member to the organization                           |
-| **SEPA Beneficiaries**          |                                                                   |
-| `beneficiary_list`              | List SEPA beneficiaries in the organization                       |
-| `beneficiary_show`              | Show details of a specific SEPA beneficiary                       |
-| `beneficiary_add`               | Create a new SEPA beneficiary                                     |
-| `beneficiary_update`            | Update an existing SEPA beneficiary                               |
-| `beneficiary_trust`             | Trust one or more SEPA beneficiaries                              |
-| `beneficiary_untrust`           | Untrust one or more SEPA beneficiaries                            |
-| **SEPA Transfers**              |                                                                   |
-| `transfer_list`                 | List SEPA transfers with optional filters                         |
-| `transfer_show`                 | Show details of a specific SEPA transfer                          |
-| `transfer_create`               | Create a SEPA transfer                                            |
-| `transfer_cancel`               | Cancel a pending SEPA transfer                                    |
-| `transfer_proof`                | Download SEPA transfer proof PDF                                  |
-| `transfer_verify_payee`         | Verify a payee (Verification of Payee / VoP)                      |
-| `transfer_bulk_verify_payee`    | Bulk verify payees (VoP)                                          |
-| **Internal Transfers**          |                                                                   |
-| `internal_transfer_create`      | Create an internal transfer between two bank accounts             |
-| **Bulk Transfers**              |                                                                   |
-| `bulk_transfer_list`            | List bulk transfers                                               |
-| `bulk_transfer_show`            | Show details of a specific bulk transfer                          |
-| **Recurring Transfers**         |                                                                   |
-| `recurring_transfer_list`       | List recurring transfers                                          |
-| `recurring_transfer_show`       | Show details of a specific recurring transfer                     |
-| **Clients**                     |                                                                   |
-| `client_list`                   | List clients with optional pagination                             |
-| `client_show`                   | Show details of a specific client                                 |
-| `client_create`                 | Create a new client                                               |
-| `client_update`                 | Update an existing client                                         |
-| `client_delete`                 | Delete a client                                                   |
-| **Client Invoices**             |                                                                   |
-| `client_invoice_list`           | List client invoices with optional filters                        |
-| `client_invoice_show`           | Show details of a specific client invoice                         |
-| `client_invoice_create`         | Create a draft client invoice with client and line items          |
-| `client_invoice_update`         | Update a draft client invoice                                     |
-| `client_invoice_delete`         | Delete a draft client invoice                                     |
-| `client_invoice_finalize`       | Finalize a client invoice (assign number)                         |
-| `client_invoice_send`           | Send a client invoice to the client via email                     |
-| `client_invoice_mark_paid`      | Mark a client invoice as paid                                     |
-| `client_invoice_unmark_paid`    | Unmark a client invoice paid status                               |
-| `client_invoice_cancel`         | Cancel a finalized client invoice                                 |
-| `client_invoice_upload`         | Upload a file to a client invoice                                 |
-| `client_invoice_upload_show`    | Show upload details for a client invoice                          |
-| **Quotes**                      |                                                                   |
-| `quote_list`                    | List quotes with optional filters                                 |
-| `quote_show`                    | Show details of a specific quote                                  |
-| `quote_create`                  | Create a new quote with client and line items                     |
-| `quote_update`                  | Update an existing quote                                          |
-| `quote_delete`                  | Delete a quote                                                    |
-| `quote_send`                    | Send a quote to the client via email                              |
-| **Credit Notes**                |                                                                   |
-| `credit_note_list`              | List credit notes in the organization                             |
-| `credit_note_show`              | Show details of a specific credit note                            |
-| **Supplier Invoices**           |                                                                   |
-| `supplier_invoice_list`         | List supplier invoices with optional filters                      |
-| `supplier_invoice_show`         | Show details of a specific supplier invoice                       |
-| `supplier_invoice_bulk_create`  | Create supplier invoices by uploading files                       |
-| **Requests**                    |                                                                   |
-| `request_list`                  | List all requests in the organization                             |
-| **Attachments**                 |                                                                   |
-| `attachment_upload`             | Upload an attachment file (PDF, JPEG, PNG)                        |
-| `attachment_show`               | Show details of a specific attachment                             |
-| **E-Invoicing**                 |                                                                   |
-| `einvoicing_settings`           | Retrieve e-invoicing settings for the organization                |
+| Tool                                            | Description                                                       |
+| ----------------------------------------------- | ----------------------------------------------------------------- |
+| **Organization**                                |                                                                   |
+| `org_show`                                      | Show organization details including name, slug, and bank accounts |
+| **Accounts**                                    |                                                                   |
+| `account_list`                                  | List all bank accounts for the organization                       |
+| `account_show`                                  | Show details of a specific bank account                           |
+| `account_iban_certificate`                      | Download IBAN certificate PDF for a bank account                  |
+| `account_create`                                | Create a new bank account                                         |
+| `account_update`                                | Update an existing bank account                                   |
+| `account_close`                                 | Close a bank account                                              |
+| **Transactions**                                |                                                                   |
+| `transaction_list`                              | List transactions for a bank account with optional filters        |
+| `transaction_show`                              | Show details of a specific transaction                            |
+| `transaction_attachment_list`                   | List attachments for a transaction                                |
+| `transaction_attachment_add`                    | Attach a file to a transaction                                    |
+| `transaction_attachment_remove`                 | Remove attachment(s) from a transaction                           |
+| **Statements**                                  |                                                                   |
+| `statement_list`                                | List bank statements with optional filters                        |
+| `statement_show`                                | Show details of a specific bank statement                         |
+| **Labels**                                      |                                                                   |
+| `label_list`                                    | List all labels in the organization                               |
+| `label_show`                                    | Show details of a specific label                                  |
+| **Memberships**                                 |                                                                   |
+| `membership_list`                               | List all memberships in the organization                          |
+| `membership_show`                               | Show the current authenticated user's membership                  |
+| `membership_invite`                             | Invite a new member to the organization                           |
+| **SEPA Beneficiaries**                          |                                                                   |
+| `beneficiary_list`                              | List SEPA beneficiaries in the organization                       |
+| `beneficiary_show`                              | Show details of a specific SEPA beneficiary                       |
+| `beneficiary_add`                               | Create a new SEPA beneficiary                                     |
+| `beneficiary_update`                            | Update an existing SEPA beneficiary                               |
+| `beneficiary_trust`                             | Trust one or more SEPA beneficiaries                              |
+| `beneficiary_untrust`                           | Untrust one or more SEPA beneficiaries                            |
+| **SEPA Transfers**                              |                                                                   |
+| `transfer_list`                                 | List SEPA transfers with optional filters                         |
+| `transfer_show`                                 | Show details of a specific SEPA transfer                          |
+| `transfer_create`                               | Create a SEPA transfer                                            |
+| `transfer_cancel`                               | Cancel a pending SEPA transfer                                    |
+| `transfer_proof`                                | Download SEPA transfer proof PDF                                  |
+| `transfer_verify_payee`                         | Verify a payee (Verification of Payee / VoP)                      |
+| `transfer_bulk_verify_payee`                    | Bulk verify payees (VoP)                                          |
+| **Internal Transfers**                          |                                                                   |
+| `internal_transfer_create`                      | Create an internal transfer between two bank accounts             |
+| **Bulk Transfers**                              |                                                                   |
+| `bulk_transfer_list`                            | List bulk transfers                                               |
+| `bulk_transfer_show`                            | Show details of a specific bulk transfer                          |
+| `bulk_transfer_create`                          | Create a bulk transfer (SCA-gated)                                |
+| **Recurring Transfers**                         |                                                                   |
+| `recurring_transfer_list`                       | List recurring transfers                                          |
+| `recurring_transfer_show`                       | Show details of a specific recurring transfer                     |
+| `recurring_transfer_create`                     | Create a recurring transfer (SCA-gated)                           |
+| `recurring_transfer_cancel`                     | Cancel a recurring transfer (SCA-gated)                           |
+| **International Transfers (SWIFT, OAuth-only)** |                                                                   |
+| `intl_transfer_create`                          | Create an international (SWIFT) transfer (SCA-gated)              |
+| `intl_transfer_requirements`                    | Get international transfer requirements                           |
+| `intl_quote_create`                             | Create an international transfer quote                            |
+| `intl_currencies`                               | List supported international currencies                           |
+| `intl_eligibility`                              | Check international transfer eligibility                          |
+| `intl_beneficiary_list`                         | List international beneficiaries                                  |
+| `intl_beneficiary_add`                          | Add an international beneficiary (SCA-gated)                      |
+| `intl_beneficiary_update`                       | Update an international beneficiary (SCA-gated)                   |
+| `intl_beneficiary_remove`                       | Remove an international beneficiary (SCA-gated)                   |
+| `intl_beneficiary_requirements`                 | Get international beneficiary requirements                        |
+| **Cards (OAuth-only)**                          |                                                                   |
+| `card_list`                                     | List cards                                                        |
+| `card_show`                                     | Show details of a specific card                                   |
+| `card_create`                                   | Create a new card (SCA-gated)                                     |
+| `card_bulk_create`                              | Bulk-create cards (SCA-gated)                                     |
+| `card_update_nickname`                          | Update card nickname (SCA-gated)                                  |
+| `card_update_limits`                            | Update card spending limits (SCA-gated)                           |
+| `card_update_options`                           | Update card options (SCA-gated)                                   |
+| `card_update_restrictions`                      | Update card restrictions (SCA-gated)                              |
+| `card_lock` / `card_unlock`                     | Lock or unlock a card (SCA-gated)                                 |
+| `card_iframe_url`                               | Get a secure iframe URL to view card details                      |
+| `card_report_lost`                              | Report a card lost                                                |
+| `card_report_stolen`                            | Report a card stolen                                              |
+| `card_discard`                                  | Discard a card                                                    |
+| `card_appearances`                              | List available card appearances                                   |
+| **Terminals & Products**                        |                                                                   |
+| `terminal_list`                                 | List Qonto Terminals (POS)                                        |
+| `terminal_payment_create`                       | Create a Qonto Terminal payment                                   |
+| `product_list`                                  | List Qonto Products (catalogue)                                   |
+| **Teams (OAuth-only)**                          |                                                                   |
+| `team_list`                                     | List teams                                                        |
+| `team_create`                                   | Create a new team                                                 |
+| **Webhooks (OAuth-only)**                       |                                                                   |
+| `webhook_list`                                  | List webhook subscriptions                                        |
+| `webhook_show`                                  | Show details of a specific webhook                                |
+| `webhook_create`                                | Create a new webhook subscription                                 |
+| `webhook_update`                                | Update a webhook subscription                                     |
+| `webhook_delete`                                | Delete a webhook subscription                                     |
+| **Payment Links (OAuth-only)**                  |                                                                   |
+| `payment_link_list`                             | List payment links                                                |
+| `payment_link_show`                             | Show details of a specific payment link                           |
+| `payment_link_create`                           | Create a new payment link                                         |
+| `payment_link_deactivate`                       | Deactivate a payment link                                         |
+| `payment_link_connect`                          | Connect a Stripe account for payment links                        |
+| `payment_link_connection_status`                | Show Stripe connection status                                     |
+| `payment_link_methods`                          | List enabled payment methods                                      |
+| `payment_link_payments`                         | List payments received via payment links                          |
+| **Insurance (OAuth-only)**                      |                                                                   |
+| `insurance_show`                                | Show insurance contract details                                   |
+| `insurance_create`                              | Create an insurance contract                                      |
+| `insurance_update`                              | Update an insurance contract                                      |
+| `insurance_upload_document`                     | Upload a document to an insurance contract                        |
+| `insurance_remove_document`                     | Remove a document from an insurance contract                      |
+| **Clients**                                     |                                                                   |
+| `client_list`                                   | List clients with optional pagination                             |
+| `client_show`                                   | Show details of a specific client                                 |
+| `client_create`                                 | Create a new client                                               |
+| `client_update`                                 | Update an existing client                                         |
+| `client_delete`                                 | Delete a client                                                   |
+| **Client Invoices**                             |                                                                   |
+| `client_invoice_list`                           | List client invoices with optional filters                        |
+| `client_invoice_show`                           | Show details of a specific client invoice                         |
+| `client_invoice_create`                         | Create a draft client invoice with client and line items          |
+| `client_invoice_update`                         | Update a draft client invoice                                     |
+| `client_invoice_delete`                         | Delete a draft client invoice                                     |
+| `client_invoice_finalize`                       | Finalize a client invoice (assign number)                         |
+| `client_invoice_send`                           | Send a client invoice to the client via email                     |
+| `client_invoice_mark_paid`                      | Mark a client invoice as paid                                     |
+| `client_invoice_unmark_paid`                    | Unmark a client invoice paid status                               |
+| `client_invoice_cancel`                         | Cancel a finalized client invoice                                 |
+| `client_invoice_upload`                         | Upload a file to a client invoice                                 |
+| `client_invoice_upload_show`                    | Show upload details for a client invoice                          |
+| **Quotes**                                      |                                                                   |
+| `quote_list`                                    | List quotes with optional filters                                 |
+| `quote_show`                                    | Show details of a specific quote                                  |
+| `quote_create`                                  | Create a new quote with client and line items                     |
+| `quote_update`                                  | Update an existing quote                                          |
+| `quote_delete`                                  | Delete a quote                                                    |
+| `quote_send`                                    | Send a quote to the client via email                              |
+| **Credit Notes**                                |                                                                   |
+| `credit_note_list`                              | List credit notes in the organization                             |
+| `credit_note_show`                              | Show details of a specific credit note                            |
+| **Supplier Invoices**                           |                                                                   |
+| `supplier_invoice_list`                         | List supplier invoices with optional filters                      |
+| `supplier_invoice_show`                         | Show details of a specific supplier invoice                       |
+| `supplier_invoice_bulk_create`                  | Create supplier invoices by uploading files                       |
+| **Requests (OAuth-only)**                       |                                                                   |
+| `request_list`                                  | List all requests in the organization                             |
+| `request_approve`                               | Approve a request (SCA-gated)                                     |
+| `request_decline`                               | Decline a request                                                 |
+| `request_create_flash_card`                     | Create a flash-card request                                       |
+| `request_create_virtual_card`                   | Create a virtual-card request                                     |
+| `request_create_multi_transfer`                 | Create a multi-transfer request                                   |
+| **Attachments**                                 |                                                                   |
+| `attachment_upload`                             | Upload an attachment file (PDF, JPEG, PNG)                        |
+| `attachment_show`                               | Show details of a specific attachment                             |
+| **E-Invoicing**                                 |                                                                   |
+| `einvoicing_settings`                           | Retrieve e-invoicing settings for the organization                |
+| **SCA Sessions**                                |                                                                   |
+| `sca_session_show`                              | Inspect an SCA session by token                                   |
+| `sca_session_mock_decision`                     | Inject a mock SCA decision (sandbox only)                         |
+| **Diagnostics**                                 |                                                                   |
+| `diagnose`                                      | Report current configuration, auth status, and connectivity       |
 
 ## Programmatic Usage
 

--- a/packages/qontoctl/README.md
+++ b/packages/qontoctl/README.md
@@ -1,4 +1,4 @@
-# QontoCtl: The Complete CLI & MCP for Qonto
+![QontoCtl: The Complete CLI & MCP for Qonto](https://raw.githubusercontent.com/qontoctl/.github/main/profile/assets/social-preview.png)
 
 [![CI](https://github.com/alexey-pelykh/qontoctl/actions/workflows/ci.yml/badge.svg)](https://github.com/alexey-pelykh/qontoctl/actions/workflows/ci.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/alexey-pelykh/qontoctl?logo=codecov)](https://codecov.io/gh/alexey-pelykh/qontoctl)
@@ -24,8 +24,16 @@ QontoCtl lets AI assistants (Claude, etc.) interact with Qonto through the [Mode
 - **SEPA Beneficiaries** — list, add, update, trust/untrust SEPA beneficiaries
 - **SEPA Transfers** — list, create, cancel transfers; download proofs; verify payees
 - **Internal Transfers** — create transfers between accounts in the same organization
-- **Bulk Transfers** — list and view bulk transfer batches
-- **Recurring Transfers** — list and view recurring transfers
+- **Bulk Transfers** — list, view, and create bulk SEPA transfer batches
+- **Recurring Transfers** — list, view, create, cancel recurring transfers
+- **International Transfers (SWIFT)** — create SWIFT transfers and manage international beneficiaries
+- **Cards** — list, create, update, lock/unlock, report lost/stolen, discard cards
+- **Teams** — list and create teams
+- **Webhooks** — create and manage webhook subscriptions
+- **Payment Links** — create, deactivate, and manage Stripe-backed payment links
+- **Insurance** — show, create, update insurance contracts and manage documents
+- **Terminals (POS)** — list Qonto Terminals and initiate terminal payments
+- **Products** — list catalogue products
 - **Clients** — list, create, update, delete clients
 - **Client Invoices** — full lifecycle: create, update, finalize, send, mark paid, cancel, upload files
 - **Quotes** — create, update, delete, send quotes
@@ -161,100 +169,168 @@ The MCP server has no CLI flags. To load credentials from a config file other th
 }
 ```
 
-The path is captured at server startup. See [`docs/configuration.md`](https://github.com/alexey-pelykh/qontoctl/blob/main/docs/configuration.md) for the full resolution chain.
+The path is captured at server startup. See [`docs/configuration.md`](docs/configuration.md) for the full resolution chain.
 
 ### Available MCP Tools
 
-| Tool                            | Description                                                       |
-| ------------------------------- | ----------------------------------------------------------------- |
-| **Organization**                |                                                                   |
-| `org_show`                      | Show organization details including name, slug, and bank accounts |
-| **Accounts**                    |                                                                   |
-| `account_list`                  | List all bank accounts for the organization                       |
-| `account_show`                  | Show details of a specific bank account                           |
-| `account_iban_certificate`      | Download IBAN certificate PDF for a bank account                  |
-| `account_create`                | Create a new bank account                                         |
-| `account_update`                | Update an existing bank account                                   |
-| `account_close`                 | Close a bank account                                              |
-| **Transactions**                |                                                                   |
-| `transaction_list`              | List transactions for a bank account with optional filters        |
-| `transaction_show`              | Show details of a specific transaction                            |
-| `transaction_attachment_list`   | List attachments for a transaction                                |
-| `transaction_attachment_add`    | Attach a file to a transaction                                    |
-| `transaction_attachment_remove` | Remove attachment(s) from a transaction                           |
-| **Statements**                  |                                                                   |
-| `statement_list`                | List bank statements with optional filters                        |
-| `statement_show`                | Show details of a specific bank statement                         |
-| **Labels**                      |                                                                   |
-| `label_list`                    | List all labels in the organization                               |
-| `label_show`                    | Show details of a specific label                                  |
-| **Memberships**                 |                                                                   |
-| `membership_list`               | List all memberships in the organization                          |
-| `membership_show`               | Show the current authenticated user's membership                  |
-| `membership_invite`             | Invite a new member to the organization                           |
-| **SEPA Beneficiaries**          |                                                                   |
-| `beneficiary_list`              | List SEPA beneficiaries in the organization                       |
-| `beneficiary_show`              | Show details of a specific SEPA beneficiary                       |
-| `beneficiary_add`               | Create a new SEPA beneficiary                                     |
-| `beneficiary_update`            | Update an existing SEPA beneficiary                               |
-| `beneficiary_trust`             | Trust one or more SEPA beneficiaries                              |
-| `beneficiary_untrust`           | Untrust one or more SEPA beneficiaries                            |
-| **SEPA Transfers**              |                                                                   |
-| `transfer_list`                 | List SEPA transfers with optional filters                         |
-| `transfer_show`                 | Show details of a specific SEPA transfer                          |
-| `transfer_create`               | Create a SEPA transfer                                            |
-| `transfer_cancel`               | Cancel a pending SEPA transfer                                    |
-| `transfer_proof`                | Download SEPA transfer proof PDF                                  |
-| `transfer_verify_payee`         | Verify a payee (Verification of Payee / VoP)                      |
-| `transfer_bulk_verify_payee`    | Bulk verify payees (VoP)                                          |
-| **Internal Transfers**          |                                                                   |
-| `internal_transfer_create`      | Create an internal transfer between two bank accounts             |
-| **Bulk Transfers**              |                                                                   |
-| `bulk_transfer_list`            | List bulk transfers                                               |
-| `bulk_transfer_show`            | Show details of a specific bulk transfer                          |
-| **Recurring Transfers**         |                                                                   |
-| `recurring_transfer_list`       | List recurring transfers                                          |
-| `recurring_transfer_show`       | Show details of a specific recurring transfer                     |
-| **Clients**                     |                                                                   |
-| `client_list`                   | List clients with optional pagination                             |
-| `client_show`                   | Show details of a specific client                                 |
-| `client_create`                 | Create a new client                                               |
-| `client_update`                 | Update an existing client                                         |
-| `client_delete`                 | Delete a client                                                   |
-| **Client Invoices**             |                                                                   |
-| `client_invoice_list`           | List client invoices with optional filters                        |
-| `client_invoice_show`           | Show details of a specific client invoice                         |
-| `client_invoice_create`         | Create a draft client invoice with client and line items          |
-| `client_invoice_update`         | Update a draft client invoice                                     |
-| `client_invoice_delete`         | Delete a draft client invoice                                     |
-| `client_invoice_finalize`       | Finalize a client invoice (assign number)                         |
-| `client_invoice_send`           | Send a client invoice to the client via email                     |
-| `client_invoice_mark_paid`      | Mark a client invoice as paid                                     |
-| `client_invoice_unmark_paid`    | Unmark a client invoice paid status                               |
-| `client_invoice_cancel`         | Cancel a finalized client invoice                                 |
-| `client_invoice_upload`         | Upload a file to a client invoice                                 |
-| `client_invoice_upload_show`    | Show upload details for a client invoice                          |
-| **Quotes**                      |                                                                   |
-| `quote_list`                    | List quotes with optional filters                                 |
-| `quote_show`                    | Show details of a specific quote                                  |
-| `quote_create`                  | Create a new quote with client and line items                     |
-| `quote_update`                  | Update an existing quote                                          |
-| `quote_delete`                  | Delete a quote                                                    |
-| `quote_send`                    | Send a quote to the client via email                              |
-| **Credit Notes**                |                                                                   |
-| `credit_note_list`              | List credit notes in the organization                             |
-| `credit_note_show`              | Show details of a specific credit note                            |
-| **Supplier Invoices**           |                                                                   |
-| `supplier_invoice_list`         | List supplier invoices with optional filters                      |
-| `supplier_invoice_show`         | Show details of a specific supplier invoice                       |
-| `supplier_invoice_bulk_create`  | Create supplier invoices by uploading files                       |
-| **Requests**                    |                                                                   |
-| `request_list`                  | List all requests in the organization                             |
-| **Attachments**                 |                                                                   |
-| `attachment_upload`             | Upload an attachment file (PDF, JPEG, PNG)                        |
-| `attachment_show`               | Show details of a specific attachment                             |
-| **E-Invoicing**                 |                                                                   |
-| `einvoicing_settings`           | Retrieve e-invoicing settings for the organization                |
+| Tool                                            | Description                                                           |
+| ----------------------------------------------- | --------------------------------------------------------------------- |
+| **Organization**                                |                                                                       |
+| `org_show`                                      | Show organization details including name, slug, and bank accounts     |
+| **Accounts**                                    |                                                                       |
+| `account_list`                                  | List all bank accounts for the organization                           |
+| `account_show`                                  | Show details of a specific bank account                               |
+| `account_iban_certificate`                      | Download IBAN certificate PDF for a bank account                      |
+| `account_create`                                | Create a new bank account                                             |
+| `account_update`                                | Update an existing bank account                                       |
+| `account_close`                                 | Close a bank account                                                  |
+| **Transactions**                                |                                                                       |
+| `transaction_list`                              | List transactions for a bank account with optional filters            |
+| `transaction_show`                              | Show details of a specific transaction                                |
+| `transaction_attachment_list`                   | List attachments for a transaction                                    |
+| `transaction_attachment_add`                    | Attach a file to a transaction                                        |
+| `transaction_attachment_remove`                 | Remove attachment(s) from a transaction                               |
+| **Statements**                                  |                                                                       |
+| `statement_list`                                | List bank statements with optional filters                            |
+| `statement_show`                                | Show details of a specific bank statement                             |
+| **Labels**                                      |                                                                       |
+| `label_list`                                    | List all labels in the organization                                   |
+| `label_show`                                    | Show details of a specific label                                      |
+| **Memberships**                                 |                                                                       |
+| `membership_list`                               | List all memberships in the organization                              |
+| `membership_show`                               | Show the current authenticated user's membership                      |
+| `membership_invite`                             | Invite a new member to the organization                               |
+| **SEPA Beneficiaries**                          |                                                                       |
+| `beneficiary_list`                              | List SEPA beneficiaries in the organization                           |
+| `beneficiary_show`                              | Show details of a specific SEPA beneficiary                           |
+| `beneficiary_add`                               | Create a new SEPA beneficiary                                         |
+| `beneficiary_update`                            | Update an existing SEPA beneficiary                                   |
+| `beneficiary_trust`                             | Trust one or more SEPA beneficiaries                                  |
+| `beneficiary_untrust`                           | Untrust one or more SEPA beneficiaries                                |
+| **SEPA Transfers**                              |                                                                       |
+| `transfer_list`                                 | List SEPA transfers with optional filters                             |
+| `transfer_show`                                 | Show details of a specific SEPA transfer                              |
+| `transfer_create`                               | Create a SEPA transfer                                                |
+| `transfer_cancel`                               | Cancel a pending SEPA transfer                                        |
+| `transfer_proof`                                | Download SEPA transfer proof PDF                                      |
+| `transfer_verify_payee`                         | Verify a payee (Verification of Payee / VoP)                          |
+| `transfer_bulk_verify_payee`                    | Bulk verify payees (VoP)                                              |
+| **Internal Transfers**                          |                                                                       |
+| `internal_transfer_create`                      | Create an internal transfer between two bank accounts                 |
+| **Bulk Transfers**                              |                                                                       |
+| `bulk_transfer_list`                            | List bulk transfers                                                   |
+| `bulk_transfer_show`                            | Show details of a specific bulk transfer                              |
+| `bulk_transfer_create`                          | Create a bulk SEPA transfer (auto-resolves VoP via bulk_verify_payee) |
+| **Recurring Transfers**                         |                                                                       |
+| `recurring_transfer_list`                       | List recurring transfers                                              |
+| `recurring_transfer_show`                       | Show details of a specific recurring transfer                         |
+| `recurring_transfer_create`                     | Create a recurring transfer (SCA-gated)                               |
+| `recurring_transfer_cancel`                     | Cancel a recurring transfer (SCA-gated)                               |
+| **International Transfers (SWIFT, OAuth-only)** |                                                                       |
+| `intl_transfer_create`                          | Create an international (SWIFT) transfer (SCA-gated)                  |
+| `intl_transfer_requirements`                    | Get international transfer requirements                               |
+| `intl_quote_create`                             | Create an international transfer quote                                |
+| `intl_currencies`                               | List supported international currencies                               |
+| `intl_eligibility`                              | Check international transfer eligibility                              |
+| `intl_beneficiary_list`                         | List international beneficiaries                                      |
+| `intl_beneficiary_add`                          | Add an international beneficiary (SCA-gated)                          |
+| `intl_beneficiary_update`                       | Update an international beneficiary (SCA-gated)                       |
+| `intl_beneficiary_remove`                       | Remove an international beneficiary (SCA-gated)                       |
+| `intl_beneficiary_requirements`                 | Get international beneficiary requirements                            |
+| **Cards (OAuth-only)**                          |                                                                       |
+| `card_list`                                     | List cards                                                            |
+| `card_show`                                     | Show details of a specific card                                       |
+| `card_create`                                   | Create a new card (SCA-gated)                                         |
+| `card_bulk_create`                              | Bulk-create cards (SCA-gated)                                         |
+| `card_update_nickname`                          | Update card nickname (SCA-gated)                                      |
+| `card_update_limits`                            | Update card spending limits (SCA-gated)                               |
+| `card_update_options`                           | Update card options (SCA-gated)                                       |
+| `card_update_restrictions`                      | Update card restrictions (SCA-gated)                                  |
+| `card_lock` / `card_unlock`                     | Lock or unlock a card (SCA-gated)                                     |
+| `card_iframe_url`                               | Get a secure iframe URL to view card details                          |
+| `card_report_lost`                              | Report a card lost                                                    |
+| `card_report_stolen`                            | Report a card stolen                                                  |
+| `card_discard`                                  | Discard a card                                                        |
+| `card_appearances`                              | List available card appearances                                       |
+| **Teams (OAuth-only)**                          |                                                                       |
+| `team_list`                                     | List teams                                                            |
+| `team_create`                                   | Create a new team                                                     |
+| **Webhooks (OAuth-only)**                       |                                                                       |
+| `webhook_list`                                  | List webhook subscriptions                                            |
+| `webhook_show`                                  | Show details of a specific webhook                                    |
+| `webhook_create`                                | Create a new webhook subscription                                     |
+| `webhook_update`                                | Update a webhook subscription                                         |
+| `webhook_delete`                                | Delete a webhook subscription                                         |
+| **Payment Links (OAuth-only)**                  |                                                                       |
+| `payment_link_list`                             | List payment links                                                    |
+| `payment_link_show`                             | Show details of a specific payment link                               |
+| `payment_link_create`                           | Create a new payment link                                             |
+| `payment_link_deactivate`                       | Deactivate a payment link                                             |
+| `payment_link_connect`                          | Connect a Stripe account for payment links                            |
+| `payment_link_connection_status`                | Show Stripe connection status                                         |
+| `payment_link_methods`                          | List enabled payment methods                                          |
+| `payment_link_payments`                         | List payments received via payment links                              |
+| **Insurance (OAuth-only)**                      |                                                                       |
+| `insurance_show`                                | Show insurance contract details                                       |
+| `insurance_create`                              | Create an insurance contract                                          |
+| `insurance_update`                              | Update an insurance contract                                          |
+| `insurance_upload_document`                     | Upload a document to an insurance contract                            |
+| `insurance_remove_document`                     | Remove a document from an insurance contract                          |
+| **Terminals (POS)**                             |                                                                       |
+| `terminal_list`                                 | List Qonto Terminals linked to the organization                       |
+| `terminal_payment_create`                       | Initiate a payment on a terminal (returns 202 Accepted)               |
+| **Products**                                    |                                                                       |
+| `product_list`                                  | List catalogue products with optional pagination and sort             |
+| **Clients**                                     |                                                                       |
+| `client_list`                                   | List clients with optional pagination                                 |
+| `client_show`                                   | Show details of a specific client                                     |
+| `client_create`                                 | Create a new client                                                   |
+| `client_update`                                 | Update an existing client                                             |
+| `client_delete`                                 | Delete a client                                                       |
+| **Client Invoices**                             |                                                                       |
+| `client_invoice_list`                           | List client invoices with optional filters                            |
+| `client_invoice_show`                           | Show details of a specific client invoice                             |
+| `client_invoice_create`                         | Create a draft client invoice with client and line items              |
+| `client_invoice_update`                         | Update a draft client invoice                                         |
+| `client_invoice_delete`                         | Delete a draft client invoice                                         |
+| `client_invoice_finalize`                       | Finalize a client invoice (assign number)                             |
+| `client_invoice_send`                           | Send a client invoice to the client via email                         |
+| `client_invoice_mark_paid`                      | Mark a client invoice as paid                                         |
+| `client_invoice_unmark_paid`                    | Unmark a client invoice paid status                                   |
+| `client_invoice_cancel`                         | Cancel a finalized client invoice                                     |
+| `client_invoice_upload`                         | Upload a file to a client invoice                                     |
+| `client_invoice_upload_show`                    | Show upload details for a client invoice                              |
+| **Quotes**                                      |                                                                       |
+| `quote_list`                                    | List quotes with optional filters                                     |
+| `quote_show`                                    | Show details of a specific quote                                      |
+| `quote_create`                                  | Create a new quote with client and line items                         |
+| `quote_update`                                  | Update an existing quote                                              |
+| `quote_delete`                                  | Delete a quote                                                        |
+| `quote_send`                                    | Send a quote to the client via email                                  |
+| **Credit Notes**                                |                                                                       |
+| `credit_note_list`                              | List credit notes in the organization                                 |
+| `credit_note_show`                              | Show details of a specific credit note                                |
+| **Supplier Invoices**                           |                                                                       |
+| `supplier_invoice_list`                         | List supplier invoices with optional filters                          |
+| `supplier_invoice_show`                         | Show details of a specific supplier invoice                           |
+| `supplier_invoice_bulk_create`                  | Create supplier invoices by uploading files                           |
+| **Requests (OAuth-only)**                       |                                                                       |
+| `request_list`                                  | List all requests in the organization                                 |
+| `request_approve`                               | Approve a request (SCA-gated)                                         |
+| `request_decline`                               | Decline a request                                                     |
+| `request_create_flash_card`                     | Create a flash-card request                                           |
+| `request_create_virtual_card`                   | Create a virtual-card request                                         |
+| `request_create_multi_transfer`                 | Create a multi-transfer request                                       |
+| **Diagnostics**                                 |                                                                       |
+| `diagnose`                                      | Report current configuration, auth status, and connectivity           |
+| **SCA Sessions**                                |                                                                       |
+| `sca_session_show`                              | Show the status of an SCA session (`waiting` / `allow` / `deny`)      |
+| `sca_session_mock_decision`                     | Simulate an SCA decision in the Qonto sandbox (sandbox-only)          |
+| **Attachments**                                 |                                                                       |
+| `attachment_upload`                             | Upload an attachment file (PDF, JPEG, PNG)                            |
+| `attachment_show`                               | Show details of a specific attachment                                 |
+| **E-Invoicing**                                 |                                                                       |
+| `einvoicing_settings`                           | Retrieve e-invoicing settings for the organization                    |
 
 ### Example Prompts
 
@@ -267,96 +343,168 @@ Once configured, you can ask your AI assistant things like:
 - "List bank statements for January 2026"
 - "Create a summary of this week's debits"
 
+### SCA Continuation
+
+Some Qonto write operations — creating a transfer, modifying a card, approving a request — require **Strong Customer Authentication (SCA)**: the user has to approve the request in the Qonto mobile app before it executes. QontoCtl wraps every SCA-gated MCP write tool with a continuation flow so the LLM client never has to reimplement polling.
+
+#### How a wrapped write tool behaves
+
+When an SCA-gated tool (e.g. `transfer_create`, `card_create`, `beneficiary_trust`, `request_approve`) hits a 428 SCA challenge, the wrapper polls the SCA session inline. If the user approves within the polling window, the tool returns the operation's success result transparently — the LLM never sees the SCA round-trip. If polling times out (or polling is disabled), the tool returns a structured **SCA-pending response** carrying the session token and instructions to continue.
+
+Every wrapped tool exposes two optional input fields for this flow:
+
+- `wait` — maximum seconds to poll inline before falling back to the pending response.
+- `sca_session_token` — bind a previously approved SCA challenge to a retry.
+
+#### The `wait` knob
+
+| Value            | Behavior                                                                             |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| `30` _(default)_ | Poll for up to 30 seconds, then fall back to the structured pending response.        |
+| `1`–`120`        | Poll for the specified number of seconds (capped at 120).                            |
+| `0` or `false`   | Skip polling entirely. Return the SCA-pending response immediately on the first 428. |
+
+The `120` upper bound is the hard ceiling enforced via Zod at the input boundary. The practical ceiling is your MCP host's request timeout — Claude Desktop hardcodes ≈ 60 s and Cursor's effective limit is ≈ 30 s, so values above those will surface as host-side timeouts before the wrapper resolves. Use a small `wait` (e.g. `5`-`10`) when the LLM expects the user to be present and willing to approve immediately. Use `wait: false` (or `wait: 0`) for **pure two-step flows** where the LLM and the user converse out-of-band between the SCA challenge and the retry.
+
+#### Two-step fallback (out-of-band continuation)
+
+When polling does not resolve, the SCA-pending response carries:
+
+- A user-facing message: `"SCA required. The user must approve this operation on their Qonto mobile app."`
+- A `Session token: <token>` line (token validity: 15 minutes from issuance).
+- Step-by-step instructions to continue.
+
+The LLM (or the user) can then:
+
+1. **Poll session status** with the `sca_session_show` tool, passing the captured token. It returns `waiting`, `allow`, or `deny`.
+2. **Retry the original tool** once the status is `allow`, passing the _same parameters_ plus `sca_session_token: "<token>"`. The wrapper invokes the operation exactly once with the token bound — no second poll happens.
+
+> **PSD2 dynamic linking.** The SCA session token is bound to the _original_ request parameters (amount, payee). Reusing a token against a different operation is rejected by Qonto. Reissue an SCA challenge by calling the original tool again whenever the parameters need to change.
+
+#### Caller-supplied retry (`sca_session_token`)
+
+When `sca_session_token` is set on a wrapped write tool, the wrapper:
+
+- Invokes the operation exactly once.
+- Skips polling entirely.
+- Forwards the token via the `X-Qonto-Sca-Session-Token` header.
+
+This is the path used by step (2) of the two-step fallback. It is also useful when the LLM client implements its own polling cadence and only needs the wrapper to retry with an already-captured approval.
+
+#### Sandbox testing
+
+Sandbox accounts cannot enroll a real paired device, so SCA challenges in sandbox use a `mock` flow. After receiving a pending response, simulate the user's decision with the `sca_session_mock_decision` tool (sandbox-only — refuses to run when no staging token is configured). See [`docs/sandbox-testing.md`](docs/sandbox-testing.md) for the full sandbox setup.
+
+#### Migration note
+
+Earlier QontoCtl builds (pre-`@qontoctl/mcp` SCA continuation) returned a free-form text response on 428 with no continuation hooks. Callers parsing that response should adopt the structured flow:
+
+| Before                                                                                | After                                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Free-form text mentioned the SCA endpoint but offered no MCP-exposed way to continue. | The SCA-pending response is still text content but its shape is stable: `Session token: <token>` is the canonical line; `sca_session_show` is the polling API. |
+| Polling required driving the Qonto HTTP API directly.                                 | Use the `sca_session_show` MCP tool.                                                                                                                           |
+| Re-running the operation orphaned the prior approval.                                 | Retry the original tool with the captured `sca_session_token` parameter — the prior approval is bound to that retry.                                           |
+| No way to opt-in to inline polling — every 428 was a dead end.                        | Pass `wait: <seconds>` (1-120) to poll inline; tools default to 30s. Pass `wait: false` for the explicit two-step flow.                                        |
+
+The pending response's textual format is stable, so callers that need to extract the token programmatically can match against the `Session token:` line — but using `sca_session_show` directly avoids relying on the response prose.
+
 ## CLI Usage
+
+> **First command to try when something doesn't work**: [`qontoctl diagnose`](docs/troubleshooting.md) — a read-only healthcheck across config, credentials, scopes, organization metadata, and host routing.
 
 ### Commands
 
-| Command                                       | Description                               |
-| --------------------------------------------- | ----------------------------------------- |
-| `org show`                                    | Show organization details                 |
-| `account list`                                | List bank accounts                        |
-| `account show <id>`                           | Show bank account details                 |
-| `account iban-certificate <id>`               | Download IBAN certificate PDF             |
-| `account create`                              | Create a new bank account                 |
-| `account update <id>`                         | Update a bank account                     |
-| `account close <id>`                          | Close a bank account                      |
-| `transaction list`                            | List transactions with filters            |
-| `transaction show <id>`                       | Show transaction details                  |
-| `transaction attachment list <id>`            | List attachments for a transaction        |
-| `transaction attachment add <id> <file>`      | Attach a file to a transaction            |
-| `transaction attachment remove <id> [att-id]` | Remove attachment(s) from a transaction   |
-| `statement list`                              | List bank statements                      |
-| `statement show <id>`                         | Show statement details                    |
-| `statement download <id>`                     | Download statement PDF                    |
-| `label list`                                  | List all labels                           |
-| `label show <id>`                             | Show label details                        |
-| `membership list`                             | List organization memberships             |
-| `membership show`                             | Show current user's membership            |
-| `membership invite`                           | Invite a new member                       |
-| `beneficiary list`                            | List SEPA beneficiaries                   |
-| `beneficiary show <id>`                       | Show beneficiary details                  |
-| `beneficiary add`                             | Create a new beneficiary                  |
-| `beneficiary update <id>`                     | Update a beneficiary                      |
-| `beneficiary trust <id...>`                   | Trust one or more beneficiaries           |
-| `beneficiary untrust <id...>`                 | Untrust one or more beneficiaries         |
-| `transfer list`                               | List SEPA transfers                       |
-| `transfer show <id>`                          | Show SEPA transfer details                |
-| `transfer create`                             | Create a SEPA transfer                    |
-| `transfer cancel <id>`                        | Cancel a pending SEPA transfer            |
-| `transfer proof <id>`                         | Download SEPA transfer proof PDF          |
-| `transfer verify-payee`                       | Verify a payee (VoP)                      |
-| `transfer bulk-verify-payee`                  | Bulk verify payees from CSV               |
-| `internal-transfer create`                    | Create an internal transfer               |
-| `bulk-transfer list`                          | List bulk transfers                       |
-| `bulk-transfer show <id>`                     | Show bulk transfer details                |
-| `recurring-transfer list`                     | List recurring transfers                  |
-| `recurring-transfer show <id>`                | Show recurring transfer details           |
-| `client list`                                 | List clients                              |
-| `client show <id>`                            | Show client details                       |
-| `client create`                               | Create a new client                       |
-| `client update <id>`                          | Update a client                           |
-| `client delete <id>`                          | Delete a client                           |
-| `client-invoice list`                         | List client invoices                      |
-| `client-invoice show <id>`                    | Show client invoice details               |
-| `client-invoice create`                       | Create a draft client invoice             |
-| `client-invoice update <id>`                  | Update a draft client invoice             |
-| `client-invoice delete <id>`                  | Delete a draft client invoice             |
-| `client-invoice finalize <id>`                | Finalize client invoice and assign number |
-| `client-invoice send <id>`                    | Send client invoice to client via email   |
-| `client-invoice mark-paid <id>`               | Mark client invoice as paid               |
-| `client-invoice unmark-paid <id>`             | Unmark client invoice paid status         |
-| `client-invoice cancel <id>`                  | Cancel a finalized client invoice         |
-| `client-invoice upload <id> <file>`           | Upload a file to a client invoice         |
-| `client-invoice upload-show <id> <upload-id>` | Show upload details for a client invoice  |
-| `quote list`                                  | List quotes                               |
-| `quote show <id>`                             | Show quote details                        |
-| `quote create`                                | Create a new quote                        |
-| `quote update <id>`                           | Update a quote                            |
-| `quote delete <id>`                           | Delete a quote                            |
-| `quote send <id>`                             | Send quote to client via email            |
-| `credit-note list`                            | List credit notes                         |
-| `credit-note show <id>`                       | Show credit note details                  |
-| `supplier-invoice list`                       | List supplier invoices                    |
-| `supplier-invoice show <id>`                  | Show supplier invoice details             |
-| `supplier-invoice bulk-create`                | Create supplier invoices from files       |
-| `einvoicing settings`                         | Show e-invoicing settings                 |
-| `request list`                                | List all requests                         |
-| `attachment upload <file>`                    | Upload an attachment file                 |
-| `attachment show <id>`                        | Show attachment details                   |
-| `auth setup`                                  | Configure OAuth client credentials        |
-| `auth login`                                  | Start OAuth login flow                    |
-| `auth status`                                 | Display OAuth token status                |
-| `auth refresh`                                | Refresh the OAuth access token            |
-| `auth revoke`                                 | Revoke OAuth consent and clear tokens     |
-| `profile add <name>`                          | Create a named profile                    |
-| `profile list`                                | List all profiles                         |
-| `profile show <name>`                         | Show profile details (secrets redacted)   |
-| `profile remove <name>`                       | Remove a named profile                    |
-| `profile test`                                | Test credentials                          |
-| `completion bash`                             | Generate bash completions                 |
-| `completion zsh`                              | Generate zsh completions                  |
-| `completion fish`                             | Generate fish completions                 |
-| `mcp`                                         | Start MCP server on stdio                 |
+| Command                                       | Description                                                                        |
+| --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `diagnose`                                    | Read-only healthcheck (see [troubleshooting](docs/troubleshooting.md))             |
+| `org show`                                    | Show organization details                                                          |
+| `account list`                                | List bank accounts                                                                 |
+| `account show <id>`                           | Show bank account details                                                          |
+| `account iban-certificate <id>`               | Download IBAN certificate PDF                                                      |
+| `account create`                              | Create a new bank account                                                          |
+| `account update <id>`                         | Update a bank account                                                              |
+| `account close <id>`                          | Close a bank account                                                               |
+| `transaction list`                            | List transactions with filters                                                     |
+| `transaction show <id>`                       | Show transaction details                                                           |
+| `transaction attachment list <id>`            | List attachments for a transaction                                                 |
+| `transaction attachment add <id> <file>`      | Attach a file to a transaction                                                     |
+| `transaction attachment remove <id> [att-id]` | Remove attachment(s) from a transaction                                            |
+| `statement list`                              | List bank statements                                                               |
+| `statement show <id>`                         | Show statement details                                                             |
+| `statement download <id>`                     | Download statement PDF                                                             |
+| `label list`                                  | List all labels                                                                    |
+| `label show <id>`                             | Show label details                                                                 |
+| `membership list`                             | List organization memberships                                                      |
+| `membership show`                             | Show current user's membership                                                     |
+| `membership invite`                           | Invite a new member                                                                |
+| `beneficiary list`                            | List SEPA beneficiaries                                                            |
+| `beneficiary show <id>`                       | Show beneficiary details                                                           |
+| `beneficiary add`                             | Create a new beneficiary                                                           |
+| `beneficiary update <id>`                     | Update a beneficiary                                                               |
+| `beneficiary trust <id...>`                   | Trust one or more beneficiaries                                                    |
+| `beneficiary untrust <id...>`                 | Untrust one or more beneficiaries                                                  |
+| `transfer list`                               | List SEPA transfers                                                                |
+| `transfer show <id>`                          | Show SEPA transfer details                                                         |
+| `transfer create`                             | Create a SEPA transfer                                                             |
+| `transfer cancel <id>`                        | Cancel a pending SEPA transfer                                                     |
+| `transfer proof <id>`                         | Download SEPA transfer proof PDF                                                   |
+| `transfer verify-payee`                       | Verify a payee (VoP)                                                               |
+| `transfer bulk-verify-payee`                  | Bulk verify payees from CSV                                                        |
+| `internal-transfer create`                    | Create an internal transfer                                                        |
+| `bulk-transfer list`                          | List bulk transfers                                                                |
+| `bulk-transfer show <id>`                     | Show bulk transfer details                                                         |
+| `bulk-transfer create`                        | Create a bulk SEPA transfer from JSON                                              |
+| `recurring-transfer list`                     | List recurring transfers                                                           |
+| `recurring-transfer show <id>`                | Show recurring transfer details                                                    |
+| `terminal list`                               | List Qonto Terminals (POS)                                                         |
+| `terminal payment create <id>`                | Initiate a payment on a terminal                                                   |
+| `product list`                                | List catalogue products                                                            |
+| `client list`                                 | List clients                                                                       |
+| `client show <id>`                            | Show client details                                                                |
+| `client create`                               | Create a new client                                                                |
+| `client update <id>`                          | Update a client                                                                    |
+| `client delete <id>`                          | Delete a client                                                                    |
+| `client-invoice list`                         | List client invoices                                                               |
+| `client-invoice show <id>`                    | Show client invoice details                                                        |
+| `client-invoice create`                       | Create a draft client invoice                                                      |
+| `client-invoice update <id>`                  | Update a draft client invoice                                                      |
+| `client-invoice delete <id>`                  | Delete a draft client invoice                                                      |
+| `client-invoice finalize <id>`                | Finalize client invoice and assign number                                          |
+| `client-invoice send <id>`                    | Send client invoice to client via email                                            |
+| `client-invoice mark-paid <id>`               | Mark client invoice as paid                                                        |
+| `client-invoice unmark-paid <id>`             | Unmark client invoice paid status                                                  |
+| `client-invoice cancel <id>`                  | Cancel a finalized client invoice                                                  |
+| `client-invoice upload <id> <file>`           | Upload a file to a client invoice                                                  |
+| `client-invoice upload-show <id> <upload-id>` | Show upload details for a client invoice                                           |
+| `quote list`                                  | List quotes                                                                        |
+| `quote show <id>`                             | Show quote details                                                                 |
+| `quote create`                                | Create a new quote                                                                 |
+| `quote update <id>`                           | Update a quote                                                                     |
+| `quote delete <id>`                           | Delete a quote                                                                     |
+| `quote send <id>`                             | Send quote to client via email                                                     |
+| `credit-note list`                            | List credit notes                                                                  |
+| `credit-note show <id>`                       | Show credit note details                                                           |
+| `supplier-invoice list`                       | List supplier invoices                                                             |
+| `supplier-invoice show <id>`                  | Show supplier invoice details                                                      |
+| `supplier-invoice bulk-create`                | Create supplier invoices from files                                                |
+| `einvoicing settings`                         | Show e-invoicing settings                                                          |
+| `request list`                                | List all requests                                                                  |
+| `attachment upload <file>`                    | Upload an attachment file                                                          |
+| `attachment show <id>`                        | Show attachment details                                                            |
+| `auth setup`                                  | Configure OAuth client credentials                                                 |
+| `auth login`                                  | Start OAuth login flow                                                             |
+| `auth status`                                 | Display OAuth token status (focused; for whole-integration health, use `diagnose`) |
+| `auth refresh`                                | Refresh the OAuth access token                                                     |
+| `auth revoke`                                 | Revoke OAuth consent and clear tokens                                              |
+| `profile add <name>`                          | Create a named profile                                                             |
+| `profile list`                                | List all profiles                                                                  |
+| `profile show <name>`                         | Show profile details (secrets redacted)                                            |
+| `profile remove <name>`                       | Remove a named profile                                                             |
+| `profile test`                                | Test credentials                                                                   |
+| `completion bash`                             | Generate bash completions                                                          |
+| `completion zsh`                              | Generate zsh completions                                                           |
+| `completion fish`                             | Generate fish completions                                                          |
+| `mcp`                                         | Start MCP server on stdio                                                          |
 
 ### Global Options
 
@@ -373,34 +521,26 @@ Once configured, you can ask your AI assistant things like:
 
 ## Configuration
 
-QontoCtl supports two authentication methods: **API Key** (read-only) and **OAuth 2.0** (read + write).
+QontoCtl supports two authentication methods:
 
-### API Key Authentication
+- **API Key** — production-only access using your organization slug and secret key. Supports the endpoints listed as "API key ✔" in the [Qonto auth table](https://docs.qonto.com/get-started/business-api/authentication/introduction) (most reads plus many writes — internal transfers, clients, attachments, …). Cannot be used against the Qonto sandbox.
+- **OAuth 2.0** — full access including OAuth-only endpoints (cards, teams, webhooks, e-invoicing, payment links, insurance, international transfers, recurring transfers, SCA flows) and the Qonto sandbox via staging-token; see the [OAuth App Setup Guide](docs/oauth-setup.md).
+
+### Profile Format
+
+All configuration files use the same YAML format:
 
 ```yaml
+# API Key authentication
 api-key:
     organization-slug: acme-corp-4821
     secret-key: your-secret-key
+
+# OAuth 2.0 authentication (see docs/oauth-setup.md)
+oauth:
+    client-id: your-client-id
+    client-secret: your-client-secret
 ```
-
-### OAuth 2.0 Authentication
-
-OAuth enables write operations (transfers, invoices, etc.) and uses the Authorization Code Grant with PKCE.
-
-```sh
-# 1. Set up OAuth credentials (interactive guide)
-qontoctl auth setup
-
-# 2. Log in via browser
-qontoctl auth login
-
-# 3. Check token status
-qontoctl auth status
-```
-
-The `auth setup` command walks you through creating an OAuth app on the [Qonto Developer Portal](https://developers.qonto.com/). After creating the app, you must **publish the production version** — the sandbox version does not work with production API endpoints.
-
-When both API key and OAuth credentials are configured, OAuth is used when an active session exists (access token present); otherwise it falls through to API key.
 
 ### Resolution Order
 
@@ -420,7 +560,7 @@ When `--config` is supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and 
 - Without `--profile`: `QONTOCTL_*` env vars override file values
 - With `--profile acme`: `QONTOCTL_ACME_*` env vars override file values
 
-For the full reference (including the migration story for users coming from pre-`0.x` builds that walked CWD), see [`docs/configuration.md`](https://github.com/alexey-pelykh/qontoctl/blob/main/docs/configuration.md).
+For the full reference (precedence rules per entry point, profile semantics, migration from CWD discovery), see [`docs/configuration.md`](docs/configuration.md).
 
 ### Environment Variables
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/qontoctl",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "2.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "qontoctl",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -16,7 +16,7 @@ startCommand:
   commandFunction: |-
     (config) => ({
       command: 'npx',
-      args: ['-y', 'qontoctl@1.0.0', 'mcp'],
+      args: ['-y', 'qontoctl', 'mcp'],
       env: {
         QONTOCTL_ORGANIZATION_SLUG: config.organizationSlug,
         QONTOCTL_SECRET_KEY: config.secretKey


### PR DESCRIPTION
## Summary

Pre-release sweep gating v2.0.0 cut. Driven by `/audit` findings (6 CRITICAL documentation findings) and the verdict to **DEFER v2.0.0** until docs/version pins are corrected.

- **CHANGELOG**: backfill 30 missing PRs, promote #479 (CWD removal) and #563 (PUT→PATCH) to BREAKING, add 6-section "Migration from v1.x" guide
- **READMEs**: cli/mcp/qontoctl/core READMEs were ~6 months stale; documenting all 128 MCP tools (was ~70) and ~60 CLI commands across Cards / International / Webhooks / Payment Links / Insurance / Teams / Terminals / Products / Requests / SCA / diagnose families
- **SECURITY.md**: drop CWD credential row, add `--config` + `QONTOCTL_CONFIG_FILE` rows, document 0600 / atomic-write semantics, expand threat-model table
- **Core README**: fix HTTP 403→428 for `QontoScaRequiredError`, add `QontoScaNotEnrolledError`, refresh Configuration Resolution chain for v2.0.0
- **Version pins**: `server.json` 1.0.0 → 2.0.0; `smithery.yaml` `qontoctl@1.0.0` → `qontoctl` (floating); release-runbook §4.5 added covering MCP Registry + Smithery
- **No code changes** — purely docs + manifest pins

## Local gates (passed)

- [x] `pnpm format:check`
- [x] `pnpm build` (5 packages)
- [x] `pnpm lint` (all packages, 0 issues)
- [x] `pnpm license-check` (100 prod deps, all allowed)
- [x] `pnpm test` (789 unit tests, all passing)

## E2E status

Earlier full E2E run on this work returned **351/366 passing** (95.9%) with the remaining 15 failures all environmental:

- **4 cards failures** — OAuth refresh-token rotated/revoked during the rerun → fallback to api-key, which 401s on OAuth-only endpoints
- **11 SCA-mock failures** — OAuth access token expiry during the SCA polling round-trip on bank-accounts / bulk-transfers / recurring-transfers / sca-continuation / beneficiaries

Both patterns are test-infrastructure churn (sandbox refresh-token rotation, sequential CLI subprocess sharing the same `.qontoctl.yaml`), not code regressions. CI's api-key-only E2E job hits none of this surface.

## Test plan

- [x] Local pre-flight gates (above)
- [ ] CI 3-OS matrix (ubuntu/macos/windows): build + lint + license + 789 unit tests
- [ ] CI api-key E2E job (post-merge to main, gated by secrets)
- [ ] Re-run full E2E locally after merge to confirm 351/366 stable baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)