### PR TITLE
(fix) Quote and ClientInvoice schemas: extend discount.type enum + relax attachment_id (#496)

### DIFF
--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -57,6 +57,20 @@ describe("ClientInvoiceDiscountSchema", () => {
     };
     expect(() => ClientInvoiceDiscountSchema.parse(data)).toThrow();
   });
+
+  // Regression for #496: symmetric fix with QuoteDiscountSchema. Qonto's
+  // client-invoice-endpoint docs use `"absolute"` canonically for the same
+  // semantic. Accept it preemptively to avoid a latent bug for any user
+  // creating a client invoice with a fixed-amount discount.
+  it("parses an absolute discount (regression: #496)", () => {
+    const data = {
+      type: "absolute" as const,
+      value: "5.00",
+      amount: { value: "5.00", currency: "EUR" },
+      amount_cents: 500,
+    };
+    expect(ClientInvoiceDiscountSchema.parse(data)).toEqual(data);
+  });
 });
 
 describe("ClientInvoiceItemSchema", () => {
@@ -369,5 +383,16 @@ describe("ClientInvoiceSchema", () => {
     const wrapperSchema = z.object({ client_invoice: ClientInvoiceSchema });
     const result = parseResponse(wrapperSchema, wrapped, "/v2/client_invoices/inv-1");
     expect(result.client_invoice.items).toEqual([]);
+  });
+
+  // Regression for #496: symmetric fix with QuoteSchema. Qonto's
+  // `ClientInvoice` OpenAPI schema does not list `attachment_id` in
+  // `required`, so the field may be omitted entirely. Mirrors the latent-bug
+  // prevention rationale for the Quote-side fix.
+  it("accepts attachment_id omitted entirely (regression: #496)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { attachment_id: _omit, ...withoutAttachment } = validInvoice;
+    const result = ClientInvoiceSchema.parse(withoutAttachment);
+    expect(result.attachment_id).toBeUndefined();
   });
 });

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -21,9 +21,13 @@ export const ClientInvoiceAmountSchema = z
   })
   .strip() satisfies z.ZodType<ClientInvoiceAmount>;
 
+// Qonto's client-invoice-endpoint docs use `"absolute"` canonically for the
+// same semantic that the quote-endpoint docs call `"amount"`. Accept all three
+// values to remain consistent with QuoteDiscountSchema and forward-compatible
+// regardless of which surface Qonto cleans up first. See #496.
 export const ClientInvoiceDiscountSchema = z
   .object({
-    type: z.enum(["percentage", "amount"]),
+    type: z.enum(["percentage", "absolute", "amount"]),
     value: z.string(),
     amount: ClientInvoiceAmountSchema,
     amount_cents: z.number(),
@@ -113,7 +117,10 @@ export const ClientInvoiceSchema = z
     due_date: z.string().nullable(),
     created_at: z.string(),
     updated_at: z.string(),
-    attachment_id: z.string().nullable(),
+    // Qonto's `ClientInvoice` schema does not list `attachment_id` in
+    // `required`, so the field may be omitted entirely (not just null).
+    // Mirrors the Quote fix from #496.
+    attachment_id: z.string().nullable().optional(),
     contact_email: z.string().nullable(),
     terms_and_conditions: z.string().nullable(),
     header: z.string().nullable(),

--- a/packages/core/src/client-invoices/types.ts
+++ b/packages/core/src/client-invoices/types.ts
@@ -11,9 +11,13 @@ export interface ClientInvoiceAmount {
 
 /**
  * A discount applied to a client invoice or invoice item.
+ *
+ * `type` accepts `"absolute"` in addition to `"percentage"` and `"amount"`
+ * for consistency with `QuoteDiscount` — Qonto's client-invoice docs use
+ * `"absolute"` canonically. See #496.
  */
 export interface ClientInvoiceDiscount {
-  readonly type: "percentage" | "amount";
+  readonly type: "percentage" | "absolute" | "amount";
   readonly value: string;
   readonly amount: ClientInvoiceAmount;
   readonly amount_cents: number;
@@ -108,7 +112,7 @@ export interface ClientInvoice {
   readonly due_date: string | null;
   readonly created_at: string;
   readonly updated_at: string;
-  readonly attachment_id: string | null;
+  readonly attachment_id?: string | null | undefined;
   readonly contact_email: string | null;
   readonly terms_and_conditions: string | null;
   readonly header: string | null;

--- a/packages/core/src/types/quote.schema.test.ts
+++ b/packages/core/src/types/quote.schema.test.ts
@@ -112,6 +112,20 @@ describe("QuoteDiscountSchema", () => {
   it("validates type enum", () => {
     expect(() => QuoteDiscountSchema.parse({ ...discount, type: "fixed" })).toThrow();
   });
+
+  // Regression for #496: the live `/v2/quotes` API returns `discount.type:
+  // "absolute"` for fixed-amount discounts (raw curl evidence in the issue
+  // comment thread), even though Qonto's own quote-endpoint docs say the
+  // enum is `[percentage, amount]`. Accept `"absolute"` to unblock parsing.
+  it("parses an absolute discount (regression: #496)", () => {
+    const absoluteDiscount = { ...discount, type: "absolute" as const };
+    expect(QuoteDiscountSchema.parse(absoluteDiscount)).toEqual(absoluteDiscount);
+  });
+
+  it("parses an amount discount (regression: #496)", () => {
+    const amountDiscount = { ...discount, type: "amount" as const };
+    expect(QuoteDiscountSchema.parse(amountDiscount)).toEqual(amountDiscount);
+  });
 });
 
 describe("QuoteItemSchema", () => {
@@ -239,5 +253,17 @@ describe("QuoteSchema", () => {
 
   it("rejects missing required fields", () => {
     expect(() => QuoteSchema.parse({ id: "quote-1" })).toThrow();
+  });
+
+  // Regression for #496: PATCH responses from `/v2/quotes/{id}` omit
+  // `attachment_id` entirely (not just `null`). Qonto's `Quote` OpenAPI
+  // schema does not list it in `required`, so per OpenAPI semantics the
+  // field MAY be absent. Reproducer: `quote_update` MCP tool / `quote
+  // update` CLI command.
+  it("accepts attachment_id omitted entirely (regression: #496)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { attachment_id: _omit, ...withoutAttachment } = validQuote;
+    const result = QuoteSchema.parse(withoutAttachment);
+    expect(result.attachment_id).toBeUndefined();
   });
 });

--- a/packages/core/src/types/quote.schema.ts
+++ b/packages/core/src/types/quote.schema.ts
@@ -13,9 +13,14 @@ export const QuoteAmountSchema = z
   })
   .strip() satisfies z.ZodType<QuoteAmount>;
 
+// Qonto's quote-endpoint docs declare `discount.type` as `[percentage, amount]`,
+// but the live `/v2/quotes` API returns `"absolute"` for fixed-amount discounts
+// (reported in #496 with raw curl evidence, 2026-05-17). The client-invoice
+// endpoint docs use `"absolute"` canonically for the same semantic. Accept all
+// three values to remain forward-compatible regardless of which docs are right.
 export const QuoteDiscountSchema = z
   .object({
-    type: z.enum(["percentage", "amount"]),
+    type: z.enum(["percentage", "absolute", "amount"]),
     value: z.string(),
     amount: QuoteAmountSchema,
     amount_cents: z.number(),
@@ -90,7 +95,10 @@ export const QuoteSchema = z
     created_at: z.string(),
     approved_at: z.string().nullable(),
     canceled_at: z.string().nullable(),
-    attachment_id: z.string().nullable(),
+    // Qonto's `Quote` schema does not list `attachment_id` in `required`,
+    // so the field may be omitted entirely (not just null). Observed in
+    // PATCH responses where the field is dropped from the payload (#496).
+    attachment_id: z.string().nullable().optional(),
     quote_url: z.string().nullable(),
     contact_email: z.string().nullable(),
     terms_and_conditions: z.string().nullable(),

--- a/packages/core/src/types/quote.ts
+++ b/packages/core/src/types/quote.ts
@@ -11,9 +11,13 @@ export interface QuoteAmount {
 
 /**
  * A discount applied to a quote or quote item.
+ *
+ * `type` accepts `"absolute"` in addition to the documented `"percentage"`
+ * and `"amount"` because the live `/v2/quotes` API returns `"absolute"` for
+ * fixed-amount discounts (reported in #496).
  */
 export interface QuoteDiscount {
-  readonly type: "percentage" | "amount";
+  readonly type: "percentage" | "absolute" | "amount";
   readonly value: string;
   readonly amount: QuoteAmount;
   readonly amount_cents: number;
@@ -92,7 +96,7 @@ export interface Quote {
   readonly created_at: string;
   readonly approved_at: string | null;
   readonly canceled_at: string | null;
-  readonly attachment_id: string | null;
+  readonly attachment_id?: string | null | undefined;
   readonly quote_url: string | null;
   readonly contact_email: string | null;
   readonly terms_and_conditions: string | null;


### PR DESCRIPTION
## Summary

Symmetric schema-alignment fixes for two docs-vs-live-API gaps on `/v2/quotes` and `/v2/client_invoices`, both reported on #496:

1. **`discount.type` enum** — extends `["percentage", "amount"]` → `["percentage", "absolute", "amount"]` on both `QuoteDiscountSchema` and `ClientInvoiceDiscountSchema`. The live `/v2/quotes` API returns `"absolute"` for fixed-amount discounts (raw curl evidence in [comment](https://github.com/alexey-pelykh/qontoctl/issues/496#issuecomment-4470471274)). The 3-value enum is forward-compat against either Qonto docs surface being authoritative.

2. **`attachment_id` optional** — relaxes `z.string().nullable()` → `z.string().nullable().optional()` on both `QuoteSchema` and `ClientInvoiceSchema`. Qonto's `Quote` and `ClientInvoice` OpenAPI schemas do not list the field in `required`, so the field MAY be absent. Observed in PATCH responses from `/v2/quotes/{id}` (#496 comment thread).

3. **Mirrored TypeScript types** in `quote.ts` and `client-invoices/types.ts` per the `satisfies z.ZodType<T>` constraint.

4. **Regression coverage** — 5 new unit tests across `quote.schema.test.ts` (3) and `client-invoices/schemas.test.ts` (2). Unit-only test strategy per project precedent (#507).

Bundled in one PR per the docs precedent (Qonto's client-invoice docs use `"absolute"` canonically — pre-emptive fix avoids a second user report).

## Test plan

- [x] `pnpm format:check` on the 6 staged files (Prettier clean)
- [x] `pnpm lint` (8/8 packages clean)
- [x] `pnpm build` (5/5 packages clean)
- [x] `pnpm test` (workspace: 1141 core + 789 cli unit tests pass)
- [x] `pnpm license-check` (100 prod deps, all allowed)
- [x] `pnpm test:e2e` — quote suites (4 files) all pass with one Qonto sandbox flake on `quotes/mcp.e2e.test.ts > updates the created quote via callTool` (HTTP 412 `quote_has_no_attachment`, passes in isolation, intermittent under suite load — Qonto sandbox state issue, not caused by this PR; baseline-equivalent to bare main)
- [x] `pnpm test:e2e` — client-invoice suites (24 cli + 16 mcp tests pass, 8 skipped)
- [x] Full `pnpm test:e2e` shows 63 baseline failures, identical to bare main (all in unrelated OAuth-gated suites like webhooks/transfers)

Fixes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)