### PR TITLE
(test) eliminate L1 silent-skip mask suite-wide + skip-reason helpers + CI regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - run: pnpm license-check
       - run: pnpm publish-check
       - run: pnpm coverage-drift-check
+      - run: pnpm silent-skip-check
       - run: pnpm test ${{ matrix.os == 'ubuntu-latest' && '-- -- --coverage' || '' }}
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "license-check": "node scripts/check-licenses.js",
     "publish-check": "node scripts/check-publish-manifest.js",
     "coverage-drift-check": "node scripts/check-coverage-drift.js",
+    "silent-skip-check": "node scripts/check-no-silent-skip.js",
     "dev": "turbo run dev"
   },
   "devDependencies": {

--- a/packages/e2e/src/attachments/cli.e2e.test.ts
+++ b/packages/e2e/src/attachments/cli.e2e.test.ts
@@ -4,7 +4,14 @@
 import { resolve } from "node:path";
 import { AttachmentSchema, UploadedAttachmentSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson } from "../helpers.js";
+import {
+  cli,
+  cliJson,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { hasApiKeyCredentials } from "../sandbox.js";
 
 interface TransactionItem {
@@ -59,9 +66,11 @@ function findTransactionWithoutAttachments(): TransactionItem | undefined {
 
 describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => {
   describe("transaction attachment list", () => {
-    it("lists attachments for a transaction and validates through schema", () => {
+    it("lists attachments for a transaction and validates through schema", (ctx) => {
       const txn = findTransactionWithAttachments();
-      if (txn === undefined) return;
+      if (txn === undefined) {
+        skipMissingFixture(ctx, "no transactions with attachments in sandbox");
+      }
 
       const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", txn.id);
       expect(Array.isArray(attachments)).toBe(true);
@@ -80,9 +89,11 @@ describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => 
   });
 
   describe("attachment show", () => {
-    it("shows attachment details by ID and validates through schema", () => {
+    it("shows attachment details by ID and validates through schema", (ctx) => {
       const txn = findTransactionWithAttachments();
-      if (txn === undefined) return;
+      if (txn === undefined) {
+        skipMissingFixture(ctx, "no transactions with attachments in sandbox");
+      }
 
       const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", txn.id);
       expect(attachments.length).toBeGreaterThan(0);
@@ -108,6 +119,7 @@ describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => 
   // `removeAllTransactionAttachments` is intentionally left to the MCP suite,
   // which has no such prompt and exercises the same core function.
   describe("attachment upload + delete round-trip", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let transactionId: string | undefined;
     let addedAttachmentId: string | undefined;
 
@@ -122,11 +134,10 @@ describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => 
       expect(typeof attachment.id).toBe("string");
     });
 
-    it("adds the fixture to a transaction via transaction attachment add", () => {
+    it("adds the fixture to a transaction via transaction attachment add", (ctx) => {
       const txn = findTransactionWithoutAttachments();
       if (txn === undefined) {
-        console.warn("[e2e] no attachment-free transaction in sandbox — skipping CRUD round-trip");
-        return;
+        skipMissingFixture(ctx, "no attachment-free transaction in sandbox for CRUD round-trip", lifecycleSkip);
       }
       transactionId = txn.id;
 
@@ -143,20 +154,24 @@ describe.skipIf(!hasApiKeyCredentials())("attachment CLI commands (e2e)", () => 
       addedAttachmentId = newest.id;
     });
 
-    it("listTransactionAttachments returns the added attachment", () => {
-      if (transactionId === undefined || addedAttachmentId === undefined) return;
+    it("listTransactionAttachments returns the added attachment", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const txnId = assertLifecycleState(transactionId, "transactionId");
+      const attId = assertLifecycleState(addedAttachmentId, "addedAttachmentId");
 
-      const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", transactionId);
-      expect(attachments.map((a) => a.id)).toContain(addedAttachmentId);
+      const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", txnId);
+      expect(attachments.map((a) => a.id)).toContain(attId);
     });
 
-    it("removes the attachment via transaction attachment remove", () => {
-      if (transactionId === undefined || addedAttachmentId === undefined) return;
+    it("removes the attachment via transaction attachment remove", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const txnId = assertLifecycleState(transactionId, "transactionId");
+      const attId = assertLifecycleState(addedAttachmentId, "addedAttachmentId");
 
-      cli("transaction", "attachment", "remove", transactionId, addedAttachmentId);
+      cli("transaction", "attachment", "remove", txnId, attId);
 
-      const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", transactionId);
-      expect(attachments.map((a) => a.id)).not.toContain(addedAttachmentId);
+      const attachments = cliJson<AttachmentItem[]>("transaction", "attachment", "list", txnId);
+      expect(attachments.map((a) => a.id)).not.toContain(attId);
     });
   });
 });

--- a/packages/e2e/src/attachments/mcp.e2e.test.ts
+++ b/packages/e2e/src/attachments/mcp.e2e.test.ts
@@ -6,7 +6,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { AttachmentSchema, UploadedAttachmentSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 /**
@@ -77,9 +84,11 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
   }
 
   describe("transaction_attachment_list", () => {
-    it("lists attachments for a transaction and validates through schema", async () => {
+    it("lists attachments for a transaction and validates through schema", async (ctx) => {
       const txn = await findTransactionWithAttachments();
-      if (txn === undefined) return;
+      if (txn === undefined) {
+        skipMissingFixture(ctx, "no transactions with attachments in sandbox");
+      }
 
       const result = await client.callTool({
         name: "transaction_attachment_list",
@@ -104,9 +113,11 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
   });
 
   describe("attachment_show", () => {
-    it("shows attachment details by ID and validates through schema", async () => {
+    it("shows attachment details by ID and validates through schema", async (ctx) => {
       const txn = await findTransactionWithAttachments();
-      if (txn === undefined) return;
+      if (txn === undefined) {
+        skipMissingFixture(ctx, "no transactions with attachments in sandbox");
+      }
 
       // First get the attachment list to find a valid ID
       const listResult = await client.callTool({
@@ -162,6 +173,7 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
   // prompt, whereas the CLI's all-remove variant does (see cli.e2e.test.ts
   // comment); this is the canonical site for that function's coverage.
   describe("attachment upload + delete round-trip (MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let transactionId: string | undefined;
     let addedAttachmentId: string | undefined;
 
@@ -181,11 +193,10 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
       expect(typeof parsed.id).toBe("string");
     });
 
-    it("adds the fixture to a transaction via transaction_attachment_add", async () => {
+    it("adds the fixture to a transaction via transaction_attachment_add", async (ctx) => {
       const txn = await findTransactionWithoutAttachments();
       if (txn === undefined) {
-        console.warn("[e2e] no attachment-free transaction in sandbox — skipping CRUD round-trip");
-        return;
+        skipMissingFixture(ctx, "no attachment-free transaction in sandbox for CRUD round-trip", lifecycleSkip);
       }
       transactionId = txn.id;
 
@@ -210,61 +221,66 @@ describe.skipIf(!hasApiKeyCredentials())("attachment MCP tools (e2e)", () => {
       addedAttachmentId = newest.id;
     });
 
-    it("transaction_attachment_list returns the added attachment", async () => {
-      if (transactionId === undefined || addedAttachmentId === undefined) return;
+    it("transaction_attachment_list returns the added attachment", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const txnId = assertLifecycleState(transactionId, "transactionId");
+      const attId = assertLifecycleState(addedAttachmentId, "addedAttachmentId");
 
       const result = await client.callTool({
         name: "transaction_attachment_list",
-        arguments: { transaction_id: transactionId },
+        arguments: { transaction_id: txnId },
       });
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as AttachmentListResponse;
-      expect(parsed.attachments.map((a) => a.id)).toContain(addedAttachmentId);
+      expect(parsed.attachments.map((a) => a.id)).toContain(attId);
     });
 
-    it("removes the specific attachment via transaction_attachment_remove", async () => {
-      if (transactionId === undefined || addedAttachmentId === undefined) return;
+    it("removes the specific attachment via transaction_attachment_remove", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const txnId = assertLifecycleState(transactionId, "transactionId");
+      const attId = assertLifecycleState(addedAttachmentId, "addedAttachmentId");
 
       const removeResult = await client.callTool({
         name: "transaction_attachment_remove",
-        arguments: { transaction_id: transactionId, attachment_id: addedAttachmentId },
+        arguments: { transaction_id: txnId, attachment_id: attId },
       });
       expect(removeResult.isError).toBeFalsy();
 
       const listResult = await client.callTool({
         name: "transaction_attachment_list",
-        arguments: { transaction_id: transactionId },
+        arguments: { transaction_id: txnId },
       });
       const parsed = JSON.parse(firstTextFromMcpResult(listResult)) as AttachmentListResponse;
-      expect(parsed.attachments.map((a) => a.id)).not.toContain(addedAttachmentId);
+      expect(parsed.attachments.map((a) => a.id)).not.toContain(attId);
     });
 
-    it("removes all attachments via transaction_attachment_remove (cleanup + coverage)", async () => {
-      if (transactionId === undefined) return;
+    it("removes all attachments via transaction_attachment_remove (cleanup + coverage)", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const txnId = assertLifecycleState(transactionId, "transactionId");
 
       // Re-seed an attachment so `removeAllTransactionAttachments` has something
       // to remove — this doubles as the function's own coverage point per AC.
       const addResult = await client.callTool({
         name: "transaction_attachment_add",
-        arguments: { transaction_id: transactionId, file_path: PDF_FIXTURE_PATH },
+        arguments: { transaction_id: txnId, file_path: PDF_FIXTURE_PATH },
       });
       expect(addResult.isError).toBeFalsy();
 
       const beforeResult = await client.callTool({
         name: "transaction_attachment_list",
-        arguments: { transaction_id: transactionId },
+        arguments: { transaction_id: txnId },
       });
       const before = JSON.parse(firstTextFromMcpResult(beforeResult)) as AttachmentListResponse;
       expect(before.attachments.length).toBeGreaterThan(0);
 
       const removeAllResult = await client.callTool({
         name: "transaction_attachment_remove",
-        arguments: { transaction_id: transactionId },
+        arguments: { transaction_id: txnId },
       });
       expect(removeAllResult.isError).toBeFalsy();
 
       const afterResult = await client.callTool({
         name: "transaction_attachment_list",
-        arguments: { transaction_id: transactionId },
+        arguments: { transaction_id: txnId },
       });
       const after = JSON.parse(firstTextFromMcpResult(afterResult)) as AttachmentListResponse;
       expect(after.attachments.length).toBe(0);

--- a/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/cli.e2e.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { BulkTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { CLI_PATH, cli, cliJson, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const execFileAsync = promisify(execFile);
@@ -69,13 +69,17 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () =
   // process must call `sca-session mock-decision <token> allow` to unblock
   // polling. Skip when the staging token (sandbox routing) is absent.
   describe.skipIf(!hasStagingToken())("bulk-transfer create (sandbox SCA)", () => {
-    it("creates a bulk transfer from a JSON file with SCA mock-decision orchestration", async () => {
+    it("creates a bulk transfer from a JSON file with SCA mock-decision orchestration", async (ctx) => {
       const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
-      if (beneficiaries.length === 0) return;
+      if (beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for bulk-transfer create");
+      }
       const beneficiaryId = (beneficiaries[0] as { id: string }).id;
 
       const accounts = cliJson<{ id: string }[]>("account", "list");
-      if (accounts.length === 0) return;
+      if (accounts.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for bulk-transfer create");
+      }
       const accountId = (accounts[0] as { id: string }).id;
 
       const tmpDir = mkdtempSync(join(tmpdir(), "qontoctl-e2e-"));
@@ -176,9 +180,11 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer CLI commands (e2e)", () =
   });
 
   describe("bulk-transfer show", () => {
-    it("shows a bulk transfer by ID", () => {
+    it("shows a bulk transfer by ID", (ctx) => {
       const bulkTransfers = cliJson<BulkTransferRecord[]>("bulk-transfer", "list", "--no-paginate");
-      if (bulkTransfers.length === 0) return;
+      if (bulkTransfers.length === 0) {
+        skipMissingFixture(ctx, "no bulk transfers in sandbox to resolve an id for bulk-transfer show");
+      }
 
       const first = bulkTransfers[0] as BulkTransferRecord;
 

--- a/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/bulk-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { BulkTransferListResponseSchema, BulkTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 /**
@@ -98,7 +98,7 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
       }
     }
 
-    it("creates a bulk transfer with inline SCA mock-decision approval", async () => {
+    it("creates a bulk transfer with inline SCA mock-decision approval", async (ctx) => {
       const beneficiaryResult = await client.callTool({
         name: "beneficiary_list",
         arguments: { per_page: 1 },
@@ -106,12 +106,16 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
       const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
-      if (beneficiaryParsed.beneficiaries.length === 0) return;
+      if (beneficiaryParsed.beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for bulk_transfer_create");
+      }
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
       const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
-      if (accountParsed.length === 0) return;
+      if (accountParsed.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for bulk_transfer_create");
+      }
       const bankAccountId = (accountParsed[0] as { id: string }).id;
 
       // Kick off the tool call (blocks while CLI polls SCA session).
@@ -181,16 +185,18 @@ describe.skipIf(!hasOAuthCredentials())("bulk-transfer MCP tools (e2e)", () => {
   });
 
   describe("bulk_transfer_show", () => {
-    it("shows a bulk transfer by ID", async () => {
+    it("shows a bulk transfer by ID", async (ctx) => {
       const listResult = await client.callTool({
         name: "bulk_transfer_list",
         arguments: { per_page: 1 },
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "bulk_transfer_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as BulkTransferListResponse;
       const first = listParsed.bulk_transfers[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no bulk transfers in sandbox to resolve an id for bulk_transfer_show");
+      }
 
       const result = await client.callTool({
         name: "bulk_transfer_show",

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { CardSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { CLI_PATH, cli, cliJson, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 import { SCA_POLL_URL_RE } from "../sca-helpers.js";
 
@@ -64,11 +64,13 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
       }
     });
 
-    it("outputs CSV format", () => {
+    it("outputs CSV format", (ctx) => {
       // CSV formatter emits no output for an empty list, so there is no header
       // row to assert against — skip when the sandbox has zero cards.
       const cards = cliJson<CardItem[]>("card", "list", "--per-page", "5");
-      if (cards[0] === undefined) return;
+      if (cards[0] === undefined) {
+        skipMissingFixture(ctx, "no cards in sandbox for CSV output assertion");
+      }
 
       const output = cli("card", "list", "--output", "csv", "--per-page", "5");
       const lines = output.trim().split("\n");
@@ -78,11 +80,13 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
       expect(header).toContain("status");
     });
 
-    it("outputs YAML format", () => {
+    it("outputs YAML format", (ctx) => {
       // YAML formatter emits `[]` for an empty list, so there is no `id:`
       // field to assert against — skip when the sandbox has zero cards.
       const cards = cliJson<CardItem[]>("card", "list", "--per-page", "2");
-      if (cards[0] === undefined) return;
+      if (cards[0] === undefined) {
+        skipMissingFixture(ctx, "no cards in sandbox for YAML output assertion");
+      }
 
       const output = cli("card", "list", "--output", "yaml", "--per-page", "2");
       expect(output).toContain("id:");
@@ -90,12 +94,14 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
   });
 
   describe("card show", () => {
-    it("shows a card by ID", () => {
+    it("shows a card by ID", (ctx) => {
       // Pick the first card from the list as a known-good ID. If the org has
       // no cards in the sandbox, skip — we cannot exercise show without one.
       const cards = cliJson<CardItem[]>("card", "list", "--per-page", "1");
       const first = cards[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no cards in sandbox to resolve an id for card show");
+      }
 
       const card = cliJson<CardItem>("card", "show", first.id);
       CardSchema.parse(card);
@@ -104,10 +110,12 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
       expect(card).toHaveProperty("card_level");
     });
 
-    it("supports table output", () => {
+    it("supports table output", (ctx) => {
       const cards = cliJson<CardItem[]>("card", "list", "--per-page", "1");
       const first = cards[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no cards in sandbox to resolve an id for card show table output");
+      }
 
       const output = cli("card", "show", first.id);
       expect(output).toContain(first.id);
@@ -115,7 +123,7 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
   });
 
   describe("card iframe-url", () => {
-    it("returns a secure iframe URL for an existing card", () => {
+    it("returns a secure iframe URL for an existing card", (ctx) => {
       // Pick the first non-virtual live card — the data_view endpoint
       // returns 400 for virtual cards in the sandbox (empirical 2026-05-12;
       // probed across 5 virtual cards, all returning `400 unknown`). The
@@ -127,7 +135,9 @@ describe.skipIf(!hasOAuthCredentials())("card CLI commands (e2e)", () => {
       // before #556 and the no-op semantics are preserved here.
       const cards = cliJson<CardItem[]>("card", "list", "--status", "live");
       const first = cards.find((c) => c.card_level !== "virtual" && c.card_level !== "virtual_partner");
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no non-virtual live card in sandbox for iframe-url");
+      }
 
       const result = cliJson<{ iframe_url: string }>("card", "iframe-url", first.id);
       expect(result).toHaveProperty("iframe_url");

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CardListResponseSchema, CardSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 import { SCA_PENDING_TOKEN_RE } from "../sca-helpers.js";
 
@@ -49,13 +49,13 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
   });
 
   describe("card_list", () => {
-    it("returns a list of cards with expected structure", async () => {
+    it("returns a list of cards with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "card_list",
         arguments: {},
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "card_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as CardListResponse;
       CardListResponseSchema.parse(parsed);
@@ -64,26 +64,26 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
       expect(Array.isArray(parsed.cards)).toBe(true);
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "card_list",
         arguments: { per_page: 2, page: 1 },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "card_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as CardListResponse;
       expect(parsed.cards.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
 
-    it("filters by status", async () => {
+    it("filters by status", async (ctx) => {
       const result = await client.callTool({
         name: "card_list",
         arguments: { statuses: ["live"] },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "card_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as CardListResponse;
       for (const c of parsed.cards) {
@@ -93,16 +93,18 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
   });
 
   describe("card_show", () => {
-    it("shows a card by ID", async () => {
+    it("shows a card by ID", async (ctx) => {
       const listResult = await client.callTool({
         name: "card_list",
         arguments: { per_page: 1 },
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "card_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as CardListResponse;
       const first = listParsed.cards[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no cards in sandbox to resolve an id for card_show");
+      }
 
       const result = await client.callTool({
         name: "card_show",
@@ -119,13 +121,13 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
   });
 
   describe("card_appearances", () => {
-    it("returns available card appearances", async () => {
+    it("returns available card appearances", async (ctx) => {
       const result = await client.callTool({
         name: "card_appearances",
         arguments: {},
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "card_appearances");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
@@ -133,7 +135,7 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
   });
 
   describe("card_iframe_url", () => {
-    it("returns a secure iframe URL for an existing card", async () => {
+    it("returns a secure iframe URL for an existing card", async (ctx) => {
       // Pick the first non-virtual live card — data_view returns 400 for
       // virtual cards in the sandbox (empirical 2026-05-12). Skip cleanly
       // when no physical card is available; mirrors the CLI counterpart.
@@ -141,7 +143,7 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
         name: "card_list",
         arguments: { statuses: ["live"] },
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "card_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as CardListResponse;
       const first = listParsed.cards.find(
@@ -149,7 +151,9 @@ describe.skipIf(!hasOAuthCredentials())("card MCP tools (e2e)", () => {
           (c as { card_level?: string }).card_level !== "virtual" &&
           (c as { card_level?: string }).card_level !== "virtual_partner",
       );
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no non-virtual live card in sandbox for iframe_url");
+      }
 
       const result = await client.callTool({
         name: "card_iframe_url",

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -6,7 +6,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientInvoiceListResponseSchema, ClientInvoiceSchema, ClientInvoiceUploadSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfToolError,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 /**
@@ -36,14 +44,15 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
   });
 
   describe("client_invoice_list", () => {
-    it("returns a list of client invoices with expected structure", async () => {
+    it("returns a list of client invoices with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "client_invoice_list",
         arguments: {},
       });
 
-      // Sandbox may not have client invoices — skip gracefully on tool error
-      if (result.isError === true) return;
+      // Sandbox may not expose the client-invoices module — surface as visible
+      // feature-not-supported skip (#605).
+      skipIfToolError(result, ctx, "feature-not-supported", "client_invoice_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         client_invoices: unknown[];
@@ -61,13 +70,13 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
     // value Qonto actually returns) and accepted `pending` (which Qonto's API
     // silently treats as no-match). This asserts the canonical value passes the
     // tool's input schema AND the API accepts it.
-    it("supports status: 'unpaid' (canonical Qonto value)", async () => {
+    it("supports status: 'unpaid' (canonical Qonto value)", async (ctx) => {
       const result = await client.callTool({
         name: "client_invoice_list",
         arguments: { status: "unpaid" },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "client_invoice_list (status=unpaid)");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         client_invoices: unknown[];
@@ -79,18 +88,18 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
   });
 
   describe("client_invoice_show", () => {
-    it("returns details for a specific client invoice", async () => {
+    it("returns details for a specific client invoice", async (ctx) => {
       const listResult = await client.callTool({
         name: "client_invoice_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "client_invoice_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         client_invoices: { id: string }[];
       };
       if (listParsed.client_invoices.length === 0) {
-        return;
+        skipMissingFixture(ctx, "no client invoices in sandbox to resolve an id for client_invoice_show");
       }
 
       const invoiceId = (listParsed.client_invoices[0] as { id: string }).id;
@@ -121,22 +130,23 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
   // round-trip, then cleans up by deleting the invoice (which implicitly
   // removes the upload — there is no upload-delete endpoint).
   describe("client_invoice upload + retrieval round-trip (MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdInvoiceId: string | undefined;
     let uploadedFileId: string | undefined;
 
-    it("creates a draft invoice as a precondition for upload", async () => {
+    it("creates a draft invoice as a precondition for upload", async (ctx) => {
       // Fetch a client ID from existing clients (mirrors the CLI lifecycle).
       const clientListResult = await client.callTool({
         name: "client_list",
         arguments: {},
       });
-      if (clientListResult.isError === true) return;
+      skipIfToolError(clientListResult, ctx, "feature-not-supported", "client_list", lifecycleSkip);
 
       const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
         clients: { id: string }[];
       };
       if (clientsParsed.clients.length === 0) {
-        return;
+        skipMissingFixture(ctx, "no clients in sandbox to seed client_invoice_create", lifecycleSkip);
       }
 
       const clientId = (clientsParsed.clients[0] as { id: string }).id;
@@ -163,8 +173,16 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       });
 
       // Invoice creation may fail if the organization lacks required setup
-      // (e.g., IBAN not configured) — skip downstream lifecycle when it does.
-      if (createResult.isError === true) return;
+      // (e.g., IBAN not configured) — surface as visible feature-not-supported
+      // skip and propagate to downstream tests via the lifecycle carrier
+      // (see #606 for the L3 sandbox-precondition catalog, #605).
+      skipIfToolError(
+        createResult,
+        ctx,
+        "feature-not-supported",
+        "client_invoice_create requires IBAN — see #606",
+        lifecycleSkip,
+      );
 
       const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id");
@@ -172,12 +190,13 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       createdInvoiceId = parsed["id"] as string;
     });
 
-    it("uploads a PDF to the created invoice via client_invoice_upload", async () => {
-      if (createdInvoiceId === undefined) return;
+    it("uploads a PDF to the created invoice via client_invoice_upload", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdInvoiceId, "createdInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_upload",
-        arguments: { id: createdInvoiceId, file_path: PDF_FIXTURE_PATH },
+        arguments: { id, file_path: PDF_FIXTURE_PATH },
       });
 
       expect(result.isError).toBeFalsy();
@@ -190,30 +209,33 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       uploadedFileId = parsed["id"] as string;
     });
 
-    it("retrieves the upload via client_invoice_upload_show", async () => {
-      if (createdInvoiceId === undefined || uploadedFileId === undefined) return;
+    it("retrieves the upload via client_invoice_upload_show", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdInvoiceId, "createdInvoiceId");
+      const uploadId = assertLifecycleState(uploadedFileId, "uploadedFileId");
 
       const result = await client.callTool({
         name: "client_invoice_upload_show",
-        arguments: { id: createdInvoiceId, upload_id: uploadedFileId },
+        arguments: { id, upload_id: uploadId },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       ClientInvoiceUploadSchema.parse(parsed);
-      expect(parsed).toHaveProperty("id", uploadedFileId);
+      expect(parsed).toHaveProperty("id", uploadId);
       expect(parsed).toHaveProperty("file_name", "tiny.pdf");
       expect(parsed).toHaveProperty("file_content_type");
       expect(parsed).toHaveProperty("url");
       expect(parsed).toHaveProperty("created_at");
     });
 
-    it("deletes the created invoice (cleanup)", async () => {
-      if (createdInvoiceId === undefined) return;
+    it("deletes the created invoice (cleanup)", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdInvoiceId, "createdInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_delete",
-        arguments: { id: createdInvoiceId },
+        arguments: { id },
       });
       expect(result.isError).toBeFalsy();
     });
@@ -234,20 +256,21 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
   // one canceled invoice into the test org (accepted trade-off per #449
   // Group 5).
   describe("client_invoice lifecycle state transitions (#457, MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let lifecycleInvoiceId: string | undefined;
 
-    it("creates a draft invoice as the lifecycle entry point", async () => {
+    it("creates a draft invoice as the lifecycle entry point", async (ctx) => {
       const clientListResult = await client.callTool({
         name: "client_list",
         arguments: {},
       });
-      if (clientListResult.isError === true) return;
+      skipIfToolError(clientListResult, ctx, "feature-not-supported", "client_list", lifecycleSkip);
 
       const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
         clients: { id: string }[];
       };
       if (clientsParsed.clients.length === 0) {
-        return;
+        skipMissingFixture(ctx, "no clients in sandbox to seed client_invoice_create", lifecycleSkip);
       }
 
       const clientId = (clientsParsed.clients[0] as { id: string }).id;
@@ -274,8 +297,16 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       });
 
       // Invoice creation may fail if the organization lacks required setup
-      // (e.g., IBAN not configured) — skip downstream lifecycle when it does.
-      if (createResult.isError === true) return;
+      // (e.g., IBAN not configured) — surface as visible feature-not-supported
+      // skip and propagate to downstream lifecycle steps via the carrier
+      // (see #606 for the L3 sandbox-precondition catalog, #605).
+      skipIfToolError(
+        createResult,
+        ctx,
+        "feature-not-supported",
+        "client_invoice_create requires IBAN — see #606",
+        lifecycleSkip,
+      );
 
       const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
       const invoice = ClientInvoiceSchema.parse(parsed);
@@ -283,65 +314,69 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
       lifecycleInvoiceId = invoice.id;
     });
 
-    it("transitions draft → unpaid via client_invoice_finalize", async () => {
-      if (lifecycleInvoiceId === undefined) return;
+    it("transitions draft → unpaid via client_invoice_finalize", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(lifecycleInvoiceId, "lifecycleInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_finalize",
-        arguments: { id: lifecycleInvoiceId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       const invoice = ClientInvoiceSchema.parse(parsed);
-      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.id).toBe(id);
       expect(invoice.status).toBe("unpaid");
       // Finalize assigns the invoice number — pre-finalize this is null.
       expect(invoice.invoice_number).not.toBeNull();
     });
 
-    it("transitions unpaid → paid via client_invoice_mark_paid", async () => {
-      if (lifecycleInvoiceId === undefined) return;
+    it("transitions unpaid → paid via client_invoice_mark_paid", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(lifecycleInvoiceId, "lifecycleInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_mark_paid",
-        arguments: { id: lifecycleInvoiceId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       const invoice = ClientInvoiceSchema.parse(parsed);
-      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.id).toBe(id);
       expect(invoice.status).toBe("paid");
     });
 
-    it("transitions paid → unpaid via client_invoice_unmark_paid", async () => {
-      if (lifecycleInvoiceId === undefined) return;
+    it("transitions paid → unpaid via client_invoice_unmark_paid", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(lifecycleInvoiceId, "lifecycleInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_unmark_paid",
-        arguments: { id: lifecycleInvoiceId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       const invoice = ClientInvoiceSchema.parse(parsed);
-      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.id).toBe(id);
       expect(invoice.status).toBe("unpaid");
     });
 
-    it("transitions unpaid → canceled via client_invoice_cancel (terminal)", async () => {
-      if (lifecycleInvoiceId === undefined) return;
+    it("transitions unpaid → canceled via client_invoice_cancel (terminal)", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(lifecycleInvoiceId, "lifecycleInvoiceId");
 
       const result = await client.callTool({
         name: "client_invoice_cancel",
-        arguments: { id: lifecycleInvoiceId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       const invoice = ClientInvoiceSchema.parse(parsed);
-      expect(invoice.id).toBe(lifecycleInvoiceId);
+      expect(invoice.id).toBe(id);
       expect(invoice.status).toBe("canceled");
       // Terminal state — no cleanup; canceled invoices cannot be deleted.
     });
@@ -356,20 +391,21 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
   describe.skipIf(process.env["QONTOCTL_E2E_SEND_EMAIL"] !== "true")(
     "client_invoice_send (#457 AC #3, MCP, opt-in via QONTOCTL_E2E_SEND_EMAIL=true)",
     () => {
+      const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
       let sendInvoiceId: string | undefined;
 
-      it("creates a draft invoice as a send precondition", async () => {
+      it("creates a draft invoice as a send precondition", async (ctx) => {
         const clientListResult = await client.callTool({
           name: "client_list",
           arguments: {},
         });
-        if (clientListResult.isError === true) return;
+        skipIfToolError(clientListResult, ctx, "feature-not-supported", "client_list", lifecycleSkip);
 
         const clientsParsed = JSON.parse(firstTextFromMcpResult(clientListResult)) as {
           clients: { id: string }[];
         };
         if (clientsParsed.clients.length === 0) {
-          return;
+          skipMissingFixture(ctx, "no clients in sandbox to seed client_invoice_create", lifecycleSkip);
         }
 
         const clientId = (clientsParsed.clients[0] as { id: string }).id;
@@ -395,7 +431,13 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
           },
         });
 
-        if (createResult.isError === true) return;
+        skipIfToolError(
+          createResult,
+          ctx,
+          "feature-not-supported",
+          "client_invoice_create requires IBAN — see #606",
+          lifecycleSkip,
+        );
 
         const parsed = JSON.parse(firstTextFromMcpResult(createResult)) as Record<string, unknown>;
         expect(parsed).toHaveProperty("id");
@@ -403,45 +445,48 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
         sendInvoiceId = parsed["id"] as string;
       });
 
-      it("finalizes the draft to make it sendable", async () => {
-        if (sendInvoiceId === undefined) return;
+      it("finalizes the draft to make it sendable", async (ctx) => {
+        skipIfUpstreamSkipped(lifecycleSkip, ctx);
+        const id = assertLifecycleState(sendInvoiceId, "sendInvoiceId");
 
         const result = await client.callTool({
           name: "client_invoice_finalize",
-          arguments: { id: sendInvoiceId },
+          arguments: { id },
         });
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
-        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("id", id);
         expect(parsed).toHaveProperty("status", "unpaid");
       });
 
-      it("sends the finalized invoice to the client via email", async () => {
-        if (sendInvoiceId === undefined) return;
+      it("sends the finalized invoice to the client via email", async (ctx) => {
+        skipIfUpstreamSkipped(lifecycleSkip, ctx);
+        const id = assertLifecycleState(sendInvoiceId, "sendInvoiceId");
 
         const result = await client.callTool({
           name: "client_invoice_send",
-          arguments: { id: sendInvoiceId },
+          arguments: { id },
         });
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
         expect(parsed).toHaveProperty("sent", true);
-        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("id", id);
       });
 
-      it("cancels the sent invoice (cleanup)", async () => {
-        if (sendInvoiceId === undefined) return;
+      it("cancels the sent invoice (cleanup)", async (ctx) => {
+        skipIfUpstreamSkipped(lifecycleSkip, ctx);
+        const id = assertLifecycleState(sendInvoiceId, "sendInvoiceId");
 
         const result = await client.callTool({
           name: "client_invoice_cancel",
-          arguments: { id: sendInvoiceId },
+          arguments: { id },
         });
 
         expect(result.isError).toBeFalsy();
         const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
-        expect(parsed).toHaveProperty("id", sendInvoiceId);
+        expect(parsed).toHaveProperty("id", id);
         expect(parsed).toHaveProperty("status", "canceled");
       });
     },

--- a/packages/e2e/src/clients/mcp.e2e.test.ts
+++ b/packages/e2e/src/clients/mcp.e2e.test.ts
@@ -5,7 +5,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ClientListResponseSchema, ClientSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfToolError,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
@@ -29,14 +37,15 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
   });
 
   describe("client_list", () => {
-    it("returns a list of clients with expected structure", async () => {
+    it("returns a list of clients with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "client_list",
         arguments: {},
       });
 
-      // Sandbox may not have clients — skip gracefully on tool error
-      if (result.isError === true) return;
+      // Sandbox may not expose the clients module — surface as visible
+      // feature-not-supported skip (#605).
+      skipIfToolError(result, ctx, "feature-not-supported", "client_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         clients: unknown[];
@@ -50,18 +59,18 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
   });
 
   describe("client_show", () => {
-    it("returns details for a specific client", async () => {
+    it("returns details for a specific client", async (ctx) => {
       const listResult = await client.callTool({
         name: "client_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "client_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         clients: { id: string }[];
       };
       if (listParsed.clients.length === 0) {
-        return;
+        skipMissingFixture(ctx, "no clients in sandbox to resolve an id for client_show");
       }
 
       const clientId = (listParsed.clients[0] as { id: string }).id;
@@ -98,6 +107,7 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
   // operations through callTool, asserting the MCP wrapper contract on top
   // of the underlying API contract.
   describe("client CRUD lifecycle (MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdClientId: string | undefined;
 
     it("creates a client via callTool", async () => {
@@ -111,7 +121,10 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
         },
       });
 
-      if (result.isError === true) return;
+      // Suite is api-key-gated, and api-key supports clients. A create error
+      // here is the #496 class — assert loudly rather than silently mask
+      // (was: `if (result.isError === true) return;`, removed under #605).
+      expect(result.isError, `client_create failed: ${firstTextFromMcpResult(result)}`).toBeFalsy();
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       ClientSchema.parse(parsed);
@@ -120,34 +133,36 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client tools (e2e)", () => {
       createdClientId = parsed["id"] as string;
     });
 
-    it("updates the created client via callTool", async () => {
-      if (createdClientId === undefined) return;
+    it("updates the created client via callTool", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdClientId, "createdClientId");
 
       const result = await client.callTool({
         name: "client_update",
         arguments: {
-          id: createdClientId,
+          id,
           name: "E2E MCP Updated Client",
         },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("id", createdClientId);
+      expect(parsed).toHaveProperty("id", id);
     });
 
-    it("deletes the created client via callTool", async () => {
-      if (createdClientId === undefined) return;
+    it("deletes the created client via callTool", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdClientId, "createdClientId");
 
       const result = await client.callTool({
         name: "client_delete",
-        arguments: { id: createdClientId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("deleted", true);
-      expect(parsed).toHaveProperty("id", createdClientId);
+      expect(parsed).toHaveProperty("id", id);
     });
   });
 });

--- a/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
+++ b/packages/e2e/src/commands/mcp-payment-links.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { PaymentLinkConnectionSchema, PaymentLinkListResponseSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 /**
@@ -70,7 +70,7 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
   });
 
   describe("payment_link_show", () => {
-    it("returns details for a specific payment link", async () => {
+    it("returns details for a specific payment link", async (ctx) => {
       const listResult = await client.callTool({
         name: "payment_link_list",
         arguments: {},
@@ -80,7 +80,9 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         payment_links: { id: string }[];
       };
-      if (listParsed.payment_links.length === 0) return; // No payment links in sandbox
+      if (listParsed.payment_links.length === 0) {
+        skipMissingFixture(ctx, "no payment links in sandbox to resolve an id for payment_link_show");
+      }
 
       const firstLink = listParsed.payment_links[0] as { id: string };
       const result = await client.callTool({
@@ -97,7 +99,7 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
   });
 
   describe("payment_link_payments", () => {
-    it("returns payments for a payment link", async () => {
+    it("returns payments for a payment link", async (ctx) => {
       const listResult = await client.callTool({
         name: "payment_link_list",
         arguments: {},
@@ -107,7 +109,9 @@ describe.skipIf(!hasOAuthCredentials())("MCP payment link tools (e2e)", () => {
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         payment_links: { id: string }[];
       };
-      if (listParsed.payment_links.length === 0) return; // No payment links in sandbox
+      if (listParsed.payment_links.length === 0) {
+        skipMissingFixture(ctx, "no payment links in sandbox to resolve an id for payment_link_payments");
+      }
 
       const firstLink = listParsed.payment_links[0] as { id: string };
       const result = await client.callTool({

--- a/packages/e2e/src/commands/payment-link.e2e.test.ts
+++ b/packages/e2e/src/commands/payment-link.e2e.test.ts
@@ -3,7 +3,7 @@
 
 import { PaymentLinkConnectionSchema, PaymentLinkSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cliJson, cliRaw, qontoHttpStatus, SKIP, skipIfNotFound } from "../helpers.js";
+import { cliJson, cliRaw, qontoHttpStatus, SKIP, skipIfNotFound, skipMissingFixture } from "../helpers.js";
 import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
@@ -35,11 +35,13 @@ describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
   });
 
   describe("payment-link show", () => {
-    it("shows payment link details", () => {
+    it("shows payment link details", (ctx) => {
       const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
       if (stdout === SKIP) return;
       const links = JSON.parse(stdout) as { id: string }[];
-      if (links.length === 0) return; // No payment links in sandbox
+      if (links.length === 0) {
+        skipMissingFixture(ctx, "no payment links in sandbox to resolve an id for payment-link show");
+      }
 
       const firstLink = links[0] as { id: string };
       const output = cliJson<unknown>("payment-link", "show", firstLink.id);
@@ -54,11 +56,13 @@ describe.skipIf(!hasOAuthCredentials())("payment-link commands (e2e)", () => {
   });
 
   describe("payment-link payments", () => {
-    it("lists payments for a payment link", () => {
+    it("lists payments for a payment link", (ctx) => {
       const stdout = skipIfNotFound("--output", "json", "payment-link", "list");
       if (stdout === SKIP) return;
       const links = JSON.parse(stdout) as { id: string }[];
-      if (links.length === 0) return; // No payment links in sandbox
+      if (links.length === 0) {
+        skipMissingFixture(ctx, "no payment links in sandbox to resolve an id for payment-link payments");
+      }
 
       const firstLink = links[0] as { id: string };
       const parsed = cliJson<unknown[]>("payment-link", "payments", firstLink.id);

--- a/packages/e2e/src/helpers.ts
+++ b/packages/e2e/src/helpers.ts
@@ -3,7 +3,7 @@
 
 import { execFileSync, type ExecFileSyncOptions } from "node:child_process";
 import { resolve } from "node:path";
-import { expect } from "vitest";
+import { expect, type TestContext } from "vitest";
 import { cliEnv } from "./sandbox.js";
 
 /**
@@ -250,4 +250,262 @@ export function firstTextFromMcpResult(result: { content: unknown }): string {
   const entry = content[0] as McpTextContent;
   expect(entry.type).toBe("text");
   return entry.text;
+}
+
+// ---------------------------------------------------------------------------
+// Visible-skip helpers (R-FV-1…R-FV-5, R-SR-1, R-SR-2 — see #605, epic #603,
+// `docs/designs/e2e-test-reliability.md` §6.1).
+//
+// The pre-#605 suite used a two-stage silent mask — `if (result.isError ===
+// true) return;` swallowed tool errors, leaving the CRUD chain's shared
+// `createdId` undefined, then `if (createdId === undefined) return;`
+// swallowed every downstream test. Three semantically distinct outcomes
+// ("couldn't execute", "executed and found a bug", "executed correctly")
+// collapsed into one green dot. This pattern hid #496 for ~2 weeks.
+//
+// The helpers below replace the silent pattern with *visible* skips —
+// every non-execution surfaces in the vitest report with a recorded reason
+// drawn from the {@link SkipKind} taxonomy. The CI guard
+// `scripts/check-no-silent-skip.js` bans reintroduction of the raw return.
+//
+// Deviation from design §6.1 (documented for reviewers): the design sketched
+// helpers as `(...): boolean` returning a "should-stop" flag for the caller
+// to `return` on. Vitest's `ctx.skip(reason)` actually THROWS a
+// `PendingError` (verified against @vitest/runner@4.1.1
+// `chunk-artifact.js:2349-2357`), so the `if (helper(...)) return;`
+// indirection is impossible without re-implementing the skip mechanism. The
+// helpers below throw via `ctx.skip(...)` and set the optional lifecycle
+// carrier BEFORE the throw — preserving the design's
+// lifecycle-propagation intent at the cost of one syntactic indirection.
+// ---------------------------------------------------------------------------
+
+/**
+ * Triage taxonomy for E2E test skips (R-SR-2). Every visible skip carries
+ * one of these prefixes in its reason string, enabling future trend
+ * analysis (e.g. "% of runs that skipped due to sandbox preconditions").
+ *
+ * - `feature-not-supported` — the Qonto sandbox does not expose the
+ *   feature this test exercises (commonly: 404 on `*_list`). The CLI/MCP
+ *   surface is presumed correct; the test cannot reach it.
+ * - `sandbox-precondition` — the sandbox accepts the call shape but the
+ *   resource is in a state that violates an undocumented precondition
+ *   (commonly: 412 on a `*_update` that requires a related entity first).
+ *   These feed the L3 catalog tracked under epic #603 (Wave B / #606).
+ * - `missing-fixture` — a list returned successfully but contained zero
+ *   items, so the test has no seed data to exercise its scenario.
+ *   Distinct from `feature-not-supported`: the feature works; the org is
+ *   empty.
+ */
+export type SkipKind = "feature-not-supported" | "sandbox-precondition" | "missing-fixture";
+
+/**
+ * Shared, mutable record that propagates a skip reason through a CRUD
+ * lifecycle `describe` block. The first test in the chain populates
+ * `reason` (via {@link skipIfToolError}'s `carrier` parameter or directly);
+ * subsequent tests check it via {@link skipIfUpstreamSkipped} and skip
+ * themselves with the same reason prefixed by `upstream-skipped:`.
+ *
+ * Construct one per chain at module scope inside the enclosing `describe`:
+ *
+ * ```ts
+ * describe("quote CRUD lifecycle", () => {
+ *   const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
+ *   let createdQuoteId: string | undefined;
+ *
+ *   it("creates", async (ctx) => {
+ *     skipIfToolError(listResult, ctx, "feature-not-supported", "quote_list", lifecycleSkip);
+ *     // ...
+ *   });
+ *
+ *   it("updates", async (ctx) => {
+ *     skipIfUpstreamSkipped(lifecycleSkip, ctx);
+ *     // ...
+ *   });
+ * });
+ * ```
+ *
+ * Sequential E2E execution (`fileParallelism: false` in
+ * `vitest.e2e.config.ts`) guarantees the chain runs in declaration order
+ * within a single worker — no concurrency guards needed.
+ */
+export interface LifecycleSkipCarrier {
+  reason: string | undefined;
+}
+
+/**
+ * Tool-result shape with an `isError` flag (MCP `CallToolResult`-compatible).
+ * Helpers below accept this loose contract so they apply to both MCP
+ * `client.callTool` results and any other shape that signals errors via
+ * boolean.
+ */
+interface ToolResultLike {
+  readonly isError?: boolean;
+}
+
+/**
+ * Mark the current test as skipped (visible in the vitest report) when a
+ * tool/CLI result represents a known, *triaged* failure — not a bug.
+ * Optionally populates a {@link LifecycleSkipCarrier} so subsequent
+ * CRUD-chain tests can propagate the same reason via
+ * {@link skipIfUpstreamSkipped}.
+ *
+ * Throws via vitest's `ctx.skip(reason)` (returns `never` on the skip path).
+ * Returns `void` on the no-skip path so callers can chain. Setting the
+ * carrier happens BEFORE the throw, preserving downstream propagation.
+ *
+ * Triage discipline (per design §6.1):
+ *
+ * - `feature-not-supported` — sandbox lacks the feature. No catalog entry
+ *   needed. Example: `quote_list` returns 404 because the test org has no
+ *   quotes module enabled.
+ * - `sandbox-precondition` — request shape is valid; resource state is not.
+ *   Flag the site for the L3 catalog (#606). Example: `quote_update`
+ *   returns 412 `quote_has_no_attachment`.
+ * - `missing-fixture` — pass via the lifecycle pattern when an upstream
+ *   list returned successfully but empty. For in-test empty-fixture skips
+ *   (no upstream context), call {@link skipMissingFixture} directly.
+ *
+ * `unexpected-error` is intentionally NOT in {@link SkipKind} — that case
+ * is the #496 class and MUST surface as a failure via
+ * `expect(result.isError).toBeFalsy()`. Never skip on it.
+ *
+ * @param result  Tool result with an `isError` boolean.
+ * @param ctx     The vitest test context (`async (ctx) => { ... }`).
+ * @param kind    The {@link SkipKind} triage category.
+ * @param detail  Short, human-readable identifier (typically the tool/CLI
+ *                operation name, e.g. `"quote_list"`). Appears in the
+ *                vitest report after the kind prefix.
+ * @param carrier Optional CRUD-chain carrier; populated with the same
+ *                reason that's passed to `ctx.skip` before the throw.
+ */
+export function skipIfToolError(
+  result: ToolResultLike,
+  ctx: TestContext,
+  kind: SkipKind,
+  detail: string,
+  carrier?: LifecycleSkipCarrier,
+): void {
+  if (result.isError !== true) return;
+  const reason = `${kind}: ${detail}`;
+  if (carrier !== undefined) {
+    carrier.reason = reason;
+  }
+  ctx.skip(reason);
+}
+
+/**
+ * Mark the current test as skipped (visible in the vitest report) when an
+ * upstream test in a CRUD lifecycle chain has already skipped, propagating
+ * the original reason so the chain's downstream entries stay legible in
+ * the report.
+ *
+ * Throws via vitest's `ctx.skip(reason)` on the skip path; returns `void`
+ * when no upstream skip is recorded so the caller can continue.
+ *
+ * The propagated reason is prefixed with `upstream-skipped:` so the report
+ * makes the cascade obvious:
+ *
+ * ```
+ * ✓ creates a quote                                    [pass]
+ * ↓ updates the created quote — upstream-skipped:
+ *                                feature-not-supported: quote_list
+ * ↓ deletes the created quote   — upstream-skipped:
+ *                                feature-not-supported: quote_list
+ * ```
+ *
+ * @param carrier The carrier populated by the upstream test.
+ * @param ctx     The vitest test context.
+ */
+export function skipIfUpstreamSkipped(carrier: LifecycleSkipCarrier, ctx: TestContext): void {
+  if (carrier.reason === undefined) return;
+  ctx.skip(`upstream-skipped: ${carrier.reason}`);
+}
+
+/**
+ * Mark the current test as skipped (visible in the vitest report) because
+ * a required fixture is absent in the sandbox — typically a successful
+ * list-call returning zero items. Throws via vitest's `ctx.skip()`;
+ * returns `never` so TypeScript narrows variables after the call.
+ *
+ * Use for in-test empty-fixture skips that have no upstream CRUD context:
+ *
+ * ```ts
+ * const cards = cliJson<CardItem[]>("card", "list", "--per-page", "1");
+ * const first = cards[0];
+ * if (first === undefined) skipMissingFixture(ctx, "no cards in sandbox");
+ * // first: CardItem  (TS narrows via `never` return)
+ * ```
+ *
+ * The defensive `throw` after `ctx.skip()` is unreachable in practice
+ * (vitest's `PendingError` always throws) but guarantees the `never`
+ * return type at the type-system level even if vitest internals change.
+ *
+ * When called from a CRUD lifecycle chain's first step where downstream
+ * tests should propagate the missing-fixture skip, pass the chain's
+ * {@link LifecycleSkipCarrier} so subsequent {@link skipIfUpstreamSkipped}
+ * calls cascade the reason. The carrier is populated BEFORE the throw.
+ *
+ * For lifecycle-chain skips, use {@link skipIfUpstreamSkipped}. For
+ * tool-error skips, use {@link skipIfToolError}.
+ *
+ * @param ctx     The vitest test context.
+ * @param detail  Short, human-readable description of the missing fixture
+ *                (e.g. `"no cards in sandbox"`). Appears in the vitest
+ *                report after the `missing-fixture:` prefix.
+ * @param carrier Optional CRUD-chain carrier; populated with the same
+ *                reason that's passed to `ctx.skip` before the throw.
+ */
+export function skipMissingFixture(ctx: TestContext, detail: string, carrier?: LifecycleSkipCarrier): never {
+  const reason = `missing-fixture: ${detail}`;
+  if (carrier !== undefined) {
+    carrier.reason = reason;
+  }
+  ctx.skip(reason);
+  throw new Error("unreachable: ctx.skip should have thrown PendingError");
+}
+
+/**
+ * Defensive invariant check for CRUD-chain downstream tests: when
+ * {@link skipIfUpstreamSkipped} returns (chain still alive), the
+ * upstream-populated state variable MUST be defined. If it is `undefined`
+ * despite a clean lifecycle carrier, the upstream test failed
+ * assertively (rather than skipping cleanly) — throw loudly here rather
+ * than crashing on a property access several lines down with an opaque
+ * `Cannot read property of undefined` error.
+ *
+ * Also serves as a TypeScript narrowing point: returns the value with
+ * `undefined` excluded so callers can use it directly without `!`
+ * non-null assertions or `as` casts.
+ *
+ * Usage:
+ *
+ * ```ts
+ * let createdClientId: string | undefined;
+ *
+ * it("creates", async (ctx) => {
+ *   const result = await client.callTool({ name: "client_create", arguments: {...} });
+ *   expect(result.isError, ...).toBeFalsy();
+ *   createdClientId = parsed.id;
+ * });
+ *
+ * it("updates", async (ctx) => {
+ *   skipIfUpstreamSkipped(lifecycleSkip, ctx);
+ *   const id = assertLifecycleState(createdClientId, "createdClientId");
+ *   // id: string  (TS narrowed)
+ *   ...
+ * });
+ * ```
+ *
+ * @param value Lifecycle-chain shared state variable (typed `T | undefined`).
+ * @param name  Identifier of the variable, for the error message.
+ * @returns     `value`, narrowed to `T`.
+ */
+export function assertLifecycleState<T>(value: T | undefined, name: string): T {
+  if (value === undefined) {
+    throw new Error(
+      `invariant violation: lifecycle carrier clean but '${name}' not populated by upstream test ` +
+        `(upstream likely failed assertively — inspect prior test outcomes for the actual failure)`,
+    );
+  }
+  return value;
 }

--- a/packages/e2e/src/insurance/cli.e2e.test.ts
+++ b/packages/e2e/src/insurance/cli.e2e.test.ts
@@ -4,7 +4,7 @@
 import { resolve } from "node:path";
 import { InsuranceContractSchema, InsuranceDocumentSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli } from "../helpers.js";
+import { cli, type LifecycleSkipCarrier, assertLifecycleState, skipIfUpstreamSkipped } from "../helpers.js";
 import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 /**
@@ -23,6 +23,7 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
 
   describe("insurance CRUD lifecycle", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdId: string | undefined;
 
     it("creates an insurance contract", () => {
@@ -60,21 +61,23 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
       createdId = parsed["id"] as string;
     });
 
-    it("shows the created insurance contract", () => {
-      if (createdId === undefined) return;
+    it("shows the created insurance contract", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
-      const output = cli("--output", "json", "insurance", "show", createdId);
+      const output = cli("--output", "json", "insurance", "show", id);
       const parsed = JSON.parse(output) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
-      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("id", id);
     });
 
-    it("updates the created insurance contract", () => {
-      if (createdId === undefined) return;
+    it("updates the created insurance contract", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
-      const output = cli("--output", "json", "insurance", "update", createdId, "--provider-slug", "allianz");
+      const output = cli("--output", "json", "insurance", "update", id, "--provider-slug", "allianz");
       const parsed = JSON.parse(output) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("id", id);
       expect(parsed).toHaveProperty("provider_slug", "allianz");
     });
 
@@ -86,21 +89,13 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
     // fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
     let uploadedDocId: string | undefined;
 
-    it("uploads a document via insurance upload-doc", () => {
-      if (createdId === undefined) return;
+    it("uploads a document via insurance upload-doc", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
       // `--type` is required by the Qonto API (one of contract, amendment,
       // invoice, other, policy, certificate — empirically observed values).
-      const output = cli(
-        "--output",
-        "json",
-        "insurance",
-        "upload-doc",
-        createdId,
-        PDF_FIXTURE_PATH,
-        "--type",
-        "contract",
-      );
+      const output = cli("--output", "json", "insurance", "upload-doc", id, PDF_FIXTURE_PATH, "--type", "contract");
       const parsed = JSON.parse(output) as Record<string, unknown>;
       InsuranceDocumentSchema.parse(parsed);
       expect(parsed).toHaveProperty("id");
@@ -109,27 +104,31 @@ describe.skipIf(!hasOAuthCredentials())("insurance CLI commands (e2e)", () => {
       uploadedDocId = parsed["id"] as string;
     });
 
-    it("insurance show reflects the uploaded document", () => {
-      if (createdId === undefined || uploadedDocId === undefined) return;
+    it("insurance show reflects the uploaded document", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
+      const docId = assertLifecycleState(uploadedDocId, "uploadedDocId");
 
-      const output = cli("--output", "json", "insurance", "show", createdId);
+      const output = cli("--output", "json", "insurance", "show", id);
       const parsed = JSON.parse(output) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
       const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
-      expect(documents.map((d) => d.id)).toContain(uploadedDocId);
+      expect(documents.map((d) => d.id)).toContain(docId);
     });
 
-    it("removes the document via insurance remove-doc --yes", () => {
-      if (createdId === undefined || uploadedDocId === undefined) return;
+    it("removes the document via insurance remove-doc --yes", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
+      const docId = assertLifecycleState(uploadedDocId, "uploadedDocId");
 
       // `--yes` is required: without it, the CLI prints a confirmation prompt
       // to stderr and exits 1 (see `packages/cli/src/commands/insurance.ts`).
-      cli("--output", "json", "insurance", "remove-doc", createdId, uploadedDocId, "--yes");
+      cli("--output", "json", "insurance", "remove-doc", id, docId, "--yes");
 
-      const output = cli("--output", "json", "insurance", "show", createdId);
+      const output = cli("--output", "json", "insurance", "show", id);
       const parsed = JSON.parse(output) as Record<string, unknown>;
       const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
-      expect(documents.map((d) => d.id)).not.toContain(uploadedDocId);
+      expect(documents.map((d) => d.id)).not.toContain(docId);
     });
   });
 });

--- a/packages/e2e/src/insurance/mcp.e2e.test.ts
+++ b/packages/e2e/src/insurance/mcp.e2e.test.ts
@@ -6,7 +6,14 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { InsuranceContractSchema, InsuranceDocumentSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfToolError,
+  skipIfUpstreamSkipped,
+} from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 /**
@@ -44,9 +51,10 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
   });
 
   describe("insurance CRUD lifecycle", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdId: string | undefined;
 
-    it("creates an insurance contract", async () => {
+    it("creates an insurance contract", async (ctx) => {
       const result = await client.callTool({
         name: "insurance_create",
         arguments: {
@@ -63,7 +71,10 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
         },
       });
 
-      if (result.isError === true) return;
+      // Insurance is an OAuth feature that some sandbox orgs do not have
+      // provisioned. Surface as visible feature-not-supported skip and
+      // propagate to downstream tests via the lifecycle carrier (#605).
+      skipIfToolError(result, ctx, "feature-not-supported", "insurance_create", lifecycleSkip);
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
@@ -72,34 +83,36 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       createdId = parsed["id"] as string;
     });
 
-    it("shows the created insurance contract", async () => {
-      if (createdId === undefined) return;
+    it("shows the created insurance contract", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
       const result = await client.callTool({
         name: "insurance_show",
-        arguments: { id: createdId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
-      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("id", id);
     });
 
-    it("updates the created insurance contract", async () => {
-      if (createdId === undefined) return;
+    it("updates the created insurance contract", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
       const result = await client.callTool({
         name: "insurance_update",
         arguments: {
-          id: createdId,
+          id,
           provider_slug: "allianz",
         },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("id", createdId);
+      expect(parsed).toHaveProperty("id", id);
       expect(parsed).toHaveProperty("provider_slug", "allianz");
     });
 
@@ -111,14 +124,15 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
     // fixture (`packages/e2e/fixtures/tiny.pdf`) landed with #G4A.
     let uploadedDocId: string | undefined;
 
-    it("uploads a document via insurance_upload_document", async () => {
-      if (createdId === undefined) return;
+    it("uploads a document via insurance_upload_document", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
 
       // `type` is required by the Qonto API (one of contract, amendment,
       // invoice, other, policy, certificate — empirically observed values).
       const result = await client.callTool({
         name: "insurance_upload_document",
-        arguments: { contract_id: createdId, file_path: PDF_FIXTURE_PATH, type: "contract" },
+        arguments: { contract_id: id, file_path: PDF_FIXTURE_PATH, type: "contract" },
       });
 
       expect(result.isError).toBeFalsy();
@@ -130,38 +144,42 @@ describe.skipIf(!hasOAuthCredentials())("insurance MCP tools (e2e)", () => {
       uploadedDocId = parsed["id"] as string;
     });
 
-    it("insurance_show reflects the uploaded document", async () => {
-      if (createdId === undefined || uploadedDocId === undefined) return;
+    it("insurance_show reflects the uploaded document", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
+      const docId = assertLifecycleState(uploadedDocId, "uploadedDocId");
 
       const result = await client.callTool({
         name: "insurance_show",
-        arguments: { id: createdId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       InsuranceContractSchema.parse(parsed);
       const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
-      expect(documents.map((d) => d.id)).toContain(uploadedDocId);
+      expect(documents.map((d) => d.id)).toContain(docId);
     });
 
-    it("removes the document via insurance_remove_document", async () => {
-      if (createdId === undefined || uploadedDocId === undefined) return;
+    it("removes the document via insurance_remove_document", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdId, "createdId");
+      const docId = assertLifecycleState(uploadedDocId, "uploadedDocId");
 
       const removeResult = await client.callTool({
         name: "insurance_remove_document",
-        arguments: { contract_id: createdId, document_id: uploadedDocId },
+        arguments: { contract_id: id, document_id: docId },
       });
       expect(removeResult.isError).toBeFalsy();
 
       const showResult = await client.callTool({
         name: "insurance_show",
-        arguments: { id: createdId },
+        arguments: { id },
       });
       expect(showResult.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(showResult)) as Record<string, unknown>;
       const documents = (parsed["documents"] as readonly InsuranceDocumentRef[] | null | undefined) ?? [];
-      expect(documents.map((d) => d.id)).not.toContain(uploadedDocId);
+      expect(documents.map((d) => d.id)).not.toContain(docId);
     });
   });
 });

--- a/packages/e2e/src/international/mcp.e2e.test.ts
+++ b/packages/e2e/src/international/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlCurrencySchema, IntlEligibilitySchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
@@ -31,13 +31,13 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
   });
 
   describe("intl_eligibility", () => {
-    it("returns eligibility status (flat shape)", async () => {
+    it("returns eligibility status (flat shape)", async (ctx) => {
       const result = await client.callTool({
         name: "intl_eligibility",
         arguments: {},
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "intl_eligibility");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       IntlEligibilitySchema.parse(parsed);
@@ -46,13 +46,13 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
   });
 
   describe("intl_currencies", () => {
-    it("returns a list of currencies", async () => {
+    it("returns a list of currencies", async (ctx) => {
       const result = await client.callTool({
         name: "intl_currencies",
         arguments: { source: "EUR" },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "intl_currencies");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as unknown[];
       expect(Array.isArray(parsed)).toBe(true);
@@ -62,13 +62,13 @@ describe.skipIf(!hasOAuthCredentials())("international MCP tools (e2e)", () => {
       }
     });
 
-    it("supports search filter", async () => {
+    it("supports search filter", async (ctx) => {
       const result = await client.callTool({
         name: "intl_currencies",
         arguments: { source: "EUR", search: "EUR" },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "intl_currencies");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as { currency_code: string; country_code: string }[];
       expect(Array.isArray(parsed)).toBe(true);

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { IntlBeneficiaryListResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () => {
@@ -31,13 +31,13 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
   });
 
   describe("intl_beneficiary_list", () => {
-    it("returns a list with expected structure", async () => {
+    it("returns a list with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "intl_beneficiary_list",
         arguments: { currency: "USD" },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "intl_beneficiary_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         international_beneficiaries: unknown[];
@@ -49,13 +49,13 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
       expect(Array.isArray(parsed.international_beneficiaries)).toBe(true);
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "intl_beneficiary_list",
         arguments: { currency: "USD", per_page: 2, page: 1 },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "intl_beneficiary_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         international_beneficiaries: unknown[];
@@ -67,17 +67,19 @@ describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () =
   });
 
   describe("intl_beneficiary_requirements", () => {
-    it("returns requirements for an existing beneficiary", async () => {
+    it("returns requirements for an existing beneficiary", async (ctx) => {
       const listResult = await client.callTool({
         name: "intl_beneficiary_list",
         arguments: { currency: "USD" },
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "intl_beneficiary_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         international_beneficiaries: { id: string }[];
       };
-      if (listParsed.international_beneficiaries.length === 0) return;
+      if (listParsed.international_beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no international beneficiaries in sandbox");
+      }
 
       const id = (listParsed.international_beneficiaries[0] as { id: string }).id;
 

--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson, cliRaw } from "../helpers.js";
+import { CLI_PATH, cli, cliRaw, SKIP, skipIfNotFound, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 import { SCA_POLL_URL_RE } from "../sca-helpers.js";
 
@@ -30,15 +30,20 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () =
   pinAuthPreference("oauth-first");
 
   describe("intl-transfer requirements", () => {
-    it("returns requirements for a beneficiary", () => {
-      // First list intl beneficiaries to get an ID
-      let beneficiaries: { id: string }[];
-      try {
-        beneficiaries = cliJson<{ id: string }[]>("intl-beneficiary", "list");
-      } catch {
-        return;
+    it("returns requirements for a beneficiary", (ctx) => {
+      // First list intl beneficiaries to get an ID. The intl-beneficiary
+      // feature can be sandbox-gated; previously a bare try/catch swallowed
+      // ANY error (including auth failures — the #496 class). Use the
+      // 404-specific `skipIfNotFound` helper instead so genuine errors
+      // (401 auth failure, 5xx) still surface as test failures.
+      const stdout = skipIfNotFound("--output", "json", "intl-beneficiary", "list");
+      if (stdout === SKIP) {
+        skipMissingFixture(ctx, "intl-beneficiary list returned 404 — feature not enabled in sandbox");
       }
-      if (beneficiaries.length === 0) return;
+      const beneficiaries = JSON.parse(stdout) as { id: string }[];
+      if (beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no international beneficiaries in sandbox for intl-transfer requirements");
+      }
 
       const id = (beneficiaries[0] as { id: string }).id;
       const output = cli("--output", "json", "intl-transfer", "requirements", id);

--- a/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { IntlTransferRequirementsResponseSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 import { SCA_PENDING_TOKEN_RE } from "../sca-helpers.js";
 
@@ -45,18 +45,20 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer MCP tools (e2e)", () => {
   });
 
   describe("intl_transfer_requirements", () => {
-    it("returns requirements for a beneficiary", async () => {
+    it("returns requirements for a beneficiary", async (ctx) => {
       // First list intl beneficiaries to get an ID
       const listResult = await client.callTool({
         name: "intl_beneficiary_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "intl_beneficiary_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         international_beneficiaries: { id: string }[];
       };
-      if (listParsed.international_beneficiaries.length === 0) return;
+      if (listParsed.international_beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no international beneficiaries in sandbox for intl_transfer_requirements");
+      }
 
       const id = (listParsed.international_beneficiaries[0] as { id: string }).id;
 

--- a/packages/e2e/src/products/mcp.e2e.test.ts
+++ b/packages/e2e/src/products/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { ProductListResponseSchema, ProductSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 interface ProductItem {
@@ -45,9 +45,9 @@ describe.skipIf(!hasApiKeyCredentials())("product MCP tools (e2e)", () => {
   });
 
   describe("product_list", () => {
-    it("returns a list of products with the expected structure", async () => {
+    it("returns a list of products with the expected structure", async (ctx) => {
       const result = await client.callTool({ name: "product_list", arguments: {} });
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "product_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
       ProductListResponseSchema.parse(parsed);
@@ -60,24 +60,24 @@ describe.skipIf(!hasApiKeyCredentials())("product MCP tools (e2e)", () => {
       }
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "product_list",
         arguments: { per_page: 1, page: 1 },
       });
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "product_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
       expect(parsed.products.length).toBeLessThanOrEqual(1);
       expect(parsed.meta.current_page).toBe(1);
     });
 
-    it("supports sort_by", async () => {
+    it("supports sort_by", async (ctx) => {
       const result = await client.callTool({
         name: "product_list",
         arguments: { sort_by: "title:asc", per_page: 5 },
       });
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "product_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as ProductListResponse;
       expect(Array.isArray(parsed.products)).toBe(true);

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -5,7 +5,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { QuoteListResponseSchema, QuoteSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfToolError,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
@@ -31,14 +39,15 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
   });
 
   describe("quote_list", () => {
-    it("returns a list of quotes with expected structure", async () => {
+    it("returns a list of quotes with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "quote_list",
         arguments: {},
       });
 
-      // Sandbox may not support quotes — skip gracefully on tool error
-      if (result.isError === true) return;
+      // Sandbox may not expose the quotes module — surface as visible
+      // feature-not-supported skip (#605).
+      skipIfToolError(result, ctx, "feature-not-supported", "quote_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         quotes: unknown[];
@@ -52,18 +61,18 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
   });
 
   describe("quote_show", () => {
-    it("returns details for a specific quote", async () => {
+    it("returns details for a specific quote", async (ctx) => {
       const listResult = await client.callTool({
         name: "quote_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "quote_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         quotes: { id: string }[];
       };
       if (listParsed.quotes.length === 0) {
-        return;
+        skipMissingFixture(ctx, "no quotes in sandbox to resolve an id for quote_show");
       }
 
       const quoteId = (listParsed.quotes[0] as { id: string }).id;
@@ -89,21 +98,24 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
   // wrapper contract (input schema, isError, text-content shape) on top of
   // the underlying API contract.
   describe("quote CRUD lifecycle (MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdQuoteId: string | undefined;
 
-    it("creates a quote via callTool", async () => {
+    it("creates a quote via callTool", async (ctx) => {
       // Reuse an existing quote's client_id (creating a new client for an
       // ad-hoc test would muddy the sandbox).
       const listResult = await client.callTool({
         name: "quote_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "quote_list", lifecycleSkip);
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         quotes: { client: { id: string } }[];
       };
-      if (listParsed.quotes.length === 0) return;
+      if (listParsed.quotes.length === 0) {
+        skipMissingFixture(ctx, "no quotes in sandbox to reuse a client_id", lifecycleSkip);
+      }
 
       const clientId = (listParsed.quotes[0] as { client: { id: string } }).client.id;
       const today = new Date().toISOString().split("T")[0] as string;
@@ -128,7 +140,12 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
         },
       });
 
-      if (result.isError === true) return;
+      // This is the smoking-gun assertion (#496): a quote_list success
+      // followed by a quote_create schema-parse failure was previously masked
+      // as a silent green test for ~2 weeks. quote_list passing tells us the
+      // org has quotes enabled; any create error here is unexpected and MUST
+      // surface as a failure, not a skip (#605 / design §6.1).
+      expect(result.isError, `quote_create failed: ${firstTextFromMcpResult(result)}`).toBeFalsy();
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("id");
@@ -136,54 +153,65 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
       createdQuoteId = parsed["id"] as string;
     });
 
-    it("updates the created quote via callTool", async () => {
-      if (createdQuoteId === undefined) return;
+    it("updates the created quote via callTool", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdQuoteId, "createdQuoteId");
 
       const result = await client.callTool({
         name: "quote_update",
         arguments: {
-          id: createdQuoteId,
+          id,
           header: "Updated by MCP E2E test",
         },
       });
 
-      expect(result.isError).toBeFalsy();
+      // Documented sandbox-precondition: `quote_update` returns HTTP 412
+      // `quote_has_no_attachment` against the live sandbox unless the quote
+      // has at least one attachment first (design §7.2 R-SP-3 Path B; #606
+      // catalog). Triage rather than assert so the lifecycle's downstream
+      // delete step still runs.
+      skipIfToolError(result, ctx, "sandbox-precondition", "quote_update requires attachment — see #606 (design §7.2)");
+
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("id", createdQuoteId);
+      expect(parsed).toHaveProperty("id", id);
     });
 
-    it("attempts to send the created quote via callTool (skips on missing mailbox)", async () => {
-      if (createdQuoteId === undefined) return;
+    it("attempts to send the created quote via callTool (skips on missing mailbox)", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdQuoteId, "createdQuoteId");
 
       const result = await client.callTool({
         name: "quote_send",
-        arguments: { id: createdQuoteId },
+        arguments: { id },
       });
 
       // Send may fail with a 4xx if the quote's client lacks a mailbox.
-      // We accept either success (sent: true) or a recognized error path.
-      if (result.isError === true) return;
+      // Triage as sandbox-precondition (the client has no email configured);
+      // see #606 (epic #603) for the L3 sandbox-precondition catalog (#605).
+      skipIfToolError(result, ctx, "sandbox-precondition", "quote_send requires client mailbox — see #606");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("sent", true);
-      expect(parsed).toHaveProperty("id", createdQuoteId);
+      expect(parsed).toHaveProperty("id", id);
     });
 
-    it("deletes the created quote via callTool (skips if already sent)", async () => {
-      if (createdQuoteId === undefined) return;
+    it("deletes the created quote via callTool (skips if already sent)", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdQuoteId, "createdQuoteId");
 
       const result = await client.callTool({
         name: "quote_delete",
-        arguments: { id: createdQuoteId },
+        arguments: { id },
       });
 
       // If the previous step actually sent the quote, the delete is likely
-      // rejected by the API. Treat that as a recognized skip.
-      if (result.isError === true) return;
+      // rejected by the API. Triage as sandbox-precondition (delete requires
+      // non-sent state); see #606 for the L3 catalog (#605).
+      skipIfToolError(result, ctx, "sandbox-precondition", "quote_delete requires non-sent state — see #606");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
       expect(parsed).toHaveProperty("deleted", true);
-      expect(parsed).toHaveProperty("id", createdQuoteId);
+      expect(parsed).toHaveProperty("id", id);
     });
   });
 });

--- a/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/cli.e2e.test.ts
@@ -5,7 +5,7 @@ import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { RecurringTransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { CLI_PATH, cli, cliJson, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 const execFileAsync = promisify(execFile);
@@ -150,7 +150,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)",
   });
 
   describe("recurring-transfer show", () => {
-    it("shows a recurring transfer by ID", () => {
+    it("shows a recurring transfer by ID", (ctx) => {
       const recurringTransfers = cliJson<RecurringTransferItem[]>(
         "recurring-transfer",
         "list",
@@ -159,7 +159,9 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)",
         "1",
       );
       const first = recurringTransfers[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no recurring transfers in sandbox to resolve an id for recurring-transfer show");
+      }
 
       const rt = cliJson<RecurringTransferItem>("recurring-transfer", "show", first.id);
       RecurringTransferSchema.parse(rt);
@@ -178,13 +180,17 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)",
   // separate process must call `sca-session mock-decision <token> allow` to
   // unblock polling. Skip when the staging token (sandbox routing) is absent.
   describe.skipIf(!hasStagingToken())("recurring-transfer create (sandbox SCA)", () => {
-    it("creates a recurring transfer with SCA mock-decision orchestration", async () => {
+    it("creates a recurring transfer with SCA mock-decision orchestration", async (ctx) => {
       const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
-      if (beneficiaries.length === 0) return;
+      if (beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for recurring-transfer create");
+      }
       const beneficiaryId = (beneficiaries[0] as { id: string }).id;
 
       const accounts = cliJson<{ id: string }[]>("account", "list");
-      if (accounts.length === 0) return;
+      if (accounts.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for recurring-transfer create");
+      }
       const accountId = (accounts[0] as { id: string }).id;
 
       const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
@@ -230,13 +236,17 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer CLI commands (e2e)",
   // SCA approval against the sandbox. Each spawn handles its own SCA
   // orchestration independently (two child processes, two approvals).
   describe.skipIf(!hasStagingToken())("recurring-transfer cancel (sandbox SCA)", () => {
-    it("creates and then cancels a recurring transfer with SCA mock-decision orchestration", async () => {
+    it("creates and then cancels a recurring transfer with SCA mock-decision orchestration", async (ctx) => {
       const beneficiaries = cliJson<{ id: string }[]>("beneficiary", "list", "--no-paginate", "--per-page", "1");
-      if (beneficiaries.length === 0) return;
+      if (beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for recurring-transfer cancel");
+      }
       const beneficiaryId = (beneficiaries[0] as { id: string }).id;
 
       const accounts = cliJson<{ id: string }[]>("account", "list");
-      if (accounts.length === 0) return;
+      if (accounts.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for recurring-transfer cancel");
+      }
       const accountId = (accounts[0] as { id: string }).id;
 
       const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;

--- a/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/recurring-transfers/mcp.e2e.test.ts
@@ -6,7 +6,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { RecurringTransferListResponseSchema, RecurringTransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, hasStagingToken, pinAuthPreference } from "../sandbox.js";
 
 /**
@@ -100,7 +100,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
   // SCA orchestration is required for recurring_transfer_create against the
   // Qonto sandbox. Skip when no staging token (sandbox routing) is present.
   describe.skipIf(!hasStagingToken())("recurring_transfer_create (sandbox SCA)", () => {
-    it("creates a recurring transfer with inline SCA mock-decision approval", async () => {
+    it("creates a recurring transfer with inline SCA mock-decision approval", async (ctx) => {
       const beneficiaryResult = await client.callTool({
         name: "beneficiary_list",
         arguments: { per_page: 1 },
@@ -108,12 +108,16 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
-      if (beneficiaryParsed.beneficiaries.length === 0) return;
+      if (beneficiaryParsed.beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for recurring_transfer_create");
+      }
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
       const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
-      if (accountParsed.length === 0) return;
+      if (accountParsed.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for recurring_transfer_create");
+      }
       const accountId = (accountParsed[0] as { id: string }).id;
 
       const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
@@ -166,7 +170,7 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
   // triggers SCA, we approve it; if it doesn't, the token-capture times out
   // harmlessly while the cancel call resolves successfully on the happy path.
   describe.skipIf(!hasStagingToken())("recurring_transfer_cancel (sandbox SCA)", () => {
-    it("creates a recurring transfer with SCA approval and then cancels it", async () => {
+    it("creates a recurring transfer with SCA approval and then cancels it", async (ctx) => {
       const beneficiaryResult = await client.callTool({
         name: "beneficiary_list",
         arguments: { per_page: 1 },
@@ -174,12 +178,16 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
       const beneficiaryParsed = JSON.parse(firstTextFromMcpResult(beneficiaryResult)) as {
         beneficiaries: { id: string }[];
       };
-      if (beneficiaryParsed.beneficiaries.length === 0) return;
+      if (beneficiaryParsed.beneficiaries.length === 0) {
+        skipMissingFixture(ctx, "no beneficiaries in sandbox for recurring_transfer_cancel");
+      }
       const beneficiaryId = (beneficiaryParsed.beneficiaries[0] as { id: string }).id;
 
       const accountResult = await client.callTool({ name: "account_list", arguments: {} });
       const accountParsed = JSON.parse(firstTextFromMcpResult(accountResult)) as { id: string }[];
-      if (accountParsed.length === 0) return;
+      if (accountParsed.length === 0) {
+        skipMissingFixture(ctx, "no bank accounts in sandbox for recurring_transfer_cancel");
+      }
       const accountId = (accountParsed[0] as { id: string }).id;
 
       const futureDate = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().split("T")[0] as string;
@@ -282,14 +290,16 @@ describe.skipIf(!hasOAuthCredentials())("recurring-transfer MCP tools (e2e)", ()
   });
 
   describe("recurring_transfer_show", () => {
-    it("shows a recurring transfer by ID", async () => {
+    it("shows a recurring transfer by ID", async (ctx) => {
       const listResult = await client.callTool({
         name: "recurring_transfer_list",
         arguments: { per_page: 1 },
       });
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as RecurringTransferListResponse;
       const first = listParsed.recurring_transfers[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no recurring transfers in sandbox to resolve an id for recurring_transfer_show");
+      }
 
       const result = await client.callTool({
         name: "recurring_transfer_show",

--- a/packages/e2e/src/statements/cli.e2e.test.ts
+++ b/packages/e2e/src/statements/cli.e2e.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { CLI_PATH, cli, cliJson, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 function listStatements(): Record<string, unknown>[] {
@@ -17,12 +17,14 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
   // -- statement list --
 
   describe("statement list", () => {
-    it("lists statements with expected fields", () => {
+    it("lists statements with expected fields", (ctx) => {
       const rows = listStatements();
       expect(Array.isArray(rows)).toBe(true);
 
       // Sandbox may have no statements — verify structure only when data exists
-      if (rows.length === 0) return;
+      if (rows.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to assert per-row structure");
+      }
 
       const first = rows[0] as Record<string, unknown>;
       expect(first).toHaveProperty("id");
@@ -33,9 +35,11 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       expect(first).toHaveProperty("file_size");
     });
 
-    it("filters by bank account ID", () => {
+    it("filters by bank account ID", (ctx) => {
       const allRows = listStatements();
-      if (allRows.length === 0) return;
+      if (allRows.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to derive a bank-account filter");
+      }
 
       const bankAccountId = (allRows[0] as Record<string, unknown>)["bank_account_id"] as string;
 
@@ -62,9 +66,11 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
   // -- statement show --
 
   describe("statement show", () => {
-    it("shows full details of a statement", () => {
+    it("shows full details of a statement", (ctx) => {
       const allRows = listStatements();
-      if (allRows.length === 0) return;
+      if (allRows.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to resolve an id for statement show");
+      }
 
       const statementId = (allRows[0] as Record<string, unknown>)["id"] as string;
 
@@ -94,9 +100,11 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       rmSync(tempDir, { recursive: true, force: true });
     });
 
-    it("downloads a statement PDF to the current directory", () => {
+    it("downloads a statement PDF to the current directory", (ctx) => {
       const allRows = listStatements();
-      if (allRows.length === 0) return;
+      if (allRows.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to download to cwd");
+      }
 
       const firstRow = allRows[0] as Record<string, unknown>;
       const statementId = firstRow["id"] as string;
@@ -118,9 +126,11 @@ describe.skipIf(!hasApiKeyCredentials())("statement CLI commands (e2e)", () => {
       expect(existsSync(downloadedFile)).toBe(true);
     });
 
-    it("downloads a statement PDF to a specified output directory", () => {
+    it("downloads a statement PDF to a specified output directory", (ctx) => {
       const allRows = listStatements();
-      if (allRows.length === 0) return;
+      if (allRows.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to download to --output-dir");
+      }
 
       const firstRow = allRows[0] as Record<string, unknown>;
       const statementId = firstRow["id"] as string;

--- a/packages/e2e/src/statements/mcp.e2e.test.ts
+++ b/packages/e2e/src/statements/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StatementListResponseSchema, StatementSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
@@ -29,11 +29,12 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
   });
 
   describe("statement_list", () => {
-    it("lists statements and returns expected fields", async () => {
+    it("lists statements and returns expected fields", async (ctx) => {
       const result = await client.callTool({ name: "statement_list", arguments: {} });
 
-      // Sandbox may not have statements — skip gracefully on tool error
-      if (result.isError === true) return;
+      // Sandbox may not expose the statements module — surface as visible
+      // feature-not-supported skip (#605).
+      skipIfToolError(result, ctx, "feature-not-supported", "statement_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as {
         statements: Record<string, unknown>[];
@@ -42,8 +43,10 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
       StatementListResponseSchema.parse(parsed);
       expect(parsed.meta).toHaveProperty("current_page");
 
-      // Sandbox may have no statements — verify structure only when data exists
-      if (parsed.statements.length === 0) return;
+      // Sandbox may have no statements — verify structure only when data exists.
+      if (parsed.statements.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to verify per-item shape");
+      }
 
       const first = parsed.statements[0] as Record<string, unknown>;
       expect(first).toHaveProperty("id");
@@ -71,18 +74,20 @@ describe.skipIf(!hasApiKeyCredentials())("statement MCP tools (e2e)", () => {
   });
 
   describe("statement_show", () => {
-    it("shows details of a specific statement", async () => {
+    it("shows details of a specific statement", async (ctx) => {
       // First, get a statement ID from the list
       const listResult = await client.callTool({
         name: "statement_list",
         arguments: {},
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "statement_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as {
         statements: Record<string, unknown>[];
       };
-      if (listParsed.statements.length === 0) return;
+      if (listParsed.statements.length === 0) {
+        skipMissingFixture(ctx, "no statements in sandbox to resolve an id for statement_show");
+      }
 
       const statementId = (listParsed.statements[0] as Record<string, unknown>)["id"] as string;
 

--- a/packages/e2e/src/teams/mcp.e2e.test.ts
+++ b/packages/e2e/src/teams/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TeamListResponseSchema, TeamSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface TeamItem {
@@ -45,13 +45,13 @@ describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
   });
 
   describe("team_list", () => {
-    it("returns a list of teams with expected structure", async () => {
+    it("returns a list of teams with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "team_list",
         arguments: {},
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "team_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TeamListResponse;
       TeamListResponseSchema.parse(parsed);
@@ -60,30 +60,32 @@ describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
       expect(Array.isArray(parsed.teams)).toBe(true);
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "team_list",
         arguments: { per_page: 2, page: 1 },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "team_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TeamListResponse;
       expect(parsed.teams.length).toBeLessThanOrEqual(2);
       expect(parsed.meta.current_page).toBe(1);
     });
 
-    it("validates team schema", async () => {
+    it("validates team schema", async (ctx) => {
       const result = await client.callTool({
         name: "team_list",
         arguments: { per_page: 1 },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "team_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TeamListResponse;
       const first = parsed.teams[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no teams in sandbox to validate per-team schema");
+      }
 
       TeamSchema.parse(first);
       expect(first).toHaveProperty("id");
@@ -101,14 +103,17 @@ describe.skipIf(!hasOAuthCredentials())("team MCP tools (e2e)", () => {
   // 401 surfaced through the MCP wrapper as `result.isError === true`. We
   // treat that as a skip rather than a spurious failure.
   describe("team_create", () => {
-    it("creates a team via callTool (skips on OAuth scope gap)", async () => {
+    it("creates a team via callTool (skips on OAuth scope gap)", async (ctx) => {
       const teamName = `E2E MCP Test Team ${String(Date.now())}`;
       const result = await client.callTool({
         name: "team_create",
         arguments: { name: teamName },
       });
 
-      if (result.isError === true) return;
+      // POST /v2/teams returns HTTP 401 when the OAuth token lacks the
+      // team-management scope (header comment above). Surface as visible
+      // feature-not-supported skip — the gating is environmental, not a bug.
+      skipIfToolError(result, ctx, "feature-not-supported", "team_create (OAuth scope gap)");
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TeamItem;
       TeamSchema.parse(parsed);
       expect(parsed).toHaveProperty("id");

--- a/packages/e2e/src/terminals/mcp.e2e.test.ts
+++ b/packages/e2e/src/terminals/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TerminalListResponseSchema, TerminalSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipIfToolError } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface TerminalItem {
@@ -57,9 +57,9 @@ describe.skipIf(!hasOAuthCredentials())("terminal MCP tools (e2e)", () => {
   });
 
   describe("terminal_list", () => {
-    it("returns a list of terminals with the expected structure", async () => {
+    it("returns a list of terminals with the expected structure", async (ctx) => {
       const result = await client.callTool({ name: "terminal_list", arguments: {} });
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "terminal_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TerminalListResponse;
       TerminalListResponseSchema.parse(parsed);
@@ -68,12 +68,12 @@ describe.skipIf(!hasOAuthCredentials())("terminal MCP tools (e2e)", () => {
       expect(Array.isArray(parsed.terminals)).toBe(true);
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "terminal_list",
         arguments: { per_page: 1, page: 1 },
       });
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "terminal_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as TerminalListResponse;
       expect(parsed.terminals.length).toBeLessThanOrEqual(1);
@@ -82,9 +82,9 @@ describe.skipIf(!hasOAuthCredentials())("terminal MCP tools (e2e)", () => {
   });
 
   describe("terminal_payment_create", () => {
-    it("either initiates a payment or surfaces a known sandbox-feature gating error", async () => {
+    it("either initiates a payment or surfaces a known sandbox-feature gating error", async (ctx) => {
       const listResult = await client.callTool({ name: "terminal_list", arguments: { per_page: 1 } });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "terminal_list");
 
       const parsedList = JSON.parse(firstTextFromMcpResult(listResult)) as TerminalListResponse;
       const first = parsedList.terminals[0];

--- a/packages/e2e/src/transactions/cli.e2e.test.ts
+++ b/packages/e2e/src/transactions/cli.e2e.test.ts
@@ -3,7 +3,7 @@
 
 import { TransactionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson } from "../helpers.js";
+import { cli, cliJson, skipMissingFixture } from "../helpers.js";
 import { hasApiKeyCredentials } from "../sandbox.js";
 
 interface TransactionItem {
@@ -56,10 +56,12 @@ describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () =>
       expect(transactions.length).toBeLessThanOrEqual(2);
     });
 
-    it("filters by bank account ID", () => {
+    it("filters by bank account ID", (ctx) => {
       const all = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransaction(all);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to derive a bank-account filter");
+      }
 
       const bankAccountId = first.bank_account_id;
       const filtered = cliJson<TransactionItem[]>(
@@ -206,10 +208,12 @@ describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () =>
   });
 
   describe("transaction show", () => {
-    it("shows a transaction by ID", () => {
+    it("shows a transaction by ID", (ctx) => {
       const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransaction(transactions);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to resolve an id for transaction show");
+      }
 
       const txnId = first.id;
       const transaction = cliJson<TransactionItem>("transaction", "show", txnId);
@@ -221,10 +225,12 @@ describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () =>
       expect(transaction).toHaveProperty("currency");
     });
 
-    it("shows a transaction with included labels", () => {
+    it("shows a transaction with included labels", (ctx) => {
       const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransaction(transactions);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to resolve an id for transaction show with labels");
+      }
 
       const txnId = first.id;
       const transaction = cliJson<TransactionItem>("transaction", "show", txnId, "--include", "labels");
@@ -233,10 +239,12 @@ describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () =>
       expect(Array.isArray(transaction.labels)).toBe(true);
     });
 
-    it("shows a transaction with included attachments", () => {
+    it("shows a transaction with included attachments", (ctx) => {
       const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransaction(transactions);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to resolve an id for transaction show with attachments");
+      }
 
       const txnId = first.id;
       const transaction = cliJson<TransactionItem>("transaction", "show", txnId, "--include", "attachments");
@@ -244,10 +252,12 @@ describe.skipIf(!hasApiKeyCredentials())("transaction CLI commands (e2e)", () =>
       expect(transaction).toHaveProperty("attachments");
     });
 
-    it("outputs transaction details as YAML", () => {
+    it("outputs transaction details as YAML", (ctx) => {
       const transactions = cliJson<TransactionItem[]>("transaction", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransaction(transactions);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to resolve an id for transaction show YAML output");
+      }
 
       const txnId = first.id;
       const output = cli("transaction", "show", txnId, "--output", "yaml");

--- a/packages/e2e/src/transactions/mcp.e2e.test.ts
+++ b/packages/e2e/src/transactions/mcp.e2e.test.ts
@@ -5,7 +5,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { TransactionListResponseSchema, TransactionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
 
 interface TransactionItem {
@@ -115,7 +115,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
       expect(Array.isArray(parsed.transactions)).toBe(true);
     });
 
-    it("filters by bank account ID", async () => {
+    it("filters by bank account ID", async (ctx) => {
       // First get a transaction to extract bank_account_id
       const listResult = await client.callTool({
         name: "transaction_list",
@@ -123,7 +123,9 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
       });
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransactionListResponse;
       const firstTxn = listParsed.transactions[0];
-      if (firstTxn === undefined) return;
+      if (firstTxn === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to derive a bank-account filter");
+      }
 
       const bankAccountId = firstTxn.bank_account_id;
       const result = await client.callTool({
@@ -139,7 +141,7 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
   });
 
   describe("transaction_show", () => {
-    it("shows a transaction by ID", async () => {
+    it("shows a transaction by ID", async (ctx) => {
       // First get a transaction ID
       const listResult = await client.callTool({
         name: "transaction_list",
@@ -147,7 +149,9 @@ describe.skipIf(!hasApiKeyCredentials())("transaction MCP tools (e2e)", () => {
       });
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransactionListResponse;
       const firstTxn = listParsed.transactions[0];
-      if (firstTxn === undefined) return;
+      if (firstTxn === undefined) {
+        skipMissingFixture(ctx, "no transactions in sandbox to resolve an id for transaction_show");
+      }
 
       const txnId = firstTxn.id;
       const result = await client.callTool({

--- a/packages/e2e/src/transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/transfers/cli.e2e.test.ts
@@ -9,7 +9,7 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { TransferSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { CLI_PATH, cli, cliJson } from "../helpers.js";
+import { CLI_PATH, cli, cliJson, skipMissingFixture } from "../helpers.js";
 import {
   cliEnv,
   getTransferProofId,
@@ -126,10 +126,12 @@ describe.skipIf(!hasApiKeyCredentials())("transfer CLI commands (e2e)", () => {
   });
 
   describe("transfer show", () => {
-    it("shows a transfer by ID", () => {
+    it("shows a transfer by ID", (ctx) => {
       const transfers = cliJson<TransferItem[]>("transfer", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransfer(transfers);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transfers in sandbox to resolve an id for transfer show");
+      }
 
       const transferId = first.id;
       const transfer = cliJson<TransferItem>("transfer", "show", transferId);
@@ -141,10 +143,12 @@ describe.skipIf(!hasApiKeyCredentials())("transfer CLI commands (e2e)", () => {
       expect(transfer).toHaveProperty("amount_currency");
     });
 
-    it("outputs transfer details as YAML", () => {
+    it("outputs transfer details as YAML", (ctx) => {
       const transfers = cliJson<TransferItem[]>("transfer", "list", "--no-paginate", "--per-page", "1");
       const first = firstTransfer(transfers);
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no transfers in sandbox to resolve an id for transfer show YAML");
+      }
 
       const transferId = first.id;
       const output = cli("transfer", "show", transferId, "--output", "yaml");

--- a/packages/e2e/src/transfers/mcp.e2e.test.ts
+++ b/packages/e2e/src/transfers/mcp.e2e.test.ts
@@ -7,7 +7,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { TransferListResponseSchema, TransferSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import { CLI_PATH, firstTextFromMcpResult, skipMissingFixture } from "../helpers.js";
 import {
   cliEnv,
   getTransferProofId,
@@ -130,14 +130,16 @@ describe.skipIf(!hasApiKeyCredentials())("transfer MCP tools (e2e)", () => {
   });
 
   describe("transfer_show", () => {
-    it("shows a transfer by ID", async () => {
+    it("shows a transfer by ID", async (ctx) => {
       const listResult = await client.callTool({
         name: "transfer_list",
         arguments: { per_page: 1 },
       });
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as TransferListResponse;
       const firstTransfer = listParsed.transfers[0];
-      if (firstTransfer === undefined) return;
+      if (firstTransfer === undefined) {
+        skipMissingFixture(ctx, "no transfers in sandbox to resolve an id for transfer_show");
+      }
 
       const transferId = firstTransfer.id;
       const result = await client.callTool({

--- a/packages/e2e/src/webhooks/cli.e2e.test.ts
+++ b/packages/e2e/src/webhooks/cli.e2e.test.ts
@@ -3,7 +3,16 @@
 
 import { WebhookSubscriptionSchema } from "@qontoctl/core";
 import { describe, expect, it } from "vitest";
-import { cli, cliJson, cliRaw, qontoHttpStatus } from "../helpers.js";
+import {
+  cli,
+  cliJson,
+  cliRaw,
+  qontoHttpStatus,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface WebhookItem {
@@ -47,10 +56,12 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
   });
 
   describe("webhook show", () => {
-    it("shows a webhook by ID", () => {
+    it("shows a webhook by ID", (ctx) => {
       const webhooks = cliJson<WebhookItem[]>("webhook", "list", "--per-page", "1");
       const first = webhooks[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no webhooks in sandbox to resolve an id for webhook show");
+      }
 
       const webhook = cliJson<WebhookItem>("webhook", "show", first.id);
       WebhookSubscriptionSchema.parse(webhook);
@@ -65,6 +76,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
   // entirely uncovered by E2E. Sequential `it` blocks share `createdWebhookId`
   // via closure, mirroring the pattern in `packages/e2e/src/clients/cli.e2e.test.ts`.
   describe("webhook CRUD lifecycle", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdWebhookId: string | undefined;
 
     it("creates a webhook subscription", () => {
@@ -83,8 +95,9 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
       createdWebhookId = webhook.id;
     });
 
-    it("updates the webhook by widening the event filter", () => {
-      if (createdWebhookId === undefined) return;
+    it("updates the webhook by widening the event filter", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
       // The Qonto API treats PUT as full-replacement (not partial) — sending
       // only `types` returns "HTTP 400: CallbackURL is missing", so the URL
@@ -94,7 +107,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
       const webhook = cliJson<WebhookItem>(
         "webhook",
         "update",
-        createdWebhookId,
+        id,
         "--url",
         TEST_CALLBACK_URL,
         "--events",
@@ -102,23 +115,28 @@ describe.skipIf(!hasOAuthCredentials())("webhook CLI commands (e2e)", () => {
         "v1/cards",
       );
       WebhookSubscriptionSchema.parse(webhook);
-      expect(webhook.id).toBe(createdWebhookId);
+      expect(webhook.id).toBe(id);
       expect(webhook.types).toEqual(expect.arrayContaining(["v1/transactions", "v1/cards"]));
     });
 
-    it("deletes the webhook via the API", () => {
-      if (createdWebhookId === undefined) return;
+    it("deletes the webhook via the API", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
-      const result = cliJson<{ deleted: boolean; id: string }>("webhook", "delete", createdWebhookId, "--yes");
+      const result = cliJson<{ deleted: boolean; id: string }>("webhook", "delete", id, "--yes");
       expect(result.deleted).toBe(true);
-      expect(result.id).toBe(createdWebhookId);
+      expect(result.id).toBe(id);
     });
 
-    it("returns 404 when fetching the deleted webhook", () => {
-      if (createdWebhookId === undefined) return;
+    it("returns 404 when fetching the deleted webhook", (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
-      const result = cliRaw(["--output", "json", "webhook", "show", createdWebhookId]);
+      const result = cliRaw(["--output", "json", "webhook", "show", id]);
       expect(result.ok).toBe(false);
+      // Narrow CliResult to the failure branch so `result.stderr` is accessible
+      // — not a silent skip (the prior `expect(result.ok).toBe(false)` already
+      // failed the test if `result.ok` were true).
       if (result.ok) return;
       expect(qontoHttpStatus(result.stderr)).toBe(404);
     });

--- a/packages/e2e/src/webhooks/mcp.e2e.test.ts
+++ b/packages/e2e/src/webhooks/mcp.e2e.test.ts
@@ -5,7 +5,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { WebhookSubscriptionListResponseSchema, WebhookSubscriptionSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
+import {
+  CLI_PATH,
+  firstTextFromMcpResult,
+  type LifecycleSkipCarrier,
+  assertLifecycleState,
+  skipIfToolError,
+  skipIfUpstreamSkipped,
+  skipMissingFixture,
+} from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
 interface WebhookItem {
@@ -52,13 +60,13 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
   });
 
   describe("webhook_list", () => {
-    it("returns a list of webhooks with expected structure", async () => {
+    it("returns a list of webhooks with expected structure", async (ctx) => {
       const result = await client.callTool({
         name: "webhook_list",
         arguments: {},
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "webhook_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookListResponse;
       WebhookSubscriptionListResponseSchema.parse(parsed);
@@ -67,13 +75,13 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       expect(Array.isArray(parsed.subscriptions)).toBe(true);
     });
 
-    it("supports pagination", async () => {
+    it("supports pagination", async (ctx) => {
       const result = await client.callTool({
         name: "webhook_list",
         arguments: { per_page: 2, page: 1 },
       });
 
-      if (result.isError === true) return;
+      skipIfToolError(result, ctx, "feature-not-supported", "webhook_list");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookListResponse;
       expect(parsed.subscriptions.length).toBeLessThanOrEqual(2);
@@ -82,16 +90,18 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
   });
 
   describe("webhook_show", () => {
-    it("shows a webhook by ID", async () => {
+    it("shows a webhook by ID", async (ctx) => {
       const listResult = await client.callTool({
         name: "webhook_list",
         arguments: { per_page: 1 },
       });
-      if (listResult.isError === true) return;
+      skipIfToolError(listResult, ctx, "feature-not-supported", "webhook_list");
 
       const listParsed = JSON.parse(firstTextFromMcpResult(listResult)) as WebhookListResponse;
       const first = listParsed.subscriptions[0];
-      if (first === undefined) return;
+      if (first === undefined) {
+        skipMissingFixture(ctx, "no webhooks in sandbox to resolve an id for webhook_show");
+      }
 
       const result = await client.callTool({
         name: "webhook_show",
@@ -112,6 +122,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
   // round-trip but exercises the operations through callTool so the MCP wrapper
   // contract is asserted on top of the underlying API contract.
   describe("webhook CRUD lifecycle (MCP)", () => {
+    const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
     let createdWebhookId: string | undefined;
 
     it("creates a webhook via callTool", async () => {
@@ -132,8 +143,9 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       createdWebhookId = parsed.id;
     });
 
-    it("updates the webhook by widening the event filter", async () => {
-      if (createdWebhookId === undefined) return;
+    it("updates the webhook by widening the event filter", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
       // The Qonto API treats PUT as full-replacement (not partial) — sending
       // only `types` returns "HTTP 400: CallbackURL is missing", so the URL
@@ -143,7 +155,7 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       const result = await client.callTool({
         name: "webhook_update",
         arguments: {
-          id: createdWebhookId,
+          id,
           callback_url: TEST_CALLBACK_URL,
           types: ["v1/transactions", "v1/cards"],
         },
@@ -152,30 +164,32 @@ describe.skipIf(!hasOAuthCredentials())("webhook MCP tools (e2e)", () => {
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as WebhookItem;
       WebhookSubscriptionSchema.parse(parsed);
-      expect(parsed.id).toBe(createdWebhookId);
+      expect(parsed.id).toBe(id);
       expect(parsed.types).toEqual(expect.arrayContaining(["v1/transactions", "v1/cards"]));
     });
 
-    it("deletes the webhook via callTool", async () => {
-      if (createdWebhookId === undefined) return;
+    it("deletes the webhook via callTool", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
       const result = await client.callTool({
         name: "webhook_delete",
-        arguments: { id: createdWebhookId },
+        arguments: { id },
       });
 
       expect(result.isError).toBeFalsy();
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as { deleted: boolean; id: string };
       expect(parsed.deleted).toBe(true);
-      expect(parsed.id).toBe(createdWebhookId);
+      expect(parsed.id).toBe(id);
     });
 
-    it("returns 404 when fetching the deleted webhook", async () => {
-      if (createdWebhookId === undefined) return;
+    it("returns 404 when fetching the deleted webhook", async (ctx) => {
+      skipIfUpstreamSkipped(lifecycleSkip, ctx);
+      const id = assertLifecycleState(createdWebhookId, "createdWebhookId");
 
       const result = await client.callTool({
         name: "webhook_show",
-        arguments: { id: createdWebhookId },
+        arguments: { id },
       });
 
       expect(result.isError).toBe(true);

--- a/scripts/check-no-silent-skip.js
+++ b/scripts/check-no-silent-skip.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Silent-skip regression guard for E2E tests.
+ *
+ * Bans the L1 failure-visibility pattern that hid #496 for ~2 weeks (epic
+ * #603 / sub-issue #605):
+ *
+ *   1. `if (result.isError === true) return;` — swallows tool errors so a
+ *      schema-parse bug (the #496 class) reports green.
+ *   2. `if (X === undefined) return;` in test code — swallows CRUD-chain
+ *      cascades and inline empty-fixture cases without surfacing the skip.
+ *   3. `if (X.length === 0) return;` in test code — swallows empty-list
+ *      missing-fixture cases without surfacing the skip (same disease as
+ *      #2, different shape).
+ *   4. Empty-reason skips: `it.skip("")`, `ctx.skip("")`,
+ *      `describe.skip("")` — visible in the report but with no diagnostic
+ *      value (R-SR-1).
+ *
+ * Visible replacements live in `packages/e2e/src/helpers.ts`:
+ * `skipIfToolError`, `skipIfUpstreamSkipped`, `skipMissingFixture`, plus
+ * the {@link SkipKind} taxonomy. See `docs/designs/e2e-test-reliability.md`
+ * §6.1 for the migration pattern.
+ *
+ * Usage:
+ *   node scripts/check-no-silent-skip.js
+ *
+ * Exit codes:
+ *   0 — no banned patterns found
+ *   1 — at least one banned pattern found (CI fails)
+ *
+ * Output format (mirrors `scripts/check-coverage-drift.js`):
+ *   [<KIND>] <count> finding(s):
+ *     - <file>:<line>:<column>
+ *       <matched line>
+ *       <remediation hint>
+ *
+ * Modeled on `scripts/check-coverage-drift.js` (same walk + report shape,
+ * different rule set).
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, relative, dirname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), "..");
+const E2E_SRC = join(ROOT, "packages", "e2e", "src");
+
+// Files exempt from the chained-undefined ban (these define the visible
+// alternatives, so they may legitimately reference the banned shape in
+// comments or unrelated control flow).
+const CHAINED_UNDEFINED_EXEMPT = new Set([join("packages", "e2e", "src", "helpers.ts")]);
+
+// ---------------------------------------------------------------------------
+// Banned patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Rule descriptors. Each entry produces one finding kind. `pattern` is a
+ * RegExp executed per-line (sticky=false, global=false — line scans
+ * already iterate). `appliesTo(relPath)` returns true when the rule should
+ * be evaluated for that file.
+ */
+const RULES = [
+  {
+    kind: "SILENT_TOOL_ERROR",
+    // `if (result.isError === true) return;` — any identifier in place of
+    // `result`. Captures the canonical silent-tool-error pattern.
+    pattern: /if\s*\(\s*[A-Za-z_$][\w$]*\.isError\s*===\s*true\s*\)\s*return\s*;/,
+    appliesTo: (rel) => rel.endsWith(".e2e.test.ts"),
+    remediation:
+      "Replace with `skipIfToolError(result, ctx, kind, detail[, carrier])` (visible skip via vitest's ctx.skip)\n" +
+      "      or `expect(result.isError, ...).toBeFalsy()` (when the error is unexpected — the #496 class).\n" +
+      "      See `packages/e2e/src/helpers.ts` and `docs/designs/e2e-test-reliability.md` §6.1.",
+  },
+  {
+    kind: "SILENT_CHAINED_UNDEFINED",
+    // `if (X === undefined) return;` — silent CRUD-chain or empty-fixture
+    // skip. The `\)\s*return` is the distinguishing tail (vs the visible
+    // block form `\)\s*\{` followed by ctx.skip(...) and return).
+    pattern: /if\s*\(\s*[A-Za-z_$][\w$.[\]"']*\s*===\s*undefined\s*\)\s*return\s*;/,
+    appliesTo: (rel) => rel.endsWith(".e2e.test.ts") && !CHAINED_UNDEFINED_EXEMPT.has(rel),
+    remediation:
+      "Replace with `skipIfUpstreamSkipped(lifecycleSkip, ctx)` (CRUD-chain cascade)\n" +
+      "      or `skipMissingFixture(ctx, detail)` (in-test empty fixture)\n" +
+      "      — see `packages/e2e/src/helpers.ts`.",
+  },
+  {
+    kind: "SILENT_EMPTY_LIST",
+    // `if (X.length === 0) return;` — silent empty-fixture skip on a
+    // collection. Same disease as SILENT_CHAINED_UNDEFINED, different
+    // shape (the list call succeeded but returned no items).
+    pattern: /if\s*\(\s*[A-Za-z_$][\w$.[\]"']*\.length\s*===\s*0\s*\)\s*return\s*;/,
+    appliesTo: (rel) => rel.endsWith(".e2e.test.ts"),
+    remediation:
+      "Replace with `skipMissingFixture(ctx, detail)` — surfaces as a visible\n" +
+      "      `missing-fixture: <detail>` skip in the vitest report. See\n" +
+      "      `packages/e2e/src/helpers.ts`.",
+  },
+  {
+    kind: "EMPTY_SKIP_REASON",
+    // `it.skip("")`, `ctx.skip("")`, `describe.skip("")`, `test.skip("")`,
+    // including space-only strings. Whitespace-only counts as empty
+    // because it provides zero diagnostic value in the vitest report.
+    pattern: /(?:it|test|describe|ctx)\.skip\(\s*(["'`])\s*\1\s*[,)]/,
+    appliesTo: (rel) => rel.endsWith(".e2e.test.ts") || rel.endsWith(".ts"),
+    remediation:
+      "Every skip must carry a non-empty reason (R-SR-1) so the vitest report has diagnostic value.\n" +
+      "      Use a `SkipKind` prefix (`feature-not-supported:` / `sandbox-precondition:` / `missing-fixture:`)\n" +
+      "      or `upstream-skipped:` for CRUD-chain propagation.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// File walking
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively list files under `dir`. Returns absolute paths. Skips
+ * `node_modules` and `dist` (mirrors `check-coverage-drift.js`).
+ */
+function walk(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      results.push(...walk(full));
+    } else if (entry.isFile()) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Normalize a path to forward slashes regardless of platform, for stable
+ * report output and exempt-set matching on Windows runners.
+ */
+function toPosix(p) {
+  return p.split(sep).join("/");
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply every rule to every applicable file. Returns
+ * `{ kind, relPath, line, column, text, remediation }` findings.
+ */
+function scan() {
+  if (!existsSync(E2E_SRC)) {
+    // No E2E tree — nothing to guard. Treat as clean (the coverage-drift
+    // check has the same posture for absent surfaces).
+    return [];
+  }
+
+  const findings = [];
+  const files = walk(E2E_SRC).filter((f) => f.endsWith(".ts"));
+
+  for (const abs of files) {
+    const rel = toPosix(relative(ROOT, abs));
+    // Compare against the POSIX-normalized exempt entries so the
+    // CHAINED_UNDEFINED_EXEMPT membership check works on Windows.
+    const relPosix = rel;
+    const exemptKey = join(...rel.split("/")); // re-platformize for set lookup
+    const applicableRules = RULES.filter((r) => (r.appliesTo === undefined ? true : r.appliesTo(exemptKey)));
+    if (applicableRules.length === 0) continue;
+
+    const content = readFileSync(abs, "utf-8");
+    const lines = content.split(/\r?\n/);
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip single-line comments (`//` after any leading whitespace).
+      // The banned patterns are sometimes referenced verbatim inside
+      // explanatory comments (audit trails, migration notes); only
+      // executable code should trip the guard. Block comments (`/* */`)
+      // are not stripped — they are uncommon for inline rule-shaped text
+      // and adding multi-line state would complicate the scanner.
+      if (/^\s*\/\//.test(line)) continue;
+      for (const rule of applicableRules) {
+        const m = rule.pattern.exec(line);
+        if (m !== null) {
+          findings.push({
+            kind: rule.kind,
+            relPath: relPosix,
+            line: i + 1,
+            column: m.index + 1,
+            text: line.trim(),
+            remediation: rule.remediation,
+          });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+function reportFindings(findings) {
+  if (findings.length === 0) return;
+  const byKind = new Map();
+  for (const f of findings) {
+    if (!byKind.has(f.kind)) byKind.set(f.kind, []);
+    byKind.get(f.kind).push(f);
+  }
+  // Mirrors check-coverage-drift.js: stable ordering by kind for legibility
+  // and grep-friendliness in CI logs.
+  const kindOrder = ["SILENT_TOOL_ERROR", "SILENT_CHAINED_UNDEFINED", "SILENT_EMPTY_LIST", "EMPTY_SKIP_REASON"];
+  for (const kind of kindOrder) {
+    const items = byKind.get(kind);
+    if (items === undefined || items.length === 0) continue;
+    process.stderr.write(`\n[${kind}] ${String(items.length)} finding(s):\n`);
+    // Print remediation once per kind (shared across all findings of that kind).
+    const remediation = items[0].remediation;
+    for (const f of items) {
+      process.stderr.write(`  - ${f.relPath}:${String(f.line)}:${String(f.column)}\n`);
+      process.stderr.write(`      ${f.text}\n`);
+    }
+    process.stderr.write(`    Fix: ${remediation}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const findings = scan();
+
+  if (findings.length === 0) {
+    process.stdout.write("Silent-skip check passed.\n");
+    return;
+  }
+
+  process.stderr.write(`Silent-skip check FAILED: ${String(findings.length)} finding(s).\n`);
+  reportFindings(findings);
+  process.stderr.write(
+    "\nWhy this guard exists:\n" +
+      "  The silent-skip pattern conflated 'couldn't execute' (skip), 'executed and\n" +
+      "  found a bug' (fail), and 'executed correctly' (pass) into one green dot.\n" +
+      "  It hid #496 (Quote/ClientInvoice schema-parse failure) for ~2 weeks. See\n" +
+      "  `docs/prds/e2e-test-reliability.md` §1.1 and `docs/designs/e2e-test-reliability.md` §6.1.\n",
+  );
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Closes #605. Implements epic #603 Wave A — PRD R-FV-1...R-FV-5 + R-SR-1, R-SR-2 from \`docs/prds/e2e-test-reliability.md\`, per-site triage taxonomy from \`docs/designs/e2e-test-reliability.md\` §6.1.

## Why

The L1 silent-skip pattern (`if (result.isError === true) return;`) hid #496 — the Quote/ClientInvoice schema-parse failure — for ~2 weeks. The same pattern existed at ~80 sites suite-wide. Each one conflates three outcomes into one green dot:
1. "couldn't execute" (legitimate skip — sandbox missing feature)
2. "executed and found a bug" (must fail loudly)
3. "executed correctly" (pass)

This PR eliminates the pattern, introduces a skip-reason taxonomy that distinguishes those three outcomes, and adds a CI guard that prevents regression.

## What

### Foundation: \`packages/e2e/src/helpers.ts\`

- \`SkipKind\` union: \`"feature-not-supported" | "sandbox-precondition" | "missing-fixture"\` (R-SR-1)
- \`LifecycleSkipCarrier\` for CRUD-chain cascade propagation
- \`skipIfToolError(result, ctx, kind, detail, carrier?)\` — visible skip via \`ctx.skip\` when an MCP tool returns \`isError\`
- \`skipIfUpstreamSkipped(carrier, ctx)\` — propagates \`upstream-skipped:\` prefix across CRUD lifecycle blocks
- \`skipMissingFixture(ctx, detail, carrier?)\` — visible skip when no usable fixture row exists in sandbox
- \`assertLifecycleState<T>(value, name)\` — TS narrowing helper so post-skip lifecycle state is non-nullable

**Deviation from design**: helpers throw via vitest's \`ctx.skip\` (not boolean stop-flag) because \`PendingError\` is unconditional in vitest 4.x. Intent preserved — visible skips with structured reasons.

### Per-site sweep (~80 sites across 28 test files)

Removed every L1/L2 pattern:
- \`if (result.isError === true) return;\` — silent tool error
- \`if (X === undefined) return;\` — silent chained-undefined (CRUD-chain cascade)
- \`if (X.length === 0) return;\` — silent empty-list (missing fixture)

Each site triaged per design §6.1:
- **Assert** when error is unexpected (the #496 class). Example: \`quote_create\` failure asserts loudly — exactly the path that hid #496 for 2 weeks.
- **Skip** with \`SkipKind\` taxonomy when sandbox can't satisfy preconditions.

### Specific triage decisions worth surfacing

- **\`quote_update\` → \`sandbox-precondition\`** per design §7.2 R-SP-3 Path B. Returns 412 \`quote_has_no_attachment\` until the quote has at least one attachment; sandbox-level precondition, not a bug. Documented in #606.
- **\`intl-transfer requirements\`** previously used a bare \`try/catch\` that swallowed ANY error including 401 auth failures (the #496 class). Replaced with \`skipIfNotFound\` (404-specific), so 401/5xx surface as failures.
- **\`quote_send\` / \`quote_delete\`** triaged sandbox-precondition (client mailbox / non-sent state requirements; #606).

### CI guard: \`scripts/check-no-silent-skip.js\`

Modeled on \`scripts/check-coverage-drift.js\` (same walk + report shape). 4 rules:

| Rule | Pattern |
|---|---|
| \`SILENT_TOOL_ERROR\` | \`if (X.isError === true) return;\` |
| \`SILENT_CHAINED_UNDEFINED\` | \`if (X === undefined) return;\` (test code) |
| \`SILENT_EMPTY_LIST\` | \`if (X.length === 0) return;\` (test code) |
| \`EMPTY_SKIP_REASON\` | \`{it,test,describe,ctx}.skip("")\` |

- Single-line \`//\` comment skip so audit-trail comments referencing banned patterns don't trip the guard.
- \`helpers.ts\` exempted from chained-undefined rule (defines the visible alternatives).
- Wired into \`pnpm silent-skip-check\` + \`.github/workflows/ci.yml\` after \`coverage-drift-check\`.

## Local validation

| Gate | Result |
|---|---|
| \`pnpm silent-skip-check\` | passes (zero findings) |
| \`pnpm format:check\` | clean |
| \`pnpm lint\` | clean |
| Type-check | clean |
| Unit tests | 789 passing |
| E2E smoke (\`statements/cli\`, api-key path) | 6/6 in 7.99s |

**Full \`pnpm test:e2e\` gating note**: my local OAuth refresh token expired mid-session, blocking full re-run. The api-key migrated suites all passed in the first full run before expiry (309/383 passing, with all 14 failures being pre-existing OAuth-SCA-gated suites with sandbox-state issues — none introduced by this PR). Structural validation (guard green, types/lint/format clean, unit tests green, synthetic guard-regression test caught all 4 banned patterns) carries the rest of the confidence.

## What this PR is NOT

- Not a behavior change to any production code path. Only test code, helpers, and CI scripts.
- Not closing #496 (already closed in #496 itself). This PR closes the failure-visibility CLASS that hid it.
- Not creating the \`sandbox-precondition\` catalog (that's #606 — referenced from triaged skip messages).
- Not addressing OAuth-SCA-gated suite failures observed locally (orthogonal to L1 silent-skip; if those need attention, separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)