### PR TITLE
(docs) qonto sandbox-preconditions catalog + inline test links (#606)

### DIFF
--- a/docs/briefs/2026-05-17-design-e2e-test-reliability.md
+++ b/docs/briefs/2026-05-17-design-e2e-test-reliability.md
@@ -1,0 +1,53 @@
+---
+type: design-brief
+date: 2026-05-17
+source: ../designs/e2e-test-reliability.md
+workflow: /design-solution
+status: final
+---
+
+# Design Brief: E2E Test Reliability + Schema Strictness Sweep
+
+## Problem
+
+qontoctl's E2E suite hid #496 for ~2 weeks via a two-stage silent mask (L1), atop undetected schema-runtime drift (L2) and undocumented sandbox preconditions (L3). The design eliminates the L1 disease suite-wide, audits all 81 L2 drift candidates, documents L3 preconditions, and builds a contract probe + order-independence detector as the preventive immune system.
+
+## Key Decisions
+
+1. **L1 sweep IS the L3 triage (single pass)** — every `if (result.isError === true) return;` site is, by construction, a precondition expectation. Walking all 14+ files for L1 _is_ the L3 enumeration. Each site categorized `feature-not-supported` / `sandbox-precondition` / `unexpected-error`; doc + skip-reason fall out of the same judgment. T1 and T2 are not separate passes.
+2. **Runtime skip via `ctx.skip(reason)`, never silent return** — vitest supports in-body runtime skip. The `unexpected-error` category (the #496 class) defaults to `expect(...).toBeFalsy()` — an explicit assertion, NEVER a skip. This is the single most important reversal: the bug class that must surface, surfaces.
+3. **Two helpers collapse ~90 sites into one reviewed implementation** — `skipIfToolError` + `skipIfUpstreamSkipped` in `helpers.ts`; `SkipKind` union IS the R-SR-2 taxonomy. Chained-undefined becomes skip-reason propagation through a module-scope `LifecycleSkipCarrier`.
+4. **CI grep-guard prevents L1 regression** — `scripts/check-no-silent-skip.js` (modeled on existing `check-coverage-drift.js`) fails CI if the raw pattern or empty-reason skip reappears.
+5. **L2 audit is worklist-driven, evidence-cited, conservatively-defaulted** — generator emits the 81-item worklist; each resolved against Qonto OpenAPI with a citation comment; ambiguous → `nullable().optional()` (R-SS-5, since false-positive widening is safe but false-negative strictness causes #496). Regression test per fix.
+6. **Contract probe is the L2 audit's force multiplier AND successor** — where Qonto docs are silent, the probe resolves L2 ambiguity by observing live responses; post-v1 it replaces manual audit as the ongoing drift detector. Build early in Wave C so Wave A's ambiguous items consume its output.
+7. **Suggest-don't-apply probe** — `scripts/contract-probe.ts` emits `SchemaDriftReport` with corrective Zod suggestions but never edits schema files (auto-remediation is v2).
+
+## Design Tracks
+
+| Track                  | Approach                                                                             | Key trade-off                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| Test Architecture (T1) | Helper-driven L1 migration + worklist-driven L2 audit, both with regression coverage | ~90 hand sites → 2 helpers; per-site triage judgment is irreducible           |
+| Tooling (T2)           | `docs/qonto-sandbox-preconditions.md` + inline test links + quote_update fix         | Document-only (not probe-before-call) — zero runtime cost, defers enforcement |
+| Tooling (T3)           | `contract-probe.ts` (local) + hybrid order-independence (audit+lint+diff)            | Local-only probe + 3-layer order check; CI/random-seed deferred to v2         |
+
+Skipped (rationale in design §11): ui-visual-design, data-architecture, ux-prototype-validation, infrastructure, integration, security (PRD §8.1 N/A), performance (PRD §8.4 OUT).
+
+## Open Questions — All Resolved
+
+The PRD's 3 DoR findings are resolved in design frontmatter:
+
+- **Q1 → LOCAL-ONLY**: CI is api-key by design; OAuth can't live in CI cleanly. `pnpm contract-probe` is local + pre-release (added to release-runbook), run quarterly. CI job reconsidered only if drift frequency proves high.
+- **Q2 → DOCUMENT-ONLY (v1)**: probe-before-call doubles sandbox write-path traffic for marginal gain. Documentation delivers the primary value (stop rediscovering preconditions) at zero runtime cost.
+- **Q3 → HYBRID**: 3-layer lowest-cost-first — manual audit during T1 sweep + module-scope-mutable-state lint + pre-release run-twice-and-diff (`check-order-independence.sh`). Random-seed-matrix vitest plugin deferred to v2.
+
+## Feasibility Verdict
+
+No INFEASIBLE must-have components. No HIGH risks (all MEDIUM/LOW with mitigations). The one RED assumption (A8 — Qonto docs drift from runtime) is the project's motivation, not a blocker. `quote_update` fix has a time-boxed Path A with a guaranteed Path B fallback.
+
+## Coverage
+
+20/20 PRD requirements mapped to tracks/waves/building-blocks (design §10). Zero orphans, zero decomposition-introduced gaps.
+
+## Full Design
+
+See [`e2e-test-reliability.md`](../designs/e2e-test-reliability.md)

--- a/docs/briefs/2026-05-17-requirements-e2e-test-reliability.md
+++ b/docs/briefs/2026-05-17-requirements-e2e-test-reliability.md
@@ -1,0 +1,85 @@
+---
+type: requirements-brief
+date: 2026-05-17
+source: ../prds/e2e-test-reliability.md
+workflow: /capture-requirements
+status: final
+origin: "/scope from #496 follow-up — systematic sweep of order-dependent flake + similar issues"
+---
+
+# Requirements Brief: E2E Test Reliability + Schema Strictness Sweep
+
+## Problem Being Solved
+
+qontoctl's E2E suite has a three-layer reliability defect that hid #496 for ~2 weeks. **L1 — Failure-Visibility Defect** (the disease): a two-stage silent mask (`if (result.isError === true) return;` → `if (createdId === undefined) return;`) conflates skip / fail / pass into a single green dot. **L2 — Schema-Runtime Drift Gap** (the absent immune system): Zod schemas encode strict assumptions (`z.string().nullable()`) that diverge from Qonto's actual `required` semantics; no detection mechanism exists. **L3 — Sandbox-State Contract** (the implicit dependency): write endpoints have undocumented preconditions; each contributor rediscovers them as "flake". The visible `quote_has_no_attachment` 412 is the symptom; L1 is the root cause that lets the other two hide.
+
+Concrete scope discovered by direct enumeration: **30 L1 mask occurrences across 14+ E2E test files**, **~60 chained-undefined skips across 25+ files**, **81 nullable-not-optional fields across 15 core schema files** (post-#602; that PR fixed only 4).
+
+## Key Requirements (top 7)
+
+1. **R-FV-1 to R-FV-5 — L1 elimination**: Replace every `if (result.isError === true) return;` and `if ({sharedId} === undefined) return;` with `it.skip("recorded reason")` or explicit failure. Cover all 14+ identified files. Suite-wide grep returns 0 occurrences post-fix.
+
+2. **R-SS-1 to R-SS-5 — L2 strictness audit**: Audit all 81 occurrences against Qonto's `required` list (or runtime probe where docs are silent). Relax `nullable()` → `nullable().optional()` where field is not in `required`. Each fix carries a regression test per the #602 convention.
+
+3. **R-SP-1 to R-SP-3 — L3 sandbox preconditions**: Author `docs/qonto-sandbox-preconditions.md` covering every write endpoint with known 412/422 precondition path. Inline-link from affected tests. Fix `quote_update` 412 root cause (attach attachment OR skip-with-reason).
+
+4. **R-CP-1 to R-CP-4 — Schema-vs-runtime contract probe**: Tool that calls Qonto endpoints (OAuth-authed) and diffs response shapes against Zod schemas; produces `SchemaDriftReport` with extra/missing fields and strictness mismatches. Suggests corrective declarations but does not auto-apply.
+
+5. **R-OI-1, R-OI-2 — Test order independence verification**: Mechanism to detect cross-test state contamination (run shuffled, diff outcomes). Mechanism choice deferred to design (random-seed runner vs snapshot diff vs manual audit invariant).
+
+6. **R-SR-1, R-SR-2 — Skip reason discipline**: Every `it.skip("...")` carries non-empty reason; taxonomy convention defined (`sandbox-precondition:`, `upstream-skipped:`, `feature-not-supported:`, `missing-fixture:`); enforced via lint at minimum for non-empty.
+
+7. **R-FV-3, R-FV-4 — Failure visibility outcomes**: Skipped tests are visibly skipped in vitest report (never silently green). Unexpected error paths fail explicitly (never silently skip).
+
+## Key Decisions
+
+1. **Three-layer reframe**: The user's "order-dependent flake" frame was reframed (Phase 0) as a three-layer defect with L1 as root cause. The systematic-sweep ask becomes "audit every CRUD-lifecycle chain for the L1 pattern" rather than "look for similar flakes". This expands scope from "fix the visible 412" to "eliminate the disease class".
+
+2. **Excellence-target appetite**: 2-3 weeks across three waves — Wave A (3-5d quick wins: L1+L2 audit), Wave B (5-7d sweep+docs: L3 preconditions + sweep coverage), Wave C (5-10d infrastructure: contract probe + order-independence verification). All three waves IN; user confirmed "aim for excellence" so contract probe (highest preventive leverage) is included.
+
+3. **OAuth baseline OUT of scope**: 63 OAuth E2E failures observed during #496 execution were confirmed environmental (expired refresh token in user's local `.qontoctl.yaml`); user relogins to recover. Not a test reliability defect.
+
+4. **Mocking remains forbidden**: Project memory (`feedback_mcp_void_formatter_trap`) records that mocks lied in the past. Contract probe and E2E both hit real Qonto; this PRD does not introduce mocks.
+
+5. **Contract probe is suggest-don't-apply**: Probe outputs a `SchemaDriftReport` with suggested Zod corrections but does NOT auto-modify schema files. Auto-remediation is v2 territory.
+
+6. **CI integration of contract probe deferred to design** (Q1): Three options under consideration — (a) nightly local cron, (b) new CI job with OAuth secret, (c) pre-release ad-hoc invocation. Tradeoffs analyzed in Stage 2 design.
+
+7. **Conservative strictness posture for ambiguous fields** (R-SS-5): When Qonto docs are silent AND runtime probe is unavailable for a field, default to `nullable().optional()` with explicit ambiguity comment. Prefer false-positive widening over false-negative strictness (since strict-when-loose causes #496-style production failures).
+
+## Assumptions & Risks
+
+| ID     | Color   | Risk                                                                                                                                                                                                    |
+| ------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A1     | Green   | Qonto's `required` list is authoritative for "may be omitted" semantics                                                                                                                                 |
+| A2     | Green   | 30 L1 + 60 chained-undefined occurrences enumerate the complete pattern (grep is mechanical)                                                                                                            |
+| A3     | Yellow  | Qonto sandbox stable enough for contract probe (no rate-limit blocking)                                                                                                                                 |
+| A4     | Green   | Existing OAuth credentials sufficient for probe (no new OAuth scope)                                                                                                                                    |
+| A5     | Yellow  | `quote_update` 412 root cause is `attachment_id` missing (design phase confirms)                                                                                                                        |
+| A6     | Green   | Contract probe scope is bounded (suggest-don't-apply; no auto-remediation in v1)                                                                                                                        |
+| A7     | Yellow  | All 81 nullable occurrences are drift candidates (#602 sample: 4/4 confirmed)                                                                                                                           |
+| **A8** | **Red** | **Qonto OpenAPI / docs kept in sync with live API** — #496 itself proves divergence; contract probe exists precisely to detect this. This risk is the project's load-bearing motivation, not a blocker. |
+
+## Stats
+
+- **Objects**: 7 (E2ETest, PreconditionGate, ZodSchemaField, QontoEndpointContract, SchemaDriftReport, SandboxPreconditionDoc, CRUDLifecycleChain)
+- **EARS Requirements**: 20 across 6 groups (failure-visibility, schema-strictness, sandbox-preconditions, contract-probe, order-independence, skip-reason discipline)
+- **Acceptance Criteria scenarios**: 5 (each with explicit BUT NOT)
+- **Quality Attributes (Planguage)**: 3 (test-reliability, schema-fidelity, failure-visibility)
+- **Cross-cutting subsections**: 6 (Security, Compliance, Reliability, Performance, Operational, Lifecycle)
+- **Feature Completeness verdict**: 3 COMPLETE / 3 NEAR-COMPLETE / 1 INCOMPLETE (gaps captured as DoR findings)
+- **Assumptions**: 4 green / 3 yellow / 1 red
+
+## DoR Verdict
+
+`passed-with-findings` — three design-phase open questions:
+
+- **Q1**: Contract probe CI integration model (nightly-local vs CI-job-with-OAuth-secret vs pre-release-ad-hoc)
+- **Q2**: Sandbox precondition enforcement model (document-only vs probe-before-call)
+- **Q3**: Test order independence verification mechanism (random-seed runner vs snapshot diff vs manual-audit invariant)
+
+These do not block scoping; they parametrize design.
+
+## Full PRD
+
+See [`e2e-test-reliability.md`](../prds/e2e-test-reliability.md)

--- a/docs/briefs/2026-05-17-scope-496-followup-symmetric-fixes.md
+++ b/docs/briefs/2026-05-17-scope-496-followup-symmetric-fixes.md
@@ -1,0 +1,66 @@
+---
+type: scope-brief
+date: 2026-05-17
+workflow: /scope
+status: final
+---
+
+# Scope Brief: #496 Follow-up — Symmetric schema-alignment fixes
+
+## Problem
+
+External reporter `max-carlo` confirmed two Zod schema validation failures on `qontoctl` against the live Qonto API ([#496 comment](https://github.com/alexey-pelykh/qontoctl/issues/496#issuecomment-4470471274), 2026-05-17): `quote_list` rejects responses where `discount.type === "absolute"` (fixed-amount discounts), and `quote_update` rejects PATCH responses that omit `attachment_id` entirely. Both are cases where qontoctl's schemas are stricter than the Qonto API's actual contract.
+
+A docs deep-dive established that Qonto's quote-endpoint OpenAPI docs are internally inconsistent with their client-invoice-endpoint docs (`amount` vs `absolute` for the same field), and that Qonto's `required` lists for both `Quote` and `ClientInvoice` schemas explicitly omit `attachment_id` plus 8+ other fields where qontoctl currently uses `z.string().nullable()`. The reported symptoms are the tip of a broader docs-vs-schema gap.
+
+## What's In Scope
+
+### Wave 1 (Must — ship now)
+
+1. **#496 (reopened)** — Symmetric schema-alignment fixes. One PR covers:
+    - `QuoteDiscountSchema.type` → `z.enum(["percentage", "absolute", "amount"])` (3-value forward-compat)
+    - `QuoteSchema.attachment_id` → `.nullable().optional()`
+    - `ClientInvoiceDiscountSchema.type` → same 3-value enum (parallel docs-aligned fix)
+    - `ClientInvoiceSchema.attachment_id` → `.nullable().optional()`
+    - Mirroring TypeScript types in `quote.ts` and `client-invoices/types.ts` (per `satisfies z.ZodType<T>` constraint)
+    - Regression tests in `quote.schema.test.ts` and `client-invoices/schemas.test.ts`
+
+### Wave 2 (Should — after #496 ships)
+
+2. **#601 (new)** — Audit nullable-vs-optional alignment for Quote + ClientInvoice schemas vs OpenAPI required lists. Per-field decision (relax vs keep-strict-with-rationale) for the 8+ Quote fields and parallel ClientInvoice fields not in the docs `required` list. Deferred until #496 baseline established.
+
+## Key Decisions
+
+1. **Symmetric tier (1 PR, both surfaces)** — bundled `quote.*` and `client_invoice.*` fixes in one PR rather than split. Rationale: docs precedent (client-invoice docs use `absolute` canonically), code precedent (PR #514 bundled multiple schema-alignment fixes), and the client-invoice `absolute` gap is latent — fixing it preemptively avoids a second user report.
+2. **3-value enum `[percentage, absolute, amount]`** — accepts every value seen across Qonto docs (quote docs: `amount`, client-invoice docs: `absolute`) AND the live API (`absolute`). Maximum forward-compat against either docs being right; resilient to Qonto's own internal cleanup.
+3. **Reopen #496, ship with `Fixes #496`** — preserves the reporter's conversation context (raw curl evidence, locale info, web-app provenance) and the owner's deferred-Q&A trail. Cleaner than orphaning the new info in a fresh issue.
+4. **Broader nullable-vs-optional retrofit deferred to #601** — investigation found 8+ Quote fields with the same too-strict pattern, but symmetric scope kept tight. Filing the audit follow-up explicitly prevents the gap from being forgotten.
+5. **Test strategy: unit-only, no new E2E** — sandbox quotes likely don't carry `absolute` discounts (E2E wouldn't catch this regression naturally), so regression coverage lives in `*.schema.test.ts` per project precedent (#507).
+
+## Stats
+
+- **Work Items**: 2 in GitHub Issues
+    - #496 (reopened): READY, Tier B Gherkin AC pending test binding
+    - #601 (new): READY, typed exception (`formulation: skipped — audit task`)
+- **Ready**: 2/2
+- **Gaps accepted**: 0 (one typed exception on #601, fully documented)
+- **Deferred**: 0
+- **Total Gherkin scenarios**: 8 (mapped 1:1 to vitest test cases)
+
+## Side artifact
+
+A parallel skill-config issue was filed during this scoping session: [alexey-pelykh/.claude#688](https://github.com/alexey-pelykh/.claude/issues/688) — `qonto-api` skill has stale URLs (`openapi_v2.yml` 404, wrong slug for quote PATCH). Independent of #496 / #601; surfaced because the qontoctl-side deep-dive couldn't use the skill's cited URLs as-is.
+
+## Project conventions to respect during execution
+
+- `(fix)` lowercase commit prefix with `(#496)` issue ref (per CLAUDE.md § Commit Messages).
+- `pnpm format:check` first, then `lint`, `build`, `test`, `test:e2e` (full OAuth-inclusive suite) — per auto-memories `feedback_pnpm_format_check_first` + `feedback_e2e_before_pr`.
+- Merge via `gh pr merge --rebase --admin --delete-branch` only — per `project_merge_method_rebase_only` (repo disallows squash + merge-commit).
+- Poll PR checks via `--json bucket`, treat `skipping` as terminal-benign — per `feedback_gh_pr_checks_skipping_bucket`.
+
+## Next Steps
+
+- `/do #496` — execute the symmetric fix (highest priority)
+- After #496 merges: `/do #601` — kick off the broader audit
+
+Both items are READY for immediate execution.

--- a/docs/briefs/2026-05-17-scope-e2e-test-reliability.md
+++ b/docs/briefs/2026-05-17-scope-e2e-test-reliability.md
@@ -1,0 +1,67 @@
+---
+type: scope-brief
+date: 2026-05-17
+workflow: /scope
+status: final
+origin: "Session-discovered during /do #496 — order-dependent flake + user-stated systematic-sweep instruction"
+---
+
+# Scope Brief: E2E Test Reliability + Schema Strictness Sweep
+
+## Problem
+
+qontoctl's E2E suite hid issue #496 for ~2 weeks (reopened twice before #602 fixed it). Root-cause analysis surfaced a **three-layer defect**, not a single flake:
+
+- **L1 — Failure-Visibility Defect (the disease)**: a two-stage silent mask (`if (result.isError === true) return;` → `if (createdId === undefined) return;`) conflates skip/fail/pass into one green dot. **30 occurrences / 14+ files; ~60 chained-undefined / 25+ files.**
+- **L2 — Schema-Runtime Drift (absent immune system)**: Zod `nullable()` is stricter than Qonto's OpenAPI `required` semantics. **81 occurrences / 15 core files** (#602 fixed 4; #601 owns the Quote+ClientInvoice slice).
+- **L3 — Sandbox-State Contract (implicit dependency)**: write-endpoint preconditions are undocumented; rediscovered as "flake" each time.
+
+The visible `quote_has_no_attachment` 412 is a **symptom**; L1 is the disease that let L2 hide and made L3 look like noise. Reframed in Phase 0 from "order-dependent flake" to this three-layer model — user confirmed ("proceed, we aim for excellence" → Wave C contract probe IN).
+
+## What's In Scope
+
+Standalone epic **#603** + 6 ready children (2–3 week appetite, 3 waves):
+
+| WI       | Wave | Title                                                                                         |
+| -------- | ---- | --------------------------------------------------------------------------------------------- |
+| **#604** | A    | `(test)` eliminate L1 silent-skip mask suite-wide + skip-reason helpers + CI regression guard |
+| **#605** | A    | `(audit)` nullable-vs-optional sweep — core schema files beyond #601 (~70 fields / 13 files)  |
+| **#606** | B    | `(docs)` Qonto sandbox-preconditions catalog + inline test links                              |
+| **#607** | B    | `(fix)` quote_update E2E 412 quote_has_no_attachment under suite load                         |
+| **#608** | C    | `(test)` schema-vs-runtime contract probe — local drift detector                              |
+| **#609** | C    | `(test)` E2E order-independence detection (invariant + lint + pre-release diff)               |
+
+Existing-tracker reconciliation (no duplication): **#601** kept as-is (Quote+ClientInvoice L2 slice; #605 is its sibling for the rest); **#449** cross-linked as orthogonal (coverage _expansion_ vs reliability of _existing_); **#539/#561/#570/#567** absorbed as L3 catalog entries; **#591** noted out-of-scope (mocking + OAuth-in-CI both PRD-excluded).
+
+## What's Out of Scope
+
+OAuth credential lifecycle (user-confirmed environmental — relogin handles it); retry/quarantine infra (convergence philosophy: fix roots, don't mask); mocking (project memory: mocks lied before); parallel E2E; OAuth-in-CI; new endpoint coverage (→ #449); framework migration.
+
+## Key Decisions
+
+1. **Three-layer reframe (Phase 0)** — "systematic sweep" became "audit every CRUD chain for the L1 disease," not "look for similar flakes." Expanded scope from fixing the visible 412 to retiring the pattern class.
+2. **Sibling #601, not rewrite (user-confirmed)** — preserves #601's curated OpenAPI evidence cache; #605 covers the non-Quote/CI remainder.
+3. **Standalone epic, not nested under #449 (user-confirmed)** — reliability-of-existing ≠ coverage-expansion; different success criteria; cross-linked not nested.
+4. **3 design open questions resolved (Stage 2)** — Q1→LOCAL-ONLY (CI is api-key by design), Q2→DOCUMENT-ONLY (probe-before-call doubles traffic; v2), Q3→HYBRID (manual audit + lint + pre-release diff).
+5. **No `.feature` files (Stage 3.5)** — vitest project, not Cucumber; PRD §5 GWT+BUT NOT is the Tier-B spec; tests/guards/scripts ARE the Tier-A bindings. Gap closed: PRD Scenario 6 added for #609 (the only WI lacking an executable scenario).
+6. **Coverage gate PASS-WITH-FINDINGS, remediated in-place (Stage 3.7)** — 3 minor findings (2 seam data-flow pins on #606/#609, 1 stale PRD §8.5/§8.6 text) fixed directly rather than filing tracking-ceremony for one-line consistency.
+7. **L1 sweep IS the L3 triage (design shape)** — one pass categorizes every `isError` site as `feature-not-supported` / `sandbox-precondition` / `unexpected-error`; the catalog + skip-reasons fall out of the same judgment. The `unexpected-error` class (the #496 bug class) defaults to an explicit assertion, NEVER a skip — the single most important reversal.
+
+## Stats
+
+- **Work items**: 6 ready children + 1 tracking epic (#603); #601 sibling-linked (kept)
+- **Ready**: 6 / 6 (binary gate + test-strategy Phase 0 viability — all pass)
+- **PRD requirements**: 20 EARS / 6 GWT scenarios / 3 Planguage attributes — 20/20 mapped, zero orphans
+- **DoR**: `passed-with-findings` → all 3 findings resolved in design + Stage 3.5
+- **Pipeline**: Stages 0→1→2→3→3.5→3.7→4 all complete (2.5 skipped — single context)
+
+## Artifacts
+
+- PRD: [`docs/prds/e2e-test-reliability.md`](../prds/e2e-test-reliability.md)
+- Design: [`docs/designs/e2e-test-reliability.md`](../designs/e2e-test-reliability.md)
+- Requirements brief: [`2026-05-17-requirements-e2e-test-reliability.md`](2026-05-17-requirements-e2e-test-reliability.md)
+- Design brief: [`2026-05-17-design-e2e-test-reliability.md`](2026-05-17-design-e2e-test-reliability.md)
+
+## Next Steps
+
+`/do 604` to start (Wave A; unblocks #606 + #607). Recommended order: #604 → #605 (∥) → #606, #607 → #608, #609.

--- a/docs/designs/e2e-test-reliability.md
+++ b/docs/designs/e2e-test-reliability.md
@@ -1,0 +1,310 @@
+---
+type: solution-design
+date: 2026-05-17
+source_prd: ../prds/e2e-test-reliability.md
+brief: ../briefs/2026-05-17-design-e2e-test-reliability.md
+status: final
+tracks:
+    - test-architecture
+    - technical-architecture
+    - tooling (contract probe, order-independence check, lint guards)
+tracks_skipped:
+    - ui-visual-design (no UI — test infra + scripts)
+    - data-architecture (no persistence — probe writes ephemeral .tmp reports)
+    - ux-prototype-validation (developer-facing; no user testing)
+    - infrastructure (no new infra — local scripts + existing CI)
+    - integration (Qonto already integrated; probe reuses existing http-client)
+    - security (no auth/data-surface change — PRD §8.1 N/A with rationale)
+    - performance (E2E sequential by design — PRD §8.4 out of scope)
+resolved_open_questions:
+    Q1: "Contract probe — LOCAL-ONLY (CI is api-key by design; OAuth cannot live in CI cleanly; quarterly + pre-release local run suffices for solo maintainer)"
+    Q2: "Sandbox preconditions — DOCUMENT-ONLY in v1 (probe-before-call doubles sandbox traffic; deferred to v2 if doc-only proves insufficient)"
+    Q3: "Order independence — HYBRID (manual audit during T1 sweep + module-scope-mutable-state lint + pre-release run-twice-and-diff script; random-seed vitest plugin is v2)"
+---
+
+# Solution Design: E2E Test Reliability + Schema Strictness Sweep
+
+## 1. Goals & Drivers
+
+- **Eliminate the L1 disease**: zero `if (result.isError === true) return;` and zero silent chained-undefined skips suite-wide; every non-execution is a _visible_ skip with a recorded reason
+- **Close the L2 drift**: every `nullable()`-not-`optional()` core schema field reconciled against Qonto's contract, each fix carrying a regression test
+- **Document the L3 contract**: every write endpoint with a known precondition documented + linked from its test
+- **Build the immune system**: a contract probe that detects schema drift before users do
+- **Make order-dependence detectable**: a mechanism that surfaces cross-test state contamination
+- **Prevent regression**: guards (lint / CI grep) that stop the L1 pattern from reappearing
+
+## 2. Constraints
+
+- TypeScript ESM monorepo (turborepo + pnpm); strict tsconfig (composite, exactOptionalPropertyTypes, noUncheckedIndexedAccess, verbatimModuleSyntax)
+- `SPDX-License-Identifier: AGPL-3.0-only` + `(C) 2026 Oleksii PELYKH` on every new file
+- Coverage manifest entries required for new `cli:` / `core:` / `mcp:` surfaces (#462 policy) — N/A here (no new product surfaces; only test + script + doc)
+- No mocking in E2E (project memory `feedback_mcp_void_formatter_trap`)
+- E2E sequential (`--concurrency=1`), per-test 30 s timeout
+- No new runtime deps in `core`/`cli`/`mcp`; probe script may use existing `core` http-client + dev tooling (`tsx`)
+- Commit format `(type) lowercase message`; rebase-only merge (memory `project_merge_method_rebase_only`)
+- `pnpm format:check` + full `pnpm test:e2e` before PR (memories `feedback_pnpm_format_check_first`, `feedback_e2e_before_pr`)
+
+## 3. Context & Scope
+
+External systems:
+
+- **Qonto API** (sandbox via staging-token; production direct) — E2E + contract probe consume read+write endpoints
+- **vitest** — test runner; skip mechanism is `ctx.skip(reason)` (runtime) / `it.skip` (static)
+
+Boundaries:
+
+- IN: L1 elimination, L2 audit, L3 documentation, contract probe, order-independence detection, regression guards
+- OUT: OAuth lifecycle, retry/quarantine infra, mocking, parallel E2E, OAuth-in-CI, new endpoint coverage, framework migration (all per PRD §1.4)
+
+## 4. Solution Strategy
+
+Five shape decisions, in order of consequence:
+
+1. **L1 sweep IS the L3 triage.** Every `if (result.isError === true) return;` site is, by construction, a place where the suite expects a precondition might fail. Walking all 14+ files for L1 _is_ the enumeration of L3 preconditions. T1 and T2 are one pass, not two — categorize each site as `feature-not-supported` / `precondition-not-met` / `unexpected-error` and the doc + skip-reason fall out of the same judgment.
+
+2. **Runtime skip, not silent return.** vitest supports `ctx.skip(reason)` inside a test body. The L1 fix is mechanical: `if (result.isError === true) return;` → `if (result.isError === true) { ctx.skip(\`sandbox: ${firstTextFromMcpResult(result)}\`); return; }`. Chained-undefined becomes skip-reason propagation through a module-scope `lifecycleSkip` carrier.
+
+3. **Helpers make the migration uniform and the regression preventable.** Two helpers in `packages/e2e/src/helpers.ts` (`skipIfToolError`, `skipIfUpstreamSkipped`) collapse ~90 hand-written sites into one reviewed implementation. A CI grep guard (`scripts/check-no-silent-skip.js`, modeled on the existing `scripts/check-coverage-drift.js`) bans the raw pattern's return.
+
+4. **L2 audit is worklist-driven, evidence-cited, conservatively-defaulted.** A generator script emits the 81-item worklist; each item is resolved against Qonto OpenAPI with a citation comment; ambiguous items default to `nullable().optional()` (R-SS-5 — false-positive widening is safe; false-negative strictness causes #496). Each fix carries a "field omitted entirely" regression test.
+
+5. **The contract probe is the L2 audit's force multiplier AND its successor.** Where Qonto docs are silent, the probe resolves L2 ambiguity by observing the live response. Post-v1, the probe replaces manual audit as the ongoing drift detector. Build the probe early enough in Wave C that Wave A's ambiguous L2 items can consume its output.
+
+## 5. Building Blocks
+
+```
+packages/e2e/src/
+├── helpers.ts                         # + skipIfToolError(result, ctx, kind)
+│                                      # + skipIfUpstreamSkipped(carrier, ctx)
+│                                      # + LifecycleSkipCarrier type
+└── {domain}/{cli,mcp}.e2e.test.ts     # 14+ files: L1 sites migrated to helpers
+
+scripts/
+├── check-no-silent-skip.js            # CI guard: bans `isError === true) return` regression
+├── list-nullable-audit-candidates.js  # emits .tmp/l2-audit-worklist.json (81 items)
+├── contract-probe.ts                  # tsx: OAuth → sample endpoints → safeParse → drift report
+├── contract-probe.endpoints.json      # endpoint → schema mapping for the probe sample
+└── check-order-independence.sh        # pre-release: run suite default + shuffled, diff outcomes
+
+docs/
+└── qonto-sandbox-preconditions.md     # NEW: per-write-endpoint precondition catalog
+
+packages/core/src/**/*.schema.ts       # L2 fixes (relax nullable→nullable().optional())
+packages/core/src/**/*.schema.test.ts  # L2 regression tests (per fixed field)
+```
+
+No changes to `cli`/`mcp`/`qontoctl` product packages — this is test + tooling + docs only.
+
+## 6. Track: Test Architecture (T1 — L1 + L2, Wave A)
+
+### 6.1 L1 elimination (R-FV-1 … R-FV-5)
+
+**Helper contract** (`packages/e2e/src/helpers.ts`):
+
+```ts
+type SkipKind = "feature-not-supported" | "sandbox-precondition" | "missing-fixture";
+
+// Returns true if the test should stop (caller does `return`).
+// Calls ctx.skip(reason) so the skip is VISIBLE in the vitest report.
+function skipIfToolError(
+    result: { isError?: boolean },
+    ctx: { skip: (reason: string) => void },
+    kind: SkipKind,
+    detail: string,
+): boolean;
+
+// Module-scope carrier threaded through a CRUD chain.
+interface LifecycleSkipCarrier {
+    reason: string | undefined;
+}
+
+function skipIfUpstreamSkipped(carrier: LifecycleSkipCarrier, ctx: { skip: (reason: string) => void }): boolean; // true if upstream skipped; ctx.skip("upstream-skipped: {reason}")
+```
+
+**Migration pattern** (per the smoking-gun `quotes/mcp.e2e.test.ts`):
+
+```ts
+// BEFORE (L1 mask):
+const listResult = await client.callTool({ name: "quote_list", arguments: {} });
+if (listResult.isError === true) return;
+// ...
+it("updates the created quote", async () => {
+  if (createdQuoteId === undefined) return;   // silent chain
+  ...
+});
+
+// AFTER:
+const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
+it("creates a quote", async (ctx) => {
+  const listResult = await client.callTool({ name: "quote_list", arguments: {} });
+  if (skipIfToolError(listResult, ctx, "feature-not-supported", "quote_list")) {
+    lifecycleSkip.reason = "quote_list unavailable in sandbox";
+    return;
+  }
+  const createResult = await client.callTool({ name: "quote_create", arguments: {...} });
+  // create errors are NO LONGER masked — explicit assertion:
+  expect(createResult.isError, `quote_create failed: ${firstTextFromMcpResult(createResult)}`)
+    .toBeFalsy();
+  createdQuoteId = (...).id;
+});
+it("updates the created quote", async (ctx) => {
+  if (skipIfUpstreamSkipped(lifecycleSkip, ctx)) return;   // VISIBLE skip w/ reason
+  ...
+});
+```
+
+**Per-site triage** (the judgment that makes T1 also do T2):
+
+| Category                | Example                                                      | Action                                                                                         |
+| ----------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `feature-not-supported` | `quote_list` errors because sandbox org has no quotes module | `skipIfToolError(..., "feature-not-supported", ...)` — no doc needed                           |
+| `sandbox-precondition`  | `quote_update` 412 `quote_has_no_attachment`                 | doc entry in `qonto-sandbox-preconditions.md` + (fix test to satisfy OR skip-with-reason+link) |
+| `unexpected-error`      | `quote_create` 422 schema-parse (the #496 bug)               | **explicit `expect(...).toBeFalsy()`** — NEVER skip; this is the class that must surface       |
+
+**Regression guard** (`scripts/check-no-silent-skip.js`, wired into CI like `coverage-drift-check`):
+
+- Fails if `grep -E "isError === true\)\s*return;"` matches anywhere in `packages/e2e/src/`
+- Fails if `it.skip("")` or `ctx.skip("")` (empty reason) matches (R-SR-1)
+- Output mirrors `check-coverage-drift.js` finding format (`[SILENT_SKIP] {file}:{line}`)
+
+### 6.2 L2 strictness audit (R-SS-1 … R-SS-5)
+
+**Worklist generator** (`scripts/list-nullable-audit-candidates.js`):
+
+- Greps `packages/core/src/**/*.ts` (excl. tests) for `z.<type>().nullable()` not followed by `.optional()`
+- Emits `.tmp/l2-audit-worklist.json`: `[{ file, line, field, schema, qonto_doc_hint }]` — 81 items
+- `qonto_doc_hint` left blank; filled per-item during audit
+
+**Per-field decision tree**:
+
+```
+For each worklist item:
+  1. Look up the field in Qonto OpenAPI (developer portal) for the owning endpoint
+  2. Field listed in endpoint's `required` array?
+       YES → keep nullable() (Qonto guarantees presence); annotate worklist `verdict: keep`
+       NO  → relax to nullable().optional(); annotate `verdict: relax`; add regression test
+  3. Docs silent / endpoint not in OpenAPI?
+       → consume contract-probe output (T3) for that endpoint if available
+       → else apply R-SS-5 conservative posture: nullable().optional() + comment:
+         `// Qonto docs silent on {field}.required; conservative optional per R-SS-5 (#496-class safety)`
+```
+
+**Regression test convention** (mirrors #602, appended to existing `*.schema.test.ts`):
+
+```ts
+it("accepts {SchemaName} with {field} omitted entirely (regression: L2 audit)", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { {field}, ...without } = valid{Schema}Fixture;
+  expect(() => {Schema}.parse(without)).not.toThrow();
+});
+```
+
+## 7. Track: Tooling (T2 — Sandbox Preconditions, Wave B)
+
+### 7.1 `docs/qonto-sandbox-preconditions.md` (R-SP-1, R-SP-2)
+
+Structure — one section per write endpoint surfaced by T1's `sandbox-precondition` triage:
+
+```markdown
+### `PATCH /v2/quotes/:id` {#patch-v2-quotes-id}
+
+**Precondition**: Quote must have an attachment before PATCH.
+**Failure signature**: HTTP 412, error key `quote_has_no_attachment`.
+**Remediation in tests**: Upload+attach via `POST /v2/quotes/{id}/attachments`
+before `quote_update`; OR `ctx.skip("sandbox-precondition: see #patch-v2-quotes-id")`.
+**Discovered**: #496 / #602 (2026-05-17).
+```
+
+Tests link inline: `// precondition: docs/qonto-sandbox-preconditions.md#patch-v2-quotes-id`.
+
+### 7.2 `quote_update` 412 resolution (R-SP-3)
+
+- **Path A (attempt first)**: design-phase probe — does Qonto sandbox expose a quote-attachment create endpoint usable from the E2E harness? If yes, CRUD lifecycle gains a step: create quote → upload attachment → attach → update. The 412 disappears for real.
+- **Path B (fallback)**: if attachment-create is itself precondition-laden or absent in sandbox, `ctx.skip("sandbox-precondition: quote_update requires attachment; see docs/qonto-sandbox-preconditions.md#patch-v2-quotes-id")`.
+- Decision rule: spend ≤ 0.5 day on Path A; if it rabbit-holes, take Path B. Either satisfies R-SP-3.
+
+### 7.3 Q2 resolution — DOCUMENT-ONLY (v1)
+
+Probe-before-call (test calls `GET .../attachments` before `PATCH`, skips if absent) **doubles sandbox write-path traffic** and adds a network round-trip per lifecycle test. Document-only (R-SP-1/2) delivers the primary value — contributors stop rediscovering preconditions — at zero runtime cost. Probe-before-call is reconsidered in v2 only if document-only proves insufficient (signal: a precondition regression slips through despite the doc).
+
+## 8. Track: Tooling (T3 — Contract Probe + Order Independence, Wave C)
+
+### 8.1 Contract probe (R-CP-1 … R-CP-4)
+
+**`scripts/contract-probe.ts`** (invoked `pnpm contract-probe`, runs via `tsx`):
+
+```
+1. Load OAuth creds from resolved config (reuse core config-resolver)
+2. Read scripts/contract-probe.endpoints.json: [{ id, method, path, schema }]
+3. For each endpoint (read-only sample):
+     a. Call via core http-client (real Qonto; OAuth; staging-token if configured)
+     b. schema.safeParse(response)
+     c. parse OK → walk response keys vs schema keys → extra_fields / missing_fields
+     d. parse FAIL → map ZodError.issues → strictness_mismatches
+     e. emit suggested corrective declaration per mismatch
+4. Write .tmp/contract-probe/{ISO8601}.json (SchemaDriftReport[])
+5. Console summary table; exit 1 if any endpoint has mismatches (scriptable)
+```
+
+- Read-only by construction (endpoints.json contains only GET endpoints — no write surface)
+- Backoff on 429 (reuse core http-client retry); partial report on rate-limit (A3 mitigation)
+- Expired-OAuth detection → clear error, exit 2 (not silent failure)
+- **Suggest-don't-apply**: never edits `*.schema.ts` (PRD out-of-scope; v2 territory)
+
+### 8.2 Q1 resolution — LOCAL-ONLY (v1)
+
+CI is api-key-only **by design** (CLAUDE.md § E2E in CI). OAuth state is user-specific and cannot live in CI without secret-rotation overhead disproportionate to a solo-maintainer project. Decision: `pnpm contract-probe` is a **local + pre-release** tool, added to `docs/release-runbook.md` as a pre-release step and run quarterly. Re-evaluate a CI job only if drift frequency proves high (signal: >1 user-reported schema bug per quarter despite quarterly probe).
+
+### 8.3 Order independence (R-OI-1, R-OI-2) + Q3 resolution — HYBRID
+
+Three layers, lowest-cost first:
+
+1. **Manual audit during T1 sweep** (Wave B, ~0): while migrating L1 sites, every module-scope mutable `let createdId` is already under the eye. Document the invariant in `docs/e2e-testing.md`: "No test may depend on another test's side effects except within an explicit CRUD-lifecycle `describe` block using the `LifecycleSkipCarrier` pattern."
+2. **Lint guard** (Wave C): ESLint rule flagging module-scope `let` mutated across `it()` blocks _outside_ a recognized lifecycle `describe`. Catches new contamination at authoring time.
+3. **Pre-release diff** (`scripts/check-order-independence.sh`, Wave C): run suite twice — default order, then `--sequence.shuffle --sequence.seed=$RANDOM` — capture vitest JSON reporter outcomes, diff the pass/fail/skip _sets_ (skip-reason text may legitimately differ; pass/fail membership may not). Divergence → list contaminated tests (R-OI-2).
+
+Random-seed-matrix vitest plugin (run N seeds in CI) deferred to v2 — layers 1-3 cover the solo-maintainer risk surface.
+
+## 9. Feasibility & Risk Assessment
+
+| Component               | Feasibility                                | Key risk                                                                  | Mitigation                                                                                     |
+| ----------------------- | ------------------------------------------ | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| L1 elimination (T1)     | HIGH — mechanical, 14 files, helper-driven | Mis-triage: legit skip→fail (flaky suite) or hidden-bug→skip (regression) | Explicit 3-category triage table (§6.1); `unexpected-error` defaults to assertion not skip     |
+| L2 audit (T1)           | HIGH — bounded 81 items, #602 precedent    | False relaxation of a Qonto-required field                                | Regression test per fix; cite Qonto OpenAPI or probe; conservative default is _safe_ direction |
+| Sandbox doc (T2)        | HIGH                                       | Doc staleness                                                             | "doc+test same PR" convention; doc cites discovering issue                                     |
+| `quote_update` fix (T2) | MEDIUM — depends on sandbox attachment API | A5: 412 root cause might not be only attachment_id                        | Path A time-boxed 0.5d → Path B fallback always satisfies R-SP-3                               |
+| Contract probe (T3)     | MEDIUM — new infra, bounded scope          | A3 Qonto rate-limit; A8 docs/runtime divergence                           | Backoff + partial report; A8 is the _motivation_ not a blocker                                 |
+| Order independence (T3) | MEDIUM — least-defined                     | Mechanism over-engineering                                                | Hybrid 3-layer, lowest-cost-first; v2 escape hatch                                             |
+
+**No INFEASIBLE must-have components.** No HIGH risks (all MEDIUM/LOW). A8 (RED assumption — Qonto docs drift from runtime) is the project's _raison d'être_, explicitly not a blocker.
+
+## 10. Requirement → Track Coverage Matrix
+
+| Requirement group      | Requirements | Track | Wave | Building block                                                          |
+| ---------------------- | ------------ | ----- | ---- | ----------------------------------------------------------------------- |
+| Failure visibility     | R-FV-1…5     | T1    | A    | `helpers.ts` + per-file migration + `check-no-silent-skip.js`           |
+| Schema strictness      | R-SS-1…5     | T1    | A    | `list-nullable-audit-candidates.js` + per-field fix + regression tests  |
+| Sandbox preconditions  | R-SP-1…3     | T2    | B    | `docs/qonto-sandbox-preconditions.md` + test links + quote_update fix   |
+| Contract probe         | R-CP-1…4     | T3    | C    | `scripts/contract-probe.ts` + `endpoints.json`                          |
+| Order independence     | R-OI-1…2     | T3    | C    | manual audit + lint guard + `check-order-independence.sh`               |
+| Skip reason discipline | R-SR-1…2     | T1+T3 | A/C  | `skipIfToolError` enforces non-empty; `SkipKind` is the R-SR-2 taxonomy |
+
+**Coverage: 20/20 requirements mapped. Zero orphans. Zero decomposition-introduced gaps.**
+
+## 11. Skipped Tracks (with rationale)
+
+| Track                   | Why skipped                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------- |
+| ui-visual-design        | No UI surface — test code, scripts, markdown                                       |
+| data-architecture       | No persistence — probe writes ephemeral `.tmp/contract-probe/` reports             |
+| ux-prototype-validation | Developer-facing internal tooling; no user testing applicable                      |
+| infrastructure          | No new infra — local `pnpm` scripts + existing CI grep-guard pattern               |
+| integration             | Qonto already integrated; probe reuses existing `core` http-client                 |
+| security                | No auth/data-surface change (PRD §8.1 N/A); probe reuses existing creds, read-only |
+| performance             | E2E sequential by design (PRD §8.4 OUT); probe is on-demand, not hot-path          |
+
+## 12. Change Log
+
+| Date       | Change                                                                    | Source                            |
+| ---------- | ------------------------------------------------------------------------- | --------------------------------- |
+| 2026-05-17 | Initial design authored via `/design-solution` Stage 2; Q1/Q2/Q3 resolved | `/scope` execution (this session) |

--- a/docs/prds/e2e-test-reliability.md
+++ b/docs/prds/e2e-test-reliability.md
@@ -1,0 +1,557 @@
+---
+type: prd
+scope: e2e-test-reliability
+created: 2026-05-17
+formulation: {}
+features: {}
+artifacts:
+    scope_doc: ../../.tmp/scopes/e2e-test-reliability-schema-strictness.md
+    requirements_brief: ../briefs/2026-05-17-requirements-e2e-test-reliability.md
+    design_doc: ../designs/e2e-test-reliability.md
+    design_brief: ../briefs/2026-05-17-design-e2e-test-reliability.md
+dor_status: passed-with-findings
+dor_findings:
+    - "Q1 (Contract-probe CI integration): OAuth-required; CI runs api-key only — design must decide nightly-locally vs new CI job with secret"
+    - "Q2 (Sandbox precondition enforcement): document-only vs probe-before-call — defer to design"
+    - "Q3 (Test order independence verification): mechanism (random-seed runner, snapshot diff, or manual audit) deferred to design"
+related_commands: []
+related_issues:
+    - "#603 (epic — this PRD's tracking umbrella)"
+    - "#604 (Wave A — L1 silent-skip elimination)"
+    - "#605 (Wave A — L2 sweep beyond #601)"
+    - "#606 (Wave B — sandbox-precondition catalog)"
+    - "#607 (Wave B — quote_update 412 fix)"
+    - "#608 (Wave C — contract probe)"
+    - "#609 (Wave C — order-independence detection)"
+    - "#601 (L2 Quote+ClientInvoice slice — kept as-is, sibling of #605)"
+    - "#496 (closed; symmetric fixes merged via #602) — exposed both the L1 silent-mask pattern and L2 strictness drift"
+    - "#449 (orthogonal coverage-expansion epic — cross-linked, not nested)"
+related_prs:
+    - "#602 (merged 2026-05-17) — fix attachment_id + discount.type for Quote + ClientInvoice; deferred the broader audit that this PRD owns"
+---
+
+# PRD: E2E Test Reliability + Schema Strictness Sweep
+
+## 1. Problem & Context
+
+### 1.1 Problem statement
+
+qontoctl's E2E test suite has a **three-layer reliability defect**. Issue #496 — reopened twice over 2 weeks before #602 fixed it — exposed all three layers:
+
+**Layer 1 — Failure-Visibility Defect (the disease).** The suite uses a two-stage silent mask: `if (result.isError === true) return;` swallows tool errors → leaves the CRUD-chain's shared `createdId` as `undefined` → `if (createdId === undefined) return;` swallows every downstream test. Three semantically distinct outcomes — "couldn't execute (skip)", "executed and found a bug (fail)", "executed correctly (pass)" — collapse into a single green dot. This pattern hid #496's `quote_create` schema-parse failure for ~2 weeks while the CRUD lifecycle continued reporting all-green.
+
+**Layer 2 — Schema-Runtime Drift Detection Gap (the absent immune system).** Zod schemas in `packages/core/` encode strict assumptions (`z.string().nullable()`) that diverge from Qonto's actual API contract (`required` list semantics, where fields not in `required` may be entirely absent). There is no detection mechanism; users discover drift in production. The #496 commit explicitly deferred the broader audit — 81 occurrences across 15 core files remain unverified.
+
+**Layer 3 — Sandbox-State Contract (the implicit dependency).** Tests assume Qonto sandbox accepts operations without precondition state. The visible `quote_has_no_attachment` HTTP 412 under suite load (passes solo, fails under load) is the smoke; equivalent preconditions exist undocumented across `quote_send`, `client_invoice` send, transfer initiation, etc. Each contributor rediscovers preconditions individually.
+
+The **visible flake is a symptom, not the disease**. The L1 pattern is the root cause: it allowed L2 (schema bugs) to hide and obscured L3 (precondition gaps) as flake noise.
+
+### 1.2 Why now
+
+- #496 reopened twice (2026-05-07 → 2026-05-17) — the L1 mask is the reason it kept escaping detection
+- Concrete L1 scope: **30 occurrences of `isError === true) return` across 14+ E2E files**; **~60 chained `=== undefined) return` skips across 25+ files**
+- Concrete L2 scope: **81 nullable-not-optional fields across 15 core schema files**; #602 fixed only `attachment_id` + `discount.type` on two surfaces (4 of 81)
+- The diagnostic is fresh — discovery context, error reproducer, and root-cause analysis are all in living memory; deferring loses fidelity
+- Solo maintainer with no test-review safety net → preventive infrastructure is the only durable defense
+
+### 1.3 In scope (v1, 2-3 weeks appetite)
+
+**Wave A — Quick wins (3-5 days)**:
+
+- Replace all 30 `if (result.isError === true) return;` occurrences with `it.skip("reason")` (legitimate precondition) or explicit failure (unexpected error)
+- Replace silent chained-undefined skips with `it.skip("upstream-skipped: {dependency}")` carrying the upstream test's recorded reason
+- Audit + remediate L2 strictness drift across all 81 occurrences (core schemas): each `nullable()` field cross-checked against Qonto's `required` list; relaxed to `nullable().optional()` where the field is not in `required`
+- Add regression tests per L2 fix (mirror the #602 pattern: "accepts {field} omitted entirely (regression: #{issue})")
+
+**Wave B — Sweep & documentation (5-7 days)**:
+
+- Systematic sweep: enumerate every CRUD-lifecycle chain in E2E (clients, client-invoices, quotes, webhooks, insurance, cards, etc.) — audit each for L1 occurrences AND the masked-`create` failure pattern
+- Author `docs/qonto-sandbox-preconditions.md` — per-write-endpoint documentation of required state (attachment for quote_update, mailbox for quote_send, etc.)
+- Fix the specific `quote_update` 412 root cause by ensuring the CRUD lifecycle attaches an attachment before update, OR documenting the precondition + skipping with reason
+- Cross-reference precondition docs from the relevant tests (inline comment with `docs/qonto-sandbox-preconditions.md#{anchor}`)
+
+**Wave C — Infrastructure (5-10 days)**:
+
+- Schema-vs-runtime contract probe: tool that hits a representative sample of Qonto endpoints with OAuth credentials, parses live responses, and diffs them against the Zod schemas to surface drift (extra fields, missing fields, type mismatches)
+- Probe runs locally (OAuth-required) on demand; design decision deferred on whether/how it integrates with CI
+- Test order independence verification: mechanism to run the E2E suite in shuffled order and detect outcome divergence (any test that fails under one order but passes under another flags a state-isolation bug)
+
+### 1.4 Out of scope (explicit)
+
+| Out                                                                                   | Why                                                                                                                                          |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| OAuth credential lifecycle / refresh-token expiry recovery                            | User-confirmed environmental (re-login handles it); not a test reliability issue                                                             |
+| Deflake retry / quarantine infrastructure (retry-with-jitter, flaky-test annotations) | Convergence-driven philosophy: fix root causes, don't mask flakes with retries                                                               |
+| Mocking the Qonto API in E2E                                                          | Explicitly avoided per project convention (memory: `feedback_mcp_void_formatter_trap`) — E2E exists precisely because mocks lied in the past |
+| Parallel E2E execution                                                                | Sequential (`--concurrency=1`) is the chosen tradeoff; revisit only if suite >10 min                                                         |
+| OAuth-required tests in CI                                                            | CI is api-key-only by design; OAuth suites are local-only; this PRD does not change that                                                     |
+| New Qonto API endpoint coverage                                                       | This is reliability work on existing coverage, not coverage expansion (covered by separate scope per #449)                                   |
+| Test framework migration (vitest → other)                                             | Out of scope; vitest is the locked choice                                                                                                    |
+| Sandbox environment provisioning (new test orgs, seed data)                           | Defer until precondition documentation reveals a structural need                                                                             |
+
+### 1.5 Appetite
+
+**2-3 weeks for v1.** Three waves (A: 3-5d, B: 5-7d, C: 5-10d) sized to complete the systematic sweep + preventive infrastructure. Cap: no novel research, no Qonto-side coordination, no test framework changes. Wave C contract probe is bounded to "detect drift" not "auto-remediate"; auto-remediation is v2.
+
+## 2. Stakeholders
+
+| Stakeholder               | Role                                                          | Primary concerns                                                                               |
+| ------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Solo maintainer (Oleksii) | Runs E2E locally; fixes test+schema defects; reviews this PRD | "Does the suite tell me the truth?"; "Am I shipping schema bugs that hide for weeks?"          |
+| qontoctl end-user         | Hits production with the CLI/MCP server                       | "Why does the CLI throw a Zod parse error on a field I don't care about?" (the #496 user pain) |
+| MCP/LLM clients           | Programmatic consumers of qontoctl MCP tools                  | "Why does `quote_update` return `isError: true` with an opaque schema error?"                  |
+| Future contributors       | Read the test suite to understand patterns                    | "When a test skips, what was the reason? Why is the same pattern in 30 places?"                |
+| CI pipeline               | Runs api-key-compatible E2E against production sandbox        | "Are E2E results stable enough to be a reliable signal?"                                       |
+
+## 3. ORCA Object Model
+
+### Object: `E2ETest`
+
+One `it()` block executing against live Qonto API.
+
+**Attributes**:
+
+- `id` — `{domain}/{surface}.e2e.test.ts > {describe-path} > {it-title}`
+- `surface` — `cli` | `mcp`
+- `domain` — `quotes` | `client-invoices` | `webhooks` | etc.
+- `dependency_chain` — list of prior tests whose state this test depends on (CRUD chains)
+- `outcome` — `pass` | `fail` | `skip` (with recorded reason); MUST NOT be conflated
+
+**CTAs**:
+
+- Execute (run against live API)
+- Skip-with-reason (explicit precondition not met)
+- Fail-explicitly (unexpected error path)
+
+### Object: `PreconditionGate`
+
+Explicit guard preceding an API call. Replaces silent early-return.
+
+**Attributes**:
+
+- `precondition_kind` — `tool-error-on-list` (sandbox doesn't support feature) | `tool-error-on-create` (precondition not met) | `upstream-skipped` (prior test in chain skipped)
+- `recorded_reason` — human-readable string surfaced in vitest report
+- `link_to_precondition_doc` — optional anchor in `docs/qonto-sandbox-preconditions.md`
+
+**CTAs**:
+
+- Assert (fail explicitly if precondition not met)
+- Skip (`it.skip("reason")` — call vitest's skip mechanism)
+
+### Object: `ZodSchemaField`
+
+One field declaration in a `core` Zod schema.
+
+**Attributes**:
+
+- `file_path`, `line_number`
+- `field_name`
+- `strictness_mode` — `required` | `nullable` | `nullable-optional` | `optional`
+- `qonto_required_status` — present in Qonto's `required` list (true / false / unknown)
+
+**CTAs**:
+
+- Validate (used at runtime)
+- Audit-strictness (compare against Qonto contract; flag drift)
+- Fix-strictness-drift (relax `nullable` → `nullable().optional()` when not in Qonto's `required` list)
+
+### Object: `QontoEndpointContract`
+
+A Qonto API operation as documented + as observed in runtime.
+
+**Attributes**:
+
+- `method`, `path` (e.g., `PATCH /v2/quotes/:id`)
+- `request_required_fields` — from docs
+- `response_required_fields` — from docs
+- `response_observed_shape` — from runtime probe
+- `success_preconditions` — runtime observations (e.g., "PATCH requires attachment_id present")
+
+**CTAs**:
+
+- Probe-shape (call endpoint, capture response shape)
+- Probe-precondition (intentionally violate precondition, observe error code + message)
+
+### Object: `SchemaDriftReport`
+
+Output of one contract-probe run.
+
+**Attributes**:
+
+- `endpoint_id`
+- `extra_fields` — present in runtime, absent from schema
+- `missing_fields` — present in schema, absent from runtime
+- `strictness_mismatches` — schema strict where runtime omits, or vice versa
+- `captured_at`
+
+**CTAs**:
+
+- Generate (run probe → diff → emit report)
+- Surface (write to artifact for review)
+
+### Object: `SandboxPreconditionDoc`
+
+Markdown documentation of preconditions per write endpoint.
+
+**Attributes**:
+
+- `endpoint_id`
+- `precondition_description` (e.g., "Quote PATCH requires `attachment_id` set on the quote first; create attachment via `POST /v2/quotes/{id}/attachments`")
+- `failure_signature` (HTTP 412 + error key, e.g., `quote_has_no_attachment`)
+- `linked_tests` — list of E2E tests that cite this doc
+
+**CTAs**:
+
+- Author (write the doc entry)
+- Link-from-test (inline comment in test code)
+
+### Object: `CRUDLifecycleChain`
+
+A sequence of tests sharing module-scope state (`create → update → send → delete`).
+
+**Attributes**:
+
+- `chain_id` — e.g., `quotes/mcp.e2e.test.ts > MCP quote tools (e2e) > quote CRUD lifecycle (MCP)`
+- `shared_state_variables` — e.g., `createdQuoteId`
+- `tests` — ordered list of `E2ETest` ids
+- `audit_status` — `l1-found` | `l1-remediated` | `clean`
+
+**CTAs**:
+
+- Audit-for-L1-pattern (scan for silent-skip occurrences)
+- Remediate (replace with explicit skip-with-reason)
+
+## 4. EARS Requirements
+
+### 4.1 Failure visibility (L1)
+
+- **R-FV-1 (Ubiquitous)**: The test suite SHALL NOT use the pattern `if (result.isError === true) return;` (silent early-return on tool error). Every such occurrence SHALL be replaced with either (a) `it.skip("reason")` carrying a recorded reason, OR (b) an explicit assertion that fails the test.
+- **R-FV-2 (Ubiquitous)**: The test suite SHALL NOT use the pattern `if ({sharedId} === undefined) return;` for shared-state CRUD chains. Replacement: `it.skip(\`upstream-skipped: ${reason from prior test}\`)` — the chain MUST propagate the recorded skip reason.
+- **R-FV-3 (State-driven)**: When a test's required precondition is not met, the test SHALL be marked `skipped` in the vitest report (visible, not silently green) with the precondition reason captured in the report.
+- **R-FV-4 (Unwanted behavior)**: If a test encounters an unexpected error path (HTTP error code not enumerated in the precondition doc), the test SHALL fail explicitly — NEVER silently skip.
+- **R-FV-5 (Ubiquitous)**: The systematic sweep SHALL cover at minimum the 14+ test files currently containing the L1 pattern: clients, products, client-invoices, terminals, quotes, cards, intl-transfers, statements, teams, webhooks, insurance, international, bulk-transfers, intl-beneficiaries.
+
+### 4.2 Schema strictness (L2)
+
+- **R-SS-1 (Ubiquitous)**: Every Zod schema field declared as `z.{type}().nullable()` without `.optional()` SHALL be audited against the corresponding Qonto endpoint's `required` list (or, where docs are silent, against runtime-observed response shape).
+- **R-SS-2 (Conditional)**: When a field is NOT in Qonto's `required` list AND the schema currently declares it `nullable` (non-optional), the schema SHALL be updated to `nullable().optional()`.
+- **R-SS-3 (Ubiquitous)**: Each L2 fix SHALL include a regression test using the format `parses a response with {field} omitted entirely (regression: #{issue})` — mirroring the #602 convention.
+- **R-SS-4 (Ubiquitous)**: The audit SHALL cover all 81 occurrences across the 15 core schema files identified by grep.
+- **R-SS-5 (Conditional)**: When an audit verdict is ambiguous (Qonto docs don't list the field in `required` AND runtime probe is unavailable), the audit entry SHALL be recorded with `verdict: ambiguous` and the conservative posture (`nullable().optional()`) SHALL be applied with a comment citing the ambiguity.
+
+### 4.3 Sandbox preconditions (L3)
+
+- **R-SP-1 (Ubiquitous)**: For every Qonto write endpoint with a known non-trivial precondition (412 / 422 with specific error key), `docs/qonto-sandbox-preconditions.md` SHALL contain an entry documenting: endpoint, precondition description, failure signature (HTTP + error key), and remediation path (how the E2E test sets up the precondition).
+- **R-SP-2 (Ubiquitous)**: Every E2E test that depends on a non-trivial precondition SHALL link to its precondition-doc entry via inline comment (`// see docs/qonto-sandbox-preconditions.md#{anchor}`).
+- **R-SP-3 (Conditional)**: When the `quote_update` test's `quote_has_no_attachment` 412 precondition can be satisfied programmatically, the test SHALL satisfy it (e.g., attach an attachment before update). When it cannot, the test SHALL `it.skip("Qonto sandbox: quote_update requires attachment_id; see docs/qonto-sandbox-preconditions.md#quote-update")`.
+
+### 4.4 Schema-vs-runtime contract probe
+
+- **R-CP-1 (Ubiquitous)**: A contract probe SHALL exist as an invocable tool (CLI script under `scripts/` or `pnpm` task) that, given OAuth credentials, calls a representative sample of Qonto read endpoints and compares actual response shape against the declared Zod schemas.
+- **R-CP-2 (Ubiquitous)**: The probe output SHALL produce a `SchemaDriftReport` per endpoint: extra fields (in runtime, missing from schema), missing fields (in schema, absent from runtime), strictness mismatches.
+- **R-CP-3 (Ubiquitous)**: The probe SHALL be invokable locally; CI integration is a design-phase decision (open question Q1 in DoR findings).
+- **R-CP-4 (Optional feature)**: Where a strictness mismatch is detected, the probe SHALL suggest the corrective Zod declaration (e.g., "`attachment_id` is absent from response — change `z.string().nullable()` to `z.string().nullable().optional()`").
+
+### 4.5 Test order independence
+
+- **R-OI-1 (Ubiquitous)**: A mechanism SHALL exist to detect cross-test state contamination — running the E2E suite in shuffled order MUST yield the same set of pass/fail/skip outcomes as default order (modulo legitimate skip reasons changing).
+- **R-OI-2 (Conditional)**: When order-shuffled run differs from default-order run, the divergent tests SHALL be flagged for state-isolation review (either share state explicitly via `beforeAll` setup, or eliminate the implicit dependency).
+
+### 4.6 Skip reason discipline
+
+- **R-SR-1 (Ubiquitous)**: Every `it.skip("reason")` invocation SHALL include a non-empty reason string. Empty-reason skips SHALL fail lint.
+- **R-SR-2 (Optional feature)**: Skip reasons SHOULD follow a discoverable convention enabling future trend analysis (e.g., prefix categories: `sandbox-precondition:`, `upstream-skipped:`, `feature-not-supported:`, `missing-fixture:`).
+
+## 5. Acceptance Criteria
+
+### Scenario 1: Replacing an L1 silent-skip with explicit failure (R-FV-1, R-FV-4)
+
+**Given** a test in `packages/e2e/src/quotes/mcp.e2e.test.ts` that currently reads:
+
+```ts
+const result = await client.callTool({ name: "quote_list", arguments: {} });
+if (result.isError === true) return;
+```
+
+**When** the L1 audit + remediation Wave A is complete
+**Then** the test SHALL read:
+
+```ts
+const result = await client.callTool({ name: "quote_list", arguments: {} });
+if (result.isError === true) {
+    return; // ← FAIL: this pattern is banned
+}
+```
+
+This pattern SHALL be replaced with one of:
+
+```ts
+// Form A: precondition skip (sandbox doesn't support feature)
+if (result.isError === true) {
+    return it.skip("Qonto sandbox: feature-not-supported");
+}
+// Form B: explicit assertion (unexpected error is a test failure)
+expect(result.isError, `unexpected tool error: ${firstTextFromMcpResult(result)}`).toBeFalsy();
+```
+
+**But not**:
+
+- The test SHALL NOT silently swallow the error (regression of L1)
+- The test SHALL NOT use a generic `it.skip("error")` reason (R-SR-1)
+- The test SHALL NOT skip on errors that ARE in scope (legitimate failures must surface)
+
+### Scenario 2: L2 schema audit fix with regression test (R-SS-1, R-SS-2, R-SS-3)
+
+**Given** a Zod schema field `header: z.string().nullable()` at `packages/core/src/types/quote.schema.ts:105`
+**And** Qonto's Quote response docs do NOT list `header` in `required`
+**When** the L2 audit Wave A runs
+**Then** the field SHALL be updated to `header: z.string().nullable().optional()`
+**And** a regression test SHALL be added to the matching `.schema.test.ts`:
+
+```ts
+it("accepts a quote response with header omitted entirely (regression: L2 audit)", () => {
+    const { header, ...withoutHeader } = validQuoteFixture;
+    expect(() => QuoteSchema.parse(withoutHeader)).not.toThrow();
+});
+```
+
+**But not**:
+
+- The audit SHALL NOT blindly relax every field (false-positive risk); each fix SHALL cite either Qonto docs or runtime probe evidence
+- The audit SHALL NOT silently widen schemas already covered by tests (the regression test makes the contract explicit)
+- The audit SHALL NOT introduce `.optional()` on fields that ARE in Qonto's `required` list
+
+### Scenario 3: Sandbox precondition documentation + test link (R-SP-1, R-SP-2, R-SP-3)
+
+**Given** the `quote_update` MCP test that fails under suite load with HTTP 412 `quote_has_no_attachment`
+**When** Wave B runs
+**Then** `docs/qonto-sandbox-preconditions.md` SHALL contain:
+
+```markdown
+### `PATCH /v2/quotes/:id`
+
+**Precondition**: Quote must have `attachment_id` set before update.
+
+**Failure signature**: HTTP 412 with error key `quote_has_no_attachment`.
+
+**Remediation in tests**: Create + attach attachment via `POST /v2/quotes/{id}/attachments` before invoking `quote_update`, OR skip with `it.skip("Qonto sandbox: see #quote-update")`.
+```
+
+**And** the test SHALL be either:
+
+- Modified to attach an attachment before `quote_update`, OR
+- Marked `it.skip("Qonto sandbox: quote_update requires attachment_id; see docs/qonto-sandbox-preconditions.md#patch-v2quotesid")`
+
+**But not**:
+
+- The test SHALL NOT continue to fail silently under suite load (regression)
+- The doc SHALL NOT be silently authored without linking from the affected test (orphan doc)
+- The doc SHALL NOT speculate beyond Qonto's published / runtime-observed behavior
+
+### Scenario 4: Contract probe drift detection (R-CP-1, R-CP-2)
+
+**Given** the contract probe tool exists and OAuth credentials are configured
+**When** the probe runs against `GET /v2/quotes` and the response includes a field `e_invoicing_status` not present in `QuoteSchema`
+**Then** the probe SHALL produce a `SchemaDriftReport`:
+
+```json
+{
+    "endpoint": "GET /v2/quotes",
+    "extra_fields": [{ "field": "e_invoicing_status", "observed_type": "string" }],
+    "missing_fields": [],
+    "strictness_mismatches": []
+}
+```
+
+**And** the report SHALL include a suggested corrective Zod declaration
+**But not**:
+
+- The probe SHALL NOT mutate any state (read-only by construction)
+- The probe SHALL NOT auto-modify schema files (suggest, don't apply — manual review required)
+- The probe SHALL NOT require staging-token (OAuth alone is sufficient for read endpoints; staging-token is per-test concern)
+
+### Scenario 5: Suite-wide L1 sweep coverage (R-FV-5)
+
+**Given** Wave B runs the systematic sweep across the 14+ identified L1-pattern files
+**When** the sweep is complete
+**Then** `grep -rn "if (result.isError === true) return" packages/e2e/src/ | wc -l` SHALL return `0`
+**And** `grep -rn "=== undefined) return" packages/e2e/src/ | grep -v helpers.ts | wc -l` SHALL return `0` (excluding the `helpers.ts` utility which is not test code)
+**And** the chained-skip propagation pattern SHALL be implemented uniformly across CRUD chains
+**But not**:
+
+- The sweep SHALL NOT convert silent skips to silent failures (anti-pattern: replacing one mask with another)
+- The sweep SHALL NOT skip lifecycle chains that have masked failures (every chain MUST be audited)
+
+### Scenario 6: Order-independence diff detects cross-test contamination (R-OI-1, R-OI-2)
+
+**Given** the E2E suite passes in default order
+**And** a test `T` mutates module-scope state outside an explicit `LifecycleSkipCarrier` `describe` block
+**When** `scripts/check-order-independence.sh` runs the suite in default order, then in shuffled order (`--sequence.shuffle --sequence.seed=$RANDOM`)
+**Then** the two runs' pass/fail outcome **sets** SHALL be diffed
+**And** if `T`'s pass/fail membership differs between orders, the script SHALL exit non-zero
+**And** the divergent test(s) SHALL be listed for state-isolation review
+**But not**:
+
+- Skip-**reason** text differences alone SHALL NOT trigger divergence — only pass/fail set membership counts (legitimate skip reasons may differ by order)
+- The script SHALL NOT classify a Qonto-sandbox-state change between runs as contamination — a divergence SHALL be re-confirmed with a second shuffled run before being reported (distinguish environmental flake from real contamination)
+- The check SHALL NOT block CI (it is a pre-release local gate per Q1/Q3 design resolution — CI is api-key-only and cannot run the OAuth-gated suite)
+
+## 6. Success Criteria
+
+### 6.1 Leading indicators (drive execution feedback)
+
+| Indicator                                           | Meter                                                                              | Current                       | Target                                                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------------- | ------------------------------- |
+| L1 `isError === true) return` occurrences           | `grep -rn ... packages/e2e/src/`                                                   | 30                            | 0                                                         |
+| Chained `=== undefined) return` in tests            | `grep -rn ... packages/e2e/src/                                                    | grep -v helpers.ts`           | ~60                                                       | 0                               |
+| `nullable()` not-`.optional()` in core schemas      | `grep -rn "z.{type}().nullable()" packages/core/src/                               | grep -v optional`             | 81                                                        | 0 deviation from Qonto contract |
+| Documented sandbox preconditions per write endpoint | Count of entries in `docs/qonto-sandbox-preconditions.md`                          | 0                             | ≥1 per write endpoint with known non-trivial precondition |
+| Contract probe drift report                         | Probe output: count of `extra_fields` + `missing_fields` + `strictness_mismatches` | unknown (probe doesn't exist) | <5 per endpoint (steady-state; >5 = investigate)          |
+
+### 6.2 Lagging indicators (validate outcomes)
+
+| Indicator                                      | Meter                                                                                     | Target                                         |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| E2E suite outcome stability on full-suite-load | Pass/fail/skip set identical across 5 consecutive runs                                    | 100% stable (no flakes)                        |
+| Hidden-failure recurrence                      | Production reports of "schema parse error" or "silent test green when feature was broken" | 0 in next quarter                              |
+| Contract drift detected per quarter            | Probe run quarterly; count of new drift items                                             | Indicator only — 0 over time = stable contract |
+| Time-to-diagnosis for new schema bugs          | Wall-clock from user report to root-cause identification                                  | <1 day (vs ~2 weeks for #496)                  |
+
+### 6.3 Decision gates
+
+- **Gate A (Wave A → Wave B)**: L1 + L2 audits complete; regression tests added; CI green. If audit reveals significantly more drift than expected (>30 nullable-fix failures), pause and reassess scope.
+- **Gate B (Wave B → Wave C)**: Sandbox preconditions doc covers all write endpoints with known 412/422 paths; `quote_update` 412 root cause resolved. If Wave B uncovers Qonto-side issues requiring coordination, defer those specific items and document.
+- **Gate C (Wave C completion)**: Contract probe runs locally and produces a drift report. CI integration decision made (design-phase question Q1). Test order independence verification mechanism in place.
+
+## 7. Quality Attributes (Planguage)
+
+### 7.1 Test reliability
+
+- **Tag**: `test-reliability`
+- **Gist**: E2E suite produces deterministic pass/fail/skip outcomes across runs
+- **Scale**: Stability rate = (runs with identical outcome set) / (total runs) over a rolling window
+- **Meter**: 5 consecutive full-suite-load runs locally; outcome set diffed
+- **Wish**: 100%
+- **Target**: 100% (post-Wave-A+B)
+- **Acceptable**: 95% (one tolerable flake per 20 runs, with documented sandbox-side cause)
+- **Fail**: <90% (suite has masked or order-dependent defects)
+
+### 7.2 Schema fidelity
+
+- **Tag**: `schema-fidelity`
+- **Gist**: Zod schemas match Qonto's actual API contract
+- **Scale**: (Schema fields with strictness matching Qonto's `required` list OR runtime-observed shape) / (total fields)
+- **Meter**: Contract probe report — counts of `extra_fields`, `missing_fields`, `strictness_mismatches`
+- **Wish**: 100% (zero drift)
+- **Target**: ≥95% (some drift is inevitable; alerts on >5% deviation per endpoint)
+- **Acceptable**: 90%
+- **Fail**: <85% (systemic drift — investigate)
+
+### 7.3 Failure visibility
+
+- **Tag**: `failure-visibility`
+- **Gist**: Test outcomes are not silently conflated; every skip has a recorded reason
+- **Scale**: Binary — zero L1 occurrences across the suite
+- **Meter**: `grep -rn "if (result.isError === true) return" packages/e2e/src/` should return zero matches; `grep -rn "it.skip(\"\")" packages/e2e/src/` should return zero matches
+- **Wish**: 0 occurrences
+- **Target**: 0 occurrences (binary — passes or fails)
+- **Fail**: ≥1 occurrence (the disease is recurring)
+
+## 8. Cross-Cutting Concerns
+
+### 8.1 Security
+
+**N/A — no auth changes, no new credentials, no new data surface.** The contract probe reuses existing OAuth credentials from `.qontoctl.yaml`; no new secret storage. The sandbox-preconditions doc may reference example error responses, which MUST be redacted of any organization-identifying data (apply existing redaction conventions from `qontoctl diagnose`).
+
+### 8.2 Compliance & Regulatory
+
+**N/A.** This is test/schema infrastructure work; no regulated user data is collected, transmitted, or stored beyond what the existing E2E suite already touches (Qonto sandbox responses, which are user-owned). License headers (`SPDX-License-Identifier: AGPL-3.0-only` + copyright) MUST appear in any new source files per project convention.
+
+### 8.3 Reliability & Observability
+
+**PRIMARY focus of this PRD.** Cross-references:
+
+- Contract probe (R-CP-1 to R-CP-4) is the observability primitive for schema drift
+- Skip reason discipline (R-SR-1, R-SR-2) makes test-level reliability observable
+- Sandbox preconditions doc (R-SP-1 to R-SP-3) is observability for precondition state
+- Test order independence (R-OI-1, R-OI-2) is observability for cross-test contamination
+
+**Failure modes considered**:
+
+- Contract probe rate-limited by Qonto: design SHALL include exponential backoff + partial-report support
+- OAuth credential expiry during probe run: probe SHALL detect expired credentials and surface clear error (not silent failure)
+- Test order independence check itself flaky: mechanism SHALL distinguish "test failed under shuffled order" (real bug) from "Qonto sandbox state changed between runs" (environmental)
+
+### 8.4 Performance & Scalability
+
+**Out of scope** for this PRD. E2E suite is sequential by design (`--concurrency=1` per `feedback_e2e_before_pr` memory) and parallelism is explicitly out (§ 1.4). Contract probe runs locally on demand, not in hot path. Schema audit is one-time work + ongoing probe-driven monitoring; no scaling concern.
+
+### 8.5 Operational
+
+- **CI integration of contract probe** — RESOLVED in design (Q1 → LOCAL-ONLY): CI is api-key-only by design and OAuth cannot live in CI cleanly, so the probe is a local + pre-release tool added to `docs/release-runbook.md`, run quarterly. A CI job is reconsidered only if drift frequency proves high (>1 user-reported schema bug per quarter despite quarterly probe). Tracked as #608.
+- **Quarterly schema audit cadence**: post-v1, the contract probe SHOULD be invoked quarterly (or pre-major-release) to catch new drift. This becomes part of the release runbook.
+- **Skip reason taxonomy** (R-SR-2) is operational instrumentation — enables future trend analysis (e.g., "% of E2E test runs ended in skip-not-pass" as a release-readiness signal).
+- **Sandbox preconditions doc maintenance**: when Qonto changes a precondition (e.g., adds a 2FA requirement on transfer), the doc + linked tests SHALL be updated in the same PR that adapts the test.
+
+### 8.6 Lifecycle
+
+- **Schema audit recurring task**: post-v1, contract probe runs quarterly. Findings become work items.
+- **L1 pattern regression prevention** — RESOLVED in design (Q3 → HYBRID): `scripts/check-no-silent-skip.js` CI guard (tracked #604) bans reintroduction of `if (result.isError === true) return;`; a complementary ESLint rule for out-of-lifecycle module-scope mutable state is part of the order-independence work (tracked #609).
+- **Sandbox preconditions doc**: living document, updated as new preconditions are discovered.
+- **Deprecation**: this PRD's work is done when all leading indicators hit target AND a stable cadence of contract-probe runs is established. The "L1 pattern" is permanently retired from the codebase; the audit/probe infrastructure persists.
+
+## 9. Feature Completeness Verdict
+
+| Feature                                             | Verdict       | Notes                                                                                                                                                                                                               |
+| --------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| L1 silent-mask elimination (Wave A scope)           | COMPLETE      | R-FV-1 to R-FV-5; all 30+60 occurrences enumerated; mechanical refactor with regression tests via existing vitest harness                                                                                           |
+| L2 schema strictness audit (Wave A scope)           | COMPLETE      | R-SS-1 to R-SS-5; 81 occurrences enumerated; regression-test convention defined per #602                                                                                                                            |
+| Sandbox preconditions documentation (Wave B scope)  | NEAR-COMPLETE | R-SP-1 to R-SP-3; coverage list "every write endpoint with known non-trivial precondition" is enumerable; exact endpoint count emerges from L1 sweep                                                                |
+| `quote_update` 412 root-cause fix (Wave B scope)    | COMPLETE      | R-SP-3; two explicit alternatives (attach + update OR document + skip)                                                                                                                                              |
+| Schema-vs-runtime contract probe (Wave C scope)     | COMPLETE      | R-CP-1 to R-CP-4; Q1 resolved in design (LOCAL-ONLY); Scenario 4 is the executable spec; tracked as #608                                                                                                            |
+| Test order independence verification (Wave C scope) | NEAR-COMPLETE | R-OI-1, R-OI-2; Q3 resolved in design (HYBRID 3-layer); Scenario 6 added in Stage 3.5 as the executable spec; remaining gap is implementation-only (lint rule + diff script), not design ambiguity; tracked as #609 |
+| Skip reason taxonomy (Wave C scope)                 | NEAR-COMPLETE | R-SR-1 enforceable via the `check-no-silent-skip.js` guard (#604); R-SR-2 taxonomy IS the `SkipKind` union (design §6.1) — convention defined, lint-enforcement of the taxonomy categories deferred                 |
+
+**Overall verdict**: `passed-with-findings`. After Stage 2 design (Q1/Q2/Q3 resolved) and Stage 3.5 (Scenario 6 added), the prior INCOMPLETE feature is now NEAR-COMPLETE (design ambiguity removed; only implementation remains, tracked as #609). Remaining NEAR-COMPLETE items have implementation-only gaps, not specification gaps. No COMPLETE feature has hidden gaps. The original DoR findings Q1/Q2/Q3 are resolved in `docs/designs/e2e-test-reliability.md` frontmatter.
+
+## 10. Assumptions & Risks
+
+| ID  | Color  | Assumption                                                                                                                         | Risk if false                                                                                                             |
+| --- | ------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| A1  | Green  | Qonto's API docs `required` list is the authoritative source for "field may be omitted" semantics                                  | Medium — runtime probe is the fallback (per R-SS-5); ambiguous cases default to conservative `nullable().optional()`      |
+| A2  | Green  | The 30 L1 occurrences + 60 chained-undefined occurrences enumerate the complete suite-wide pattern                                 | Low — `grep` is mechanical; false negatives unlikely                                                                      |
+| A3  | Yellow | Qonto sandbox is stable enough to support a contract probe (no rate-limit blocking, no SCA-gate on reads)                          | Medium — read endpoints don't require SCA; rate-limit may need backoff                                                    |
+| A4  | Green  | OAuth credentials in `.qontoctl.yaml` are sufficient for contract probe (no new OAuth scope needed)                                | Low — probe hits the same endpoints E2E already uses                                                                      |
+| A5  | Yellow | `quote_update` 412 root cause is `attachment_id` missing (not some other sandbox-state precondition)                               | Medium — design phase should probe with explicit attachment + update to confirm before committing fix path                |
+| A6  | Green  | The contract probe's design surface is bounded (no auto-remediation; suggest-don't-apply)                                          | Low — explicit out-of-scope item; v2 territory                                                                            |
+| A7  | Yellow | All 81 nullable-not-optional occurrences are actual drift candidates (vs false positives where Qonto really does require non-null) | Medium — audit phase will distinguish; expected ~70% are drift candidates based on #602 sample (4 of 4 confirmed)         |
+| A8  | Red    | The Qonto OpenAPI / docs are kept up to date with the live API                                                                     | High — historical evidence (`#496` itself) shows docs and runtime diverge; contract probe exists precisely to detect this |
+
+## 11. Source Traceability
+
+| Source                                                                             | Items derived                                                                  | Confidence                                            |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------- | ------------------ |
+| `.tmp/scopes/e2e-test-reliability-schema-strictness.md` (10-item enriched seed)    | All 10 buckets → mapped to Waves A/B/C; out-of-scope OAuth confirmed           | B — user-authoritative                                |
+| Conversation context (`/do #496` execution + post-merge findings)                  | L1 pattern diagnosis; `quote_update` 412 reproducer; chained-skip mechanism    | B — user-authoritative + direct observation           |
+| `grep -rn "isError === true) return" packages/e2e/src/` (30 hits across 14+ files) | R-FV-5 sweep scope; success metric current value (30)                          | A — self-verifying                                    |
+| `grep -rn "z.string().nullable()" packages/core/src/                               | grep -v optional` (81 hits across 15 files)                                    | R-SS-4 audit scope; success metric current value (81) | A — self-verifying |
+| `packages/e2e/src/quotes/mcp.e2e.test.ts:140-187` (the smoking gun)                | Scenario 1 acceptance criteria; L1 mechanism documented                        | A — direct file evidence                              |
+| `packages/core/src/types/quote.schema.ts:96-110` (post-#602 schema)                | Regression-test format (Scenario 2); L2 fix convention                         | A — direct file evidence                              |
+| `commits/471b39e` + `commits/83e0056` (#602 merge)                                 | Deferred-audit acknowledgment; out-of-scope clarification (Wave C not in #602) | A — git history                                       |
+| OpenAI cookbook + Qonto API docs (referenced by #602 comments)                     | A1 assumption (docs are authoritative for `required` lists)                    | C — secondary; cross-validated by runtime             |
+
+## 12. Open Questions
+
+| ID  | Question                                                                                                                                                                    | Phase to resolve                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Q1  | Does the contract probe run in CI (new job + OAuth secret) or local-only (nightly cron / pre-release manual)?                                                               | Design                                                                                            |
+| Q2  | Sandbox preconditions: document-only OR probe-before-call (the test calls `GET /v2/quotes/:id/attachments` before `PATCH` and skips if absent)?                             | Design                                                                                            |
+| Q3  | Test order independence verification mechanism: random-seed runner (vitest plugin), snapshot diff (run twice, diff outcomes), or one-time manual audit + invariant comment? | Design                                                                                            |
+| Q4  | Should the skip reason taxonomy (R-SR-2) be enforced via lint, or just a convention?                                                                                        | Design (low priority)                                                                             |
+| Q5  | If the L2 audit reveals fields that Qonto's docs DO list in `required` but runtime probe shows omitted — which is authoritative?                                            | Wave A execution (per-case judgment; document precedent in `docs/qonto-sandbox-preconditions.md`) |
+
+## 13. Change Log
+
+| Date       | Change                                                   | Source                            |
+| ---------- | -------------------------------------------------------- | --------------------------------- |
+| 2026-05-17 | Initial PRD authored via `/capture-requirements` Phase 6 | `/scope` execution (this session) |

--- a/docs/qonto-sandbox-preconditions.md
+++ b/docs/qonto-sandbox-preconditions.md
@@ -1,0 +1,386 @@
+# Qonto Sandbox Preconditions
+
+The Qonto sandbox (and, for some endpoints, production with a fresh test
+organization) enforces preconditions that are not surfaced in the public Qonto
+OpenAPI reference. When a test exercises a write endpoint without first
+satisfying its precondition, the server returns a 4xx/5xx with an error key
+that contributors otherwise rediscover as "flake".
+
+This catalog is the L3 layer of the [E2E test reliability
+design](./designs/e2e-test-reliability.md) (epic [#603], sub-issue [#606]). It
+exists so that:
+
+- Every write endpoint with a known precondition is documented once, with the
+  failure signature and the remediation path.
+- Every E2E test that depends on a non-trivial precondition links back to its
+  catalog entry inline, so the next contributor reads the precondition before
+  re-deriving it from the server's error response.
+- Sandbox-blocker issues that were previously tracked as ad-hoc follow-ups
+  (#539, #561, #567, #570) are absorbed here — they become catalog entries
+  rather than scattered issues.
+
+## Scope
+
+- **In**: write endpoints (POST / PUT / PATCH / DELETE) where the Qonto
+  sandbox enforces a precondition that is not validated client-side. Examples:
+  HTTP 412 `quote_has_no_attachment` on `PATCH /v2/quotes/{id}`, HTTP 422
+  `invalid_iban` on `POST /v2/client_invoices` when the org lacks an invoicing
+  IBAN, HTTP 403 on `PUT /v2/cards/{id}/options` despite all card-write scopes.
+- **Out**: feature gating (the org's sandbox plan does not enable the feature
+  at all — covered by the `feature-not-supported` skip taxonomy in
+  `packages/e2e/src/helpers.ts`, not by this catalog).
+
+For the design decision behind this document-only approach (vs runtime
+probe-before-call), see [Solution Design §7.3 Q2
+resolution](./designs/e2e-test-reliability.md).
+
+## Entry schema
+
+Each section is one write endpoint, identified by HTTP method plus URL
+template. The entry carries four fields:
+
+- **Precondition** — the resource state that must hold before the call
+  succeeds, in plain English.
+- **Failure signature** — the HTTP status code plus the error key the sandbox
+  returns when the precondition is not met. Tests use this to triage a
+  failure as "expected sandbox state" rather than "production bug".
+- **Remediation in tests** — what the test should do: satisfy the
+  precondition first, OR skip with a `sandbox-precondition` reason via
+  `skipIfToolError(...)` (visible skip, [see
+  `helpers.ts`](../packages/e2e/src/helpers.ts)).
+- **Discovered** — the issue or commit that surfaced the precondition, plus
+  the empirical-probe date when applicable. Date is the most recent
+  re-verification; entries flip status over time as Qonto evolves the
+  sandbox.
+
+## Convention: linking from tests
+
+Tests that depend on a precondition documented here MUST carry an inline
+comment of the form:
+
+```ts
+// precondition: docs/qonto-sandbox-preconditions.md#patch-v2-quotes-id
+```
+
+so a reader of the test can resolve the precondition without re-reading the
+sandbox's error response. Anchor IDs are derived mechanically from
+`{method}-{path}` (lowercase, slashes and special chars replaced with `-`,
+`{id}` placeholders collapse to `-id`).
+
+## Catalog
+
+Grouped by Qonto API domain. Each anchor is stable across editorial passes;
+treat the anchor ID as a contract that tests link to.
+
+### Quotes
+
+#### `PATCH /v2/quotes/{id}` {#patch-v2-quotes-id}
+
+**Precondition**: The quote must have at least one attachment before PATCH.
+A freshly-created quote (`POST /v2/quotes`) starts with zero attachments,
+so the immediate PATCH that the CRUD lifecycle test attempts is rejected.
+
+**Failure signature**: HTTP 412, error key `quote_has_no_attachment`.
+
+**Remediation in tests**: Two options, per [Solution Design §7.2 R-SP-3]:
+
+- _Path A (preferred)_: Upload + attach an attachment via the quote's
+  attachment endpoint before calling `quote_update`. The 412 disappears
+  and the CRUD lifecycle exercises the real update path.
+- _Path B (fallback)_: Skip the update step with
+  `skipIfToolError(result, ctx, "sandbox-precondition", "quote_update requires
+attachment — see #606 (design §7.2)")`. The lifecycle's downstream delete
+  step still runs.
+
+The current `packages/e2e/src/quotes/mcp.e2e.test.ts` lifecycle takes Path B
+pending the [#607] follow-up that will implement Path A.
+
+**Discovered**: [#496] (originally surfaced as order-dependent flake);
+diagnosed during [#602] / [#603] root-cause analysis (2026-05-17).
+
+#### `POST /v2/quotes/{id}/send` {#post-v2-quotes-id-send}
+
+**Precondition**: The quote's `client` must have a non-empty `email`
+attribute so Qonto can deliver the quote. Client records created via the
+sandbox UI without an email satisfy `POST /v2/clients` but fail
+`POST /v2/quotes/{id}/send`.
+
+**Failure signature**: HTTP 4xx from `quote_send`. The exact error key
+depends on whether the client is missing an email entirely or has an
+unrouteable address; the test triages on `isError` and skips with a
+`sandbox-precondition` reason regardless.
+
+**Remediation in tests**: Either pre-create a client with a known-good
+email in the suite's `beforeAll`, or skip with `skipIfToolError(result,
+ctx, "sandbox-precondition", "quote_send requires client mailbox — see
+#606")`. The current quotes MCP test uses the skip path; the CLI test does
+not exercise `send` for this reason.
+
+**Discovered**: [#606] (catalogued from [#605] L1 sweep, 2026-05-17).
+
+#### `DELETE /v2/quotes/{id}` {#delete-v2-quotes-id}
+
+**Precondition**: The quote must be in a non-`sent` state. A quote that
+has been successfully sent transitions out of the deletable state and the
+delete is rejected.
+
+**Failure signature**: HTTP 4xx from `quote_delete` when `quote_send`
+succeeded earlier in the same lifecycle.
+
+**Remediation in tests**: When chaining `send` → `delete` in a CRUD
+lifecycle, treat the post-send delete as best-effort and skip with
+`skipIfToolError(result, ctx, "sandbox-precondition", "quote_delete
+requires non-sent state — see #606")`. Sent quotes accumulate in the
+sandbox; this is an accepted trade-off pending a sandbox cleanup pass.
+
+**Discovered**: [#606] (catalogued from [#605] L1 sweep, 2026-05-17).
+
+### Client Invoices
+
+#### `POST /v2/client_invoices` {#post-v2-client-invoices}
+
+**Precondition**: The organization must have an _invoicing IBAN_
+configured. This is distinct from the bank-account IBANs returned by
+`GET /v2/organization` (which may be present) and is also distinct from
+`einvoicing.sending_status` returned by `GET /v2/einvoicing/settings`
+(that field gates e-invoicing distribution, not invoice creation). The
+invoicing-IBAN setting is not exposed by the public Qonto API — it must
+be configured via the Qonto web UI or a Qonto support ticket.
+
+**Failure signature**: HTTP 422, error key `invalid_iban`, detail
+`IBAN is empty`. The error is misleading; the org has bank-account IBANs
+but `client-invoice create` requires the separate org-level invoicing
+IBAN.
+
+**Remediation in tests**: Currently triaged as
+`feature-not-supported` in `packages/e2e/src/client-invoices/{cli,mcp}.e2e.test.ts`
+(the entire write-path lifecycle is unreachable without the configuration,
+so it behaves like a missing feature from the test's perspective). The
+investigation track is [#539]; if the precondition is satisfied on a future
+test org, the triage should narrow to `sandbox-precondition`.
+
+**Discovered**: Empirically probed 2026-05-11 across sandbox + production
+test orgs (see [#539] probe matrix). Catalogued by [#606].
+
+### SEPA Beneficiaries
+
+#### `PUT /v2/sepa/beneficiaries/{id}` {#put-v2-sepa-beneficiaries-id}
+
+**Precondition**: The beneficiary must be in `status: validated`. SEPA
+beneficiaries created via `POST /v2/sepa/beneficiaries` land in
+`status: pending` and require manual validation in the Qonto web UI
+before they accept PUT updates.
+
+**Failure signature**: HTTP 404. Returned for `pending` records as if the
+beneficiary did not exist, rather than a clearer 409/422.
+
+**Remediation in tests**: The SCA-write-path tests in
+`packages/e2e/src/beneficiaries/{cli,mcp}.e2e.test.ts` filter the
+`beneficiary list` to `status: validated` server-side in their
+`beforeAll` and throw with a precondition-unmet message when zero
+validated beneficiaries exist. Manually validate one beneficiary in the
+Qonto sandbox UI to unblock the suite, or wait for the SCA-trigger
+validation path on `beneficiary_add` to mature so freshly-created records
+land in `validated`.
+
+**Discovered**: [#551], [#559] (2026-05-12 probe).
+
+### International Beneficiaries
+
+#### `POST /v2/international/beneficiaries` {#post-v2-international-beneficiaries}
+
+**Precondition**: Unknown — every probed payload variant returns the same
+generic 500. Likely causes: sandbox partner-onboarding configuration, a
+specific staging-org capability flag, or a transient sandbox defect.
+
+**Failure signature**: HTTP 500, body `{"errors":[{"code":"unknown",
+"detail":"Unknown error"}]}`. Probed corridors (US/USD, GB/GBP, DE/EUR,
+CH/CHF, JP/JPY) and field shapes (name-only, ACH-shape, UK-shape,
+no-fields) all return the same response (2026-05-12).
+
+**Remediation in tests**: No remediation available on the test side.
+`packages/e2e/src/intl-beneficiaries/{cli,mcp}.e2e.test.ts` does not
+exercise the write paths; the deferred coverage is tracked under [#561].
+The CLI / MCP code paths are confirmed structurally correct by
+audit-refresh inspection — the issue is sandbox-side.
+
+**Discovered**: [#552] discovery, [#561] tracking (2026-05-12).
+
+#### `PUT /v2/international/beneficiaries/{id}` {#put-v2-international-beneficiaries-id}
+
+**Precondition**: Requires a successfully-created international
+beneficiary; blocked by [`POST /v2/international/beneficiaries`](#post-v2-international-beneficiaries).
+
+**Failure signature**: Cannot be reached — the create endpoint blocks
+exercise of update.
+
+**Remediation in tests**: Deferred until the create blocker resolves.
+Tracked under [#561].
+
+**Discovered**: [#561] (2026-05-12).
+
+#### `DELETE /v2/international/beneficiaries/{id}` {#delete-v2-international-beneficiaries-id}
+
+**Precondition**: Requires a successfully-created international
+beneficiary; blocked by [`POST /v2/international/beneficiaries`](#post-v2-international-beneficiaries).
+
+**Failure signature**: Cannot be reached — the create endpoint blocks
+exercise of remove.
+
+**Remediation in tests**: Deferred until the create blocker resolves.
+Tracked under [#561].
+
+**Discovered**: [#561] (2026-05-12).
+
+### Cards
+
+#### `POST /v2/cards/bulk` {#post-v2-cards-bulk}
+
+**Precondition**: The sandbox-plan tier must enable bulk card creation.
+All standard `card.write` scopes (`cards.write`, `cards.update`,
+`cards.delete`) on the OAuth token are insufficient — single-card
+`POST /v2/cards` works against the same token in the same test run, so
+the issue is plan/role gating, not auth misconfiguration.
+
+**Failure signature**: HTTP 404 `not_found`.
+
+**Remediation in tests**: No client-side remediation; the endpoint is
+unavailable to the standard sandbox plan. Coverage deferred under [#570].
+`packages/e2e/src/cards/{cli,mcp}.e2e.test.ts` documents this in its
+header empirical-probe table and at the bottom-of-file deferral note.
+
+**Discovered**: [#556] original probe (2026-04), re-confirmed [#570]
+re-probe (2026-05-12).
+
+#### `PUT /v2/cards/{id}/options` {#put-v2-cards-id-options}
+
+**Precondition**: The sandbox-plan tier must enable card-options updates.
+Same sandbox-plan / admin-role pattern as `POST /v2/cards/bulk` — all
+`card.write` scopes are granted but the endpoint rejects.
+
+**Failure signature**: HTTP 403 Forbidden.
+
+**Remediation in tests**: No client-side remediation. Coverage deferred
+under [#570]. Same documentation surface as `POST /v2/cards/bulk` — see
+the header empirical-probe table in `packages/e2e/src/cards/cli.e2e.test.ts`.
+
+Note: `PUT /v2/cards/{id}/restrictions` was originally listed alongside
+this endpoint as part of [#570] but flipped from 403 → 200 between the
+2026-04 [#556] probe and the 2026-05-12 [#570] re-probe without any
+user-visible config change — likely a sandbox-plan tier upgrade by Qonto.
+It is now covered as round-trip #6 in the cards CLI lifecycle test.
+
+**Discovered**: [#556] original probe (2026-04), re-confirmed [#570]
+re-probe (2026-05-12).
+
+### Requests
+
+#### `POST /v2/requests/flash_cards` {#post-v2-requests-flash-cards}
+
+**Precondition**: The sandbox-plan or admin-role gating must enable
+flash-card request creation. All `request_*.write` scopes
+(`request_review.write`, `request_cards.write`,
+`request_transfers.write`) on the OAuth token are insufficient —
+`POST /v2/requests/multi_transfers` works on the same token in the same
+test run, so a single `request.write` scope sub-feature is gated.
+
+**Failure signature**: HTTP 403 Forbidden, body
+`{"errors":[{"code":"unknown","detail":"Unknown error"}]}`.
+
+**Remediation in tests**: No client-side remediation. Coverage deferred
+under [#567]. `packages/e2e/src/requests/{cli,mcp}.e2e.test.ts` documents
+this in its header empirical-probe block and at the bottom-of-file
+deferral note. The covered multi-transfer create exercises the one
+working write path against the sandbox.
+
+**Discovered**: [#555] (deferred to [#567], 2026-05-12).
+
+#### `POST /v2/requests/virtual_cards` {#post-v2-requests-virtual-cards}
+
+**Precondition**: Same sandbox-plan / admin-role gating as
+[`POST /v2/requests/flash_cards`](#post-v2-requests-flash-cards).
+
+**Failure signature**: HTTP 403 Forbidden, body
+`{"errors":[{"code":"unknown","detail":"Unknown error"}]}`.
+
+**Remediation in tests**: No client-side remediation. Coverage deferred
+under [#567].
+
+**Discovered**: [#555] (deferred to [#567], 2026-05-12).
+
+#### `POST /v2/requests/multi_transfers/{id}/approve` {#post-v2-requests-multi-transfers-id-approve}
+
+**Precondition**: Same sandbox-plan / admin-role gating as
+[`POST /v2/requests/flash_cards`](#post-v2-requests-flash-cards).
+Additionally requires a pre-existing pending multi-transfer request to
+target — the create-multi-transfer path that produces these works fine
+in the sandbox.
+
+**Failure signature**: HTTP 403 Forbidden, body
+`{"errors":[{"code":"unknown","detail":"Unknown error"}]}`. The 403
+fires before any approver-permission check has a chance to validate the
+request body, so the gating is on the endpoint not the payload.
+
+**Remediation in tests**: No client-side remediation. Coverage deferred
+under [#567].
+
+**Discovered**: [#555] (deferred to [#567], 2026-05-12).
+
+#### `POST /v2/requests/multi_transfers/{id}/decline` {#post-v2-requests-multi-transfers-id-decline}
+
+**Precondition**: Same sandbox-plan / admin-role gating as
+[`POST /v2/requests/multi_transfers/{id}/approve`](#post-v2-requests-multi-transfers-id-approve).
+
+**Failure signature**: HTTP 403 Forbidden, body
+`{"errors":[{"code":"unknown","detail":"Unknown error"}]}`.
+
+**Remediation in tests**: No client-side remediation. Coverage deferred
+under [#567].
+
+**Discovered**: [#555] (deferred to [#567], 2026-05-12).
+
+## Absorbed L3-blocker issues
+
+These issues tracked individual sandbox blockers before this catalog
+existed. They remain open as the investigation tracks for unblocking the
+underlying sandbox state (or accepting it as a permanent gap), but the
+_documentation_ of each blocker now lives here.
+
+| Issue  | Endpoints absorbed                                                                                                             | Catalog anchors                                                                                                                                                                                      |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [#539] | `POST /v2/client_invoices` (invoicing-IBAN config)                                                                             | [post-v2-client-invoices](#post-v2-client-invoices)                                                                                                                                                  |
+| [#561] | `POST/PUT/DELETE /v2/international/beneficiaries` (sandbox 500)                                                                | [post](#post-v2-international-beneficiaries), [put](#put-v2-international-beneficiaries-id), [delete](#delete-v2-international-beneficiaries-id)                                                     |
+| [#567] | `POST /v2/requests/{flash_cards,virtual_cards}`, `POST /v2/requests/multi_transfers/{id}/{approve,decline}` (sandbox-plan 403) | [flash](#post-v2-requests-flash-cards), [virtual](#post-v2-requests-virtual-cards), [approve](#post-v2-requests-multi-transfers-id-approve), [decline](#post-v2-requests-multi-transfers-id-decline) |
+| [#570] | `POST /v2/cards/bulk`, `PUT /v2/cards/{id}/options` (sandbox-plan 404/403)                                                     | [bulk](#post-v2-cards-bulk), [options](#put-v2-cards-id-options)                                                                                                                                     |
+
+## Maintenance
+
+- **New entries**: when a contributor surfaces a new sandbox precondition,
+  the doc update and the test inline-link MUST land in the same PR (per
+  [#606] AC #4). The "doc + test link in one PR" convention is the
+  preventative against doc drift.
+- **Sandbox flips**: when Qonto changes a precondition (e.g., the
+  `PUT /v2/cards/{id}/restrictions` 403 → 200 flip on 2026-05-12 noted
+  above), update the affected entry in place and amend the `Discovered`
+  line with the re-probe date. Do not delete entries that no longer apply
+  — they are useful as historical context for future regressions.
+- **Anchor stability**: anchor IDs are part of the API surface that tests
+  rely on. Treat them as breaking-change-prone — rename only when an
+  endpoint URL itself changes upstream.
+
+[#496]: https://github.com/alexey-pelykh/qontoctl/issues/496
+[#539]: https://github.com/alexey-pelykh/qontoctl/issues/539
+[#551]: https://github.com/alexey-pelykh/qontoctl/issues/551
+[#552]: https://github.com/alexey-pelykh/qontoctl/issues/552
+[#555]: https://github.com/alexey-pelykh/qontoctl/issues/555
+[#556]: https://github.com/alexey-pelykh/qontoctl/issues/556
+[#559]: https://github.com/alexey-pelykh/qontoctl/issues/559
+[#561]: https://github.com/alexey-pelykh/qontoctl/issues/561
+[#567]: https://github.com/alexey-pelykh/qontoctl/issues/567
+[#570]: https://github.com/alexey-pelykh/qontoctl/issues/570
+[#602]: https://github.com/alexey-pelykh/qontoctl/pull/602
+[#603]: https://github.com/alexey-pelykh/qontoctl/issues/603
+[#605]: https://github.com/alexey-pelykh/qontoctl/issues/605
+[#606]: https://github.com/alexey-pelykh/qontoctl/issues/606
+[#607]: https://github.com/alexey-pelykh/qontoctl/issues/607
+[Solution Design §7.2 R-SP-3]: ./designs/e2e-test-reliability.md

--- a/packages/e2e/src/beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/beneficiaries/cli.e2e.test.ts
@@ -195,6 +195,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
       // `beneficiary list` call goes through the same auth path the test's
       // write call will. Filter to `status: validated` server-side so the
       // failure message reflects the precondition the AC names.
+      // precondition: docs/qonto-sandbox-preconditions.md#put-v2-sepa-beneficiaries-id
       const beneficiaries = cliJson<Beneficiary[]>("beneficiary", "list", "--status", "validated");
       if (beneficiaries.length === 0) {
         throw new Error(

--- a/packages/e2e/src/beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/beneficiaries/mcp.e2e.test.ts
@@ -164,6 +164,7 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())(
       client = new Client({ name: "e2e-beneficiary-update-sca", version: "0.0.0" });
       await client.connect(transport);
 
+      // precondition: docs/qonto-sandbox-preconditions.md#put-v2-sepa-beneficiaries-id
       const listResult = (await client.callTool({
         name: "beneficiary_list",
         arguments: { status: "validated", per_page: 100 },

--- a/packages/e2e/src/cards/cli.e2e.test.ts
+++ b/packages/e2e/src/cards/cli.e2e.test.ts
@@ -238,12 +238,12 @@ async function runWithConditionalSca(args: readonly string[]): Promise<SpawnedCl
 // `0909-future-club-2702`, OAuth token with all card.write scopes):
 //
 //   - `POST /v2/cards`                                  → 428 SCA, then 200 (works)
-//   - `POST /v2/cards/bulk`                             → 404 not_found  (deferred, #570)
+//   - `POST /v2/cards/bulk`                             → 404 not_found  (precondition: docs/qonto-sandbox-preconditions.md#post-v2-cards-bulk)
 //   - `POST /v2/cards/{id}/lock`                        → 200 (works, NOT SCA-gated in sandbox)
 //   - `POST /v2/cards/{id}/unlock`                      → 428 SCA, then 200 (works)
 //   - `PUT  /v2/cards/{id}/limits`                      → 428 SCA, then 200 (works)
 //   - `PUT  /v2/cards/{id}/nickname`                    → 200 (works, NOT SCA-gated in sandbox)
-//   - `PUT  /v2/cards/{id}/options`                     → 403 Forbidden (deferred, #570)
+//   - `PUT  /v2/cards/{id}/options`                     → 403 Forbidden (precondition: docs/qonto-sandbox-preconditions.md#put-v2-cards-id-options)
 //   - `PUT  /v2/cards/{id}/restrictions`                → 200 (works, NOT SCA-gated in sandbox; was 403 pre-2026-05-12)
 //
 // Two of the 8 covered endpoints still return non-200 in the sandbox
@@ -491,7 +491,9 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("card CLI commands
 // and is now covered above):
 //
 //   - `card bulk-create`        → `POST /v2/cards/bulk`                 404 not_found
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-cards-bulk)
 //   - `card update-options`     → `PUT  /v2/cards/{id}/options`         403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#put-v2-cards-id-options)
 //
 // Same sandbox-plan / admin-role pattern as the 4 deferred request
 // endpoints in #555 (request approve/decline/create-flash-card/

--- a/packages/e2e/src/cards/mcp.e2e.test.ts
+++ b/packages/e2e/src/cards/mcp.e2e.test.ts
@@ -244,11 +244,14 @@ async function callWithConditionalSca(
 // `0909-future-club-2702`): 6 of 8 covered card write endpoints succeed
 // (create + update-nickname + update-limits + lock + unlock + update-
 // restrictions). The other 2 (bulk-create, update-options) return 404/403
-// in the sandbox despite all card.write scopes being granted; deferred
-// under #570. `update-restrictions` flipped from 403 → 200 between the
-// 2026-04 #556 probe and the 2026-05-12 re-probe without any user-visible
-// config change (likely sandbox-plan tier upgrade by Qonto), and is now
-// covered as round-trip #6 below. See `packages/e2e/src/cards/cli.e2e.test.ts`
+// in the sandbox despite all card.write scopes being granted; tracked
+// under #570. See:
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-cards-bulk
+//   - precondition: docs/qonto-sandbox-preconditions.md#put-v2-cards-id-options
+// `update-restrictions` flipped from 403 → 200 between the 2026-04 #556
+// probe and the 2026-05-12 re-probe without any user-visible config
+// change (likely sandbox-plan tier upgrade by Qonto), and is now covered
+// as round-trip #6 below. See `packages/e2e/src/cards/cli.e2e.test.ts`
 // header note for the full per-endpoint table and idempotency strategy
 // (cards accumulate; 1/run). Deferral notes for the destructive trio AND
 // the 2 sandbox-blocked write endpoints are repeated at the bottom of
@@ -427,7 +430,9 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("card MCP tools (e
 // above):
 //
 //   - `card_bulk_create`        → `POST /v2/cards/bulk`               404 not_found
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-cards-bulk)
 //   - `card_update_options`     → `PUT  /v2/cards/{id}/options`       403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#put-v2-cards-id-options)
 //
 // Same sandbox-plan / admin-role pattern as the 4 deferred request
 // endpoints in #555. Both MCP tools wrap with `executeWithMcpSca`

--- a/packages/e2e/src/client-invoices/cli.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/cli.e2e.test.ts
@@ -83,17 +83,14 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
         expect(parsed).toHaveProperty("status", "draft");
         createdInvoiceId = parsed["id"] as string;
       } catch {
-        // `client-invoice create` requires an org-level *invoicing IBAN* to be
-        // configured. This is distinct from bank-account IBANs (which can be
-        // present yet the API still returns HTTP 422 `invalid_iban: IBAN is
-        // empty`) and is NOT the same as `einvoicing.sending_status` returned
-        // by `GET /v2/einvoicing/settings` (that gates a different flow).
-        // The invoicing-IBAN setting is not exposed by the public Qonto API —
-        // it must be configured via the Qonto web UI or a Qonto support
-        // ticket. Without it the entire write-path lifecycle (create →
-        // update → upload → finalize → send → mark_paid → unmark_paid →
-        // cancel → delete) is unreachable, so downstream tests below are
-        // silently skipped (createdInvoiceId stays undefined). Tracked: #539.
+        // precondition: docs/qonto-sandbox-preconditions.md#post-v2-client-invoices
+        // `client-invoice create` requires an org-level *invoicing IBAN*
+        // (not the bank-account IBAN, and not `einvoicing.sending_status`)
+        // that is not exposed by the public Qonto API. Without it the entire
+        // write-path lifecycle (create → update → upload → finalize → send →
+        // mark_paid → unmark_paid → cancel → delete) is unreachable, so
+        // downstream tests below are silently skipped (createdInvoiceId stays
+        // undefined). Tracked: [#539].
       }
     });
 
@@ -440,14 +437,15 @@ describe.skipIf(!hasApiKeyCredentials())("client-invoice commands (e2e)", () => 
         expect(parsed).toHaveProperty("status", "draft");
         emptyDraftId = parsed["id"] as string;
       } catch {
+        // precondition: docs/qonto-sandbox-preconditions.md#post-v2-client-invoices
         // Same blocker as the parent CRUD lifecycle: `client-invoice create`
-        // is gated on an org-level invoicing-IBAN configuration not exposed
-        // by the public Qonto API (#539). On orgs where that setting is
-        // missing the API rejects with HTTP 422 `invalid_iban: IBAN is empty`
-        // before any items-shape validation runs, so the empty-items round
-        // trip is silently skipped here. The schema fix from #575 is still
-        // exercised by the unit tests in `packages/core/src/client-invoices/
-        // schemas.test.ts` (`normalizes items: null to []` and siblings).
+        // is gated on an org-level invoicing-IBAN configuration. On orgs
+        // where that setting is missing the API rejects with HTTP 422
+        // `invalid_iban: IBAN is empty` before any items-shape validation
+        // runs, so the empty-items round trip is silently skipped here.
+        // The schema fix from #575 is still exercised by the unit tests in
+        // `packages/core/src/client-invoices/schemas.test.ts`
+        // (`normalizes items: null to []` and siblings).
       }
     });
 

--- a/packages/e2e/src/client-invoices/mcp.e2e.test.ts
+++ b/packages/e2e/src/client-invoices/mcp.e2e.test.ts
@@ -172,10 +172,12 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
         },
       });
 
-      // Invoice creation may fail if the organization lacks required setup
-      // (e.g., IBAN not configured) — surface as visible feature-not-supported
-      // skip and propagate to downstream tests via the lifecycle carrier
-      // (see #606 for the L3 sandbox-precondition catalog, #605).
+      // precondition: docs/qonto-sandbox-preconditions.md#post-v2-client-invoices
+      // Invoice creation requires an org-level invoicing-IBAN setting that is
+      // not exposed by the public Qonto API — see [#539] for the
+      // configuration-investigation track. The whole write-path lifecycle is
+      // unreachable without it, so surface as `feature-not-supported` and
+      // propagate to downstream tests via the lifecycle carrier.
       skipIfToolError(
         createResult,
         ctx,
@@ -296,10 +298,12 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
         },
       });
 
-      // Invoice creation may fail if the organization lacks required setup
-      // (e.g., IBAN not configured) — surface as visible feature-not-supported
-      // skip and propagate to downstream lifecycle steps via the carrier
-      // (see #606 for the L3 sandbox-precondition catalog, #605).
+      // precondition: docs/qonto-sandbox-preconditions.md#post-v2-client-invoices
+      // Invoice creation requires an org-level invoicing-IBAN setting that is
+      // not exposed by the public Qonto API — see [#539] for the
+      // configuration-investigation track. The whole state-machine lifecycle
+      // is unreachable without it, so surface as `feature-not-supported` and
+      // propagate to downstream lifecycle steps via the carrier.
       skipIfToolError(
         createResult,
         ctx,
@@ -431,6 +435,9 @@ describe.skipIf(!hasApiKeyCredentials())("MCP client invoice tools (e2e)", () =>
           },
         });
 
+        // precondition: docs/qonto-sandbox-preconditions.md#post-v2-client-invoices
+        // Same invoicing-IBAN gate as the other lifecycles in this file —
+        // unblocked separately under [#539].
         skipIfToolError(
           createResult,
           ctx,

--- a/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/cli.e2e.test.ts
@@ -20,6 +20,14 @@ interface IntlBeneficiaryItem {
  * to the CLI as a non-zero exit. We use `cliRaw` here so the suite
  * remains useful both on eligibility-cleared and ineligible sandbox accounts;
  * the tests still assert response shape when the call succeeds.
+ *
+ * NOTE: This suite covers `intl beneficiary list` only — the SCA write
+ * paths (`intl beneficiary add`/`update`/`remove`) are blocked by a
+ * sandbox-side HTTP 500 on `POST /v2/international/beneficiaries` and are
+ * tracked separately under #561. Preconditions documented:
+ *   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-international-beneficiaries
+ *   - precondition: docs/qonto-sandbox-preconditions.md#put-v2-international-beneficiaries-id
+ *   - precondition: docs/qonto-sandbox-preconditions.md#delete-v2-international-beneficiaries-id
  */
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");

--- a/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
+++ b/packages/e2e/src/intl-beneficiaries/mcp.e2e.test.ts
@@ -8,6 +8,14 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { CLI_PATH, firstTextFromMcpResult, skipIfToolError, skipMissingFixture } from "../helpers.js";
 import { cliEnv, hasOAuthCredentials, pinAuthPreference } from "../sandbox.js";
 
+// NOTE: This suite covers `intl_beneficiary_list` and `intl_beneficiary_requirements`
+// only — the SCA write paths (`intl_beneficiary_add`/`update`/`remove`) are
+// blocked by a sandbox-side HTTP 500 on `POST /v2/international/beneficiaries`
+// and are tracked separately under #561. Preconditions documented:
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-international-beneficiaries
+//   - precondition: docs/qonto-sandbox-preconditions.md#put-v2-international-beneficiaries-id
+//   - precondition: docs/qonto-sandbox-preconditions.md#delete-v2-international-beneficiaries-id
+
 describe.skipIf(!hasOAuthCredentials())("intl-beneficiary MCP tools (e2e)", () => {
   pinAuthPreference("oauth-first");
 

--- a/packages/e2e/src/quotes/mcp.e2e.test.ts
+++ b/packages/e2e/src/quotes/mcp.e2e.test.ts
@@ -165,11 +165,11 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
         },
       });
 
-      // Documented sandbox-precondition: `quote_update` returns HTTP 412
-      // `quote_has_no_attachment` against the live sandbox unless the quote
-      // has at least one attachment first (design §7.2 R-SP-3 Path B; #606
-      // catalog). Triage rather than assert so the lifecycle's downstream
-      // delete step still runs.
+      // precondition: docs/qonto-sandbox-preconditions.md#patch-v2-quotes-id
+      // `quote_update` returns HTTP 412 `quote_has_no_attachment` against the
+      // live sandbox unless the quote has at least one attachment first
+      // (design §7.2 R-SP-3 Path B). Triage rather than assert so the
+      // lifecycle's downstream delete step still runs.
       skipIfToolError(result, ctx, "sandbox-precondition", "quote_update requires attachment — see #606 (design §7.2)");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
@@ -185,9 +185,10 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
         arguments: { id },
       });
 
+      // precondition: docs/qonto-sandbox-preconditions.md#post-v2-quotes-id-send
       // Send may fail with a 4xx if the quote's client lacks a mailbox.
-      // Triage as sandbox-precondition (the client has no email configured);
-      // see #606 (epic #603) for the L3 sandbox-precondition catalog (#605).
+      // Triage as sandbox-precondition rather than assert so the lifecycle's
+      // downstream delete step still runs.
       skipIfToolError(result, ctx, "sandbox-precondition", "quote_send requires client mailbox — see #606");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;
@@ -204,9 +205,10 @@ describe.skipIf(!hasOAuthCredentials())("MCP quote tools (e2e)", () => {
         arguments: { id },
       });
 
+      // precondition: docs/qonto-sandbox-preconditions.md#delete-v2-quotes-id
       // If the previous step actually sent the quote, the delete is likely
       // rejected by the API. Triage as sandbox-precondition (delete requires
-      // non-sent state); see #606 for the L3 catalog (#605).
+      // non-sent state) so the lifecycle stays best-effort.
       skipIfToolError(result, ctx, "sandbox-precondition", "quote_delete requires non-sent state — see #606");
 
       const parsed = JSON.parse(firstTextFromMcpResult(result)) as Record<string, unknown>;

--- a/packages/e2e/src/requests/cli.e2e.test.ts
+++ b/packages/e2e/src/requests/cli.e2e.test.ts
@@ -110,9 +110,13 @@ async function runWithConditionalSca(args: readonly string[]): Promise<SpawnedCl
 //   - `GET  /v2/requests`                                  → 200 OK (11 pending multi_transfer requests)
 //   - `POST /v2/requests/multi_transfers`                  → 200 OK (works, NOT SCA-gated)
 //   - `POST /v2/requests/flash_cards`                      → 403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-flash-cards)
 //   - `POST /v2/requests/virtual_cards`                    → 403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-virtual-cards)
 //   - `POST /v2/requests/multi_transfers/{id}/approve`     → 403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-approve)
 //   - `POST /v2/requests/multi_transfers/{id}/decline`     → 403 Forbidden
+//     (precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-decline)
 //
 // The 4 sandbox-blocked endpoints (`flash_cards` create, `virtual_cards` create,
 // approve, decline) return `403 unknown` despite all `request_*.write` scopes
@@ -203,6 +207,12 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("request CLI comma
 // `request_transfers.write`), so this is a sandbox-plan or admin-role
 // limitation — not an auth misconfiguration on our side.
 //
+// Preconditions documented in the L3 catalog:
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-flash-cards
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-virtual-cards
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-approve
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-decline
+//
 // The CLI and MCP code paths for the deferred endpoints are confirmed
 // correct by audit-refresh inspection:
 //   - `packages/cli/src/commands/request/{approve,decline,create-flash-card,
@@ -210,4 +220,4 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("request CLI comma
 //   - `packages/mcp/src/tools/request.ts` wraps all four with
 //     `executeWithMcpSca`
 //
-// Tracked as a follow-up to #555.
+// Tracked as a follow-up to #555 under #567.

--- a/packages/e2e/src/requests/mcp.e2e.test.ts
+++ b/packages/e2e/src/requests/mcp.e2e.test.ts
@@ -162,6 +162,12 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("request MCP tools
 // `request_cards.write`, `request_transfers.write`) are granted; the
 // limitation is sandbox-plan / admin-role level, not auth misconfiguration.
 //
+// Preconditions documented in the L3 catalog:
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-flash-cards
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-virtual-cards
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-approve
+//   - precondition: docs/qonto-sandbox-preconditions.md#post-v2-requests-multi-transfers-id-decline
+//
 // MCP code paths confirmed correct by audit-refresh inspection — all four
 // tools wrap with `executeWithMcpSca` in `packages/mcp/src/tools/request.ts`.
-// Tracked as a follow-up to #555.
+// Tracked as a follow-up to #555 under #567.


### PR DESCRIPTION
## Summary

- Authors `docs/qonto-sandbox-preconditions.md` with 14 entries — one per write endpoint with a known sandbox precondition surfaced by the #605 L1 sweep or by existing inline deferral notes (Quotes ×3, Client Invoices, SEPA Beneficiaries, International Beneficiaries ×3, Cards ×2, Requests ×4). Each entry carries Precondition / Failure signature / Remediation / Discovered fields per [design §7.1](../blob/docs/sandbox-preconditions-catalog/docs/designs/e2e-test-reliability.md).
- Absorbs the 4 scattered L3-blocker tracker issues into catalog entries: #539 (client-invoice IBAN), #561 (intl-beneficiary 500), #567 (request flows 403), #570 (card SCA 404/403). The issues remain open for the unblocking-investigation track; the *documentation* moves here.
- Adds 36 inline `// precondition: docs/qonto-sandbox-preconditions.md#{anchor}` comments across 11 E2E test files at every site that depends on a non-trivial precondition (per AC #2). Pure comment additions; zero runtime effect.
- Bundles the upstream `/scope` → `/capture-requirements` → `/design-solution` artifacts (PRD, design doc, 2 scope briefs, 2 captured-state briefs) so the catalog's relative cross-references resolve at merge time. Matches the #578 precedent.

Closes the L3 layer of epic #603 (Wave B). Q2 resolved per design §7.3: DOCUMENT-ONLY in v1; probe-before-call deferred to v2. Follow-up #607 will implement R-SP-3 Path A (attach-an-attachment) for the `quote_update` 412; the catalog documents Path B (skip-with-reason) as the current behaviour.

## Acceptance criteria

- [x] Every write endpoint with a known 412/422 precondition path documented — 14 entries; supersets the 412/422 requirement (also covers 4xx/404/403/500 categories)
- [x] Every test depending on a non-trivial precondition links to its catalog anchor — 36 inline `// precondition:` references; all 14 anchors are linked ≥1 time
- [x] #539/#561/#570/#567 represented as catalog entries (cross-referenced) — absorbed-issues table at the end of the catalog maps each issue → catalog anchors
- [x] Doc-update + test-link land in the same PR (no orphan doc) — single commit `458305f` with all changes

## Test plan

- [x] `pnpm format:check` — PASS (catalog reformatted by Prettier during execution)
- [x] `pnpm lint` — PASS
- [x] `node scripts/check-no-silent-skip.js` — PASS (regression guard satisfied)
- [x] `node scripts/check-coverage-drift.js` — PASS (no new code surfaces)
- [x] `pnpm test` — PASS (87 files, 789 tests)
- [x] `pnpm license-check` — PASS (100 production deps)
- [x] `pnpm test:e2e` — ran end-to-end; 74 test failures are pre-existing environmental (OAuth flow refresh + downstream cascade in card list / payment-link / bank-accounts / beneficiary / webhook lifecycles), unrelated to this doc-only change. 134-failure improvement vs last night's pre-#604/#605 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)