### PR TITLE
(fix) L2 schema-strictness audit: relax 48 nullable-not-optional fields in Quote + ClientInvoice schemas (#601)

### DIFF
--- a/packages/cli/src/commands/client-invoice.ts
+++ b/packages/cli/src/commands/client-invoice.ts
@@ -82,11 +82,12 @@ function buildClientInvoiceListParams(opts: ClientInvoiceListOptions): QueryPara
 }
 
 function clientDisplayName(client: ClientInvoice["client"]): string {
-  if (client.name !== null) {
+  // `!= null` (not `!== null`) to also strip undefined: nested EmbeddedClient
+  // fields are now optional (#601 L2 audit — no `required:` list); for company
+  // clients, first_name/last_name are omitted (not present-and-null).
+  if (client.name != null) {
     return client.name;
   }
-  // `!= null` (not `!== null`) to also strip undefined: for company clients,
-  // first_name/last_name are omitted from the response, not present-and-null.
   const parts = [client.first_name, client.last_name].filter((p) => p != null);
   return parts.length > 0 ? parts.join(" ") : "";
 }

--- a/packages/cli/src/commands/quote.ts
+++ b/packages/cli/src/commands/quote.ts
@@ -37,10 +37,12 @@ function buildQuoteListParams(opts: QuoteListOptions): QueryParams {
 }
 
 function clientDisplayName(client: Quote["client"]): string {
-  if (client.name !== null) {
+  // `!= null` (not `!== null`) to also strip undefined: nested EmbeddedClient
+  // fields are now optional (#601 L2 audit — no `required:` list).
+  if (client.name != null) {
     return client.name;
   }
-  const parts = [client.first_name, client.last_name].filter((p) => p !== null);
+  const parts = [client.first_name, client.last_name].filter((p) => p != null);
   return parts.length > 0 ? parts.join(" ") : "";
 }
 

--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -396,3 +396,90 @@ describe("ClientInvoiceSchema", () => {
     expect(result.attachment_id).toBeUndefined();
   });
 });
+
+// Nested-schema regression tests for #601 L2 audit: per Qonto's
+// client-invoice-endpoint docs, none of DocumentItem / Address / EmbeddedClient
+// has a `required:` list — every field MAY be omitted entirely. Verified at
+// the schema boundary so real Qonto responses lacking these fields parse
+// without error.
+
+describe("ClientInvoiceItemSchema (#601 L2 audit)", () => {
+  const validItem = {
+    title: "Consulting",
+    description: null,
+    quantity: "2",
+    unit: "hours",
+    vat_rate: "20.0",
+    vat_exemption_reason: null,
+    unit_price: { value: "100.00", currency: "EUR" },
+    unit_price_cents: 10000,
+    total_amount: { value: "200.00", currency: "EUR" },
+    total_amount_cents: 20000,
+    total_vat: { value: "40.00", currency: "EUR" },
+    total_vat_cents: 4000,
+    subtotal: { value: "200.00", currency: "EUR" },
+    subtotal_cents: 20000,
+    discount: null,
+  };
+
+  it("accepts Item with description omitted entirely (regression: L2 audit #601)", () => {
+    const input = Object.fromEntries(Object.entries(validItem).filter(([k]) => k !== "description"));
+    expect(() => ClientInvoiceItemSchema.parse(input)).not.toThrow();
+  });
+});
+
+describe("ClientInvoiceAddressSchema (#601 L2 audit)", () => {
+  const validAddress = {
+    street_address: "123 Main St",
+    city: "Paris",
+    zip_code: "75001",
+    province_code: null,
+    country_code: "FR",
+  };
+
+  it.each(["street_address", "city", "zip_code", "country_code"] as const)(
+    "accepts Address with %s omitted entirely (regression: L2 audit #601)",
+    (field) => {
+      const input = Object.fromEntries(Object.entries(validAddress).filter(([k]) => k !== field));
+      expect(() => ClientInvoiceAddressSchema.parse(input)).not.toThrow();
+    },
+  );
+});
+
+describe("ClientInvoiceClientSchema (#601 L2 audit)", () => {
+  const validClient = {
+    id: "client-1",
+    type: "company" as const,
+    name: "Acme Corp",
+    first_name: null,
+    last_name: null,
+    email: "billing@acme.com",
+    vat_number: "FR12345678901",
+    tax_identification_number: null,
+    address: "123 Main St",
+    city: "Paris",
+    zip_code: "75001",
+    province_code: null,
+    country_code: "FR",
+    recipient_code: null,
+    locale: "fr",
+    billing_address: null,
+    delivery_address: null,
+  };
+
+  it.each([
+    "name",
+    "email",
+    "vat_number",
+    "tax_identification_number",
+    "address",
+    "city",
+    "zip_code",
+    "country_code",
+    "locale",
+    "billing_address",
+  ] as const)("accepts Client with %s omitted entirely (regression: L2 audit #601)", (field) => {
+    const input = Object.fromEntries(Object.entries(validClient).filter(([k]) => k !== field));
+    expect(() => ClientInvoiceClientSchema.parse(input)).not.toThrow();
+  });
+});

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -34,10 +34,14 @@ export const ClientInvoiceDiscountSchema = z
   })
   .strip() satisfies z.ZodType<ClientInvoiceDiscount>;
 
+// Per Qonto's client-invoice-endpoint docs, the nested DocumentItem schema
+// has no `required:` list — every field MAY be omitted entirely. Relaxed
+// `description` from `.nullable()` to `.nullable().optional()` to match the
+// pattern used elsewhere in this Item schema (R-SS-1 / #604).
 export const ClientInvoiceItemSchema = z
   .object({
     title: z.string(),
-    description: z.string().nullable(),
+    description: z.string().nullable().optional(),
     quantity: z.string(),
     unit: z.string().nullable().optional(),
     vat_rate: z.string(),
@@ -54,38 +58,43 @@ export const ClientInvoiceItemSchema = z
   })
   .strip() satisfies z.ZodType<ClientInvoiceItem>;
 
+// Per Qonto's client-invoice-endpoint docs, the nested Address schemas
+// (ClientBillingAddress / ClientDeliveryAddress) have no `required:` list —
+// every field MAY be omitted entirely. Relaxed to `.nullable().optional()`
+// (R-SS-1 / #604 pattern).
 export const ClientInvoiceAddressSchema = z
   .object({
-    street_address: z.string().nullable(),
-    city: z.string().nullable(),
-    zip_code: z.string().nullable(),
+    street_address: z.string().nullable().optional(),
+    city: z.string().nullable().optional(),
+    zip_code: z.string().nullable().optional(),
     province_code: z.string().nullable().optional(),
-    country_code: z.string().nullable(),
+    country_code: z.string().nullable().optional(),
   })
   .strip() satisfies z.ZodType<ClientInvoiceAddress>;
 
-// Per the Qonto API docs, `first_name` and `last_name` "will be returned
-// only if the client is an individual or a freelancer" — i.e., omitted
-// entirely (not just null) for `type: "company"`. Make them optional in
-// addition to nullable. Mirrors the standalone-ClientSchema fix from #496.
+// Per Qonto's client-invoice-endpoint docs, the EmbeddedClient schema has
+// no `required:` list — every field other than `id` and `type` MAY be
+// omitted entirely. Relaxed all remaining `.nullable()`-only fields to
+// `.nullable().optional()` (R-SS-1 / #604 pattern). `first_name` /
+// `last_name` were already relaxed (#496) per the company-type carve-out.
 export const ClientInvoiceClientSchema = z
   .object({
     id: z.string(),
     type: z.enum(["individual", "company", "freelancer"]),
-    name: z.string().nullable(),
+    name: z.string().nullable().optional(),
     first_name: z.string().nullable().optional(),
     last_name: z.string().nullable().optional(),
-    email: z.string().nullable(),
-    vat_number: z.string().nullable(),
-    tax_identification_number: z.string().nullable(),
-    address: z.string().nullable(),
-    city: z.string().nullable(),
-    zip_code: z.string().nullable(),
+    email: z.string().nullable().optional(),
+    vat_number: z.string().nullable().optional(),
+    tax_identification_number: z.string().nullable().optional(),
+    address: z.string().nullable().optional(),
+    city: z.string().nullable().optional(),
+    zip_code: z.string().nullable().optional(),
     province_code: z.string().nullable().optional(),
-    country_code: z.string().nullable(),
+    country_code: z.string().nullable().optional(),
     recipient_code: z.string().nullable().optional(),
-    locale: z.string().nullable(),
-    billing_address: ClientInvoiceAddressSchema.nullable(),
+    locale: z.string().nullable().optional(),
+    billing_address: ClientInvoiceAddressSchema.nullable().optional(),
     delivery_address: ClientInvoiceAddressSchema.nullable().optional(),
   })
   .strip() satisfies z.ZodType<ClientInvoiceClient>;
@@ -101,6 +110,20 @@ export const ClientInvoiceUploadSchema = z
   })
   .strip() satisfies z.ZodType<ClientInvoiceUpload>;
 
+// Per Qonto's client-invoice-endpoint docs, `ClientInvoice.required` covers
+// (among others): id, organization_id, number, purchase_order, status,
+// invoice_url, contact_email, terms_and_conditions, header, footer,
+// currency, total_amount{,_cents}, vat_amount{,_cents}, issue_date,
+// due_date, created_at, finalized_at, paid_at, items, client, payment_methods,
+// credit_notes_ids, organization, invoice_type.
+//
+// Fields that are IN `required:` but whose VALUE is nullable per Qonto
+// (`contact_email`, `terms_and_conditions`, `header`, `footer`, `issue_date`,
+// `due_date`) keep `.nullable()` (no `.optional()`) per L2 audit
+// (#601, R-SS-2 — field presence is guaranteed by the contract).
+//
+// Fields NOT in `required:` (`attachment_id`, `discount`) are `.nullable().optional()`
+// — they MAY be omitted entirely per Qonto's OpenAPI semantics (#496 / #604 pattern).
 export const ClientInvoiceSchema = z
   .object({
     id: z.string(),
@@ -117,9 +140,6 @@ export const ClientInvoiceSchema = z
     due_date: z.string().nullable(),
     created_at: z.string(),
     updated_at: z.string(),
-    // Qonto's `ClientInvoice` schema does not list `attachment_id` in
-    // `required`, so the field may be omitted entirely (not just null).
-    // Mirrors the Quote fix from #496.
     attachment_id: z.string().nullable().optional(),
     contact_email: z.string().nullable(),
     terms_and_conditions: z.string().nullable(),

--- a/packages/core/src/client-invoices/types.ts
+++ b/packages/core/src/client-invoices/types.ts
@@ -28,7 +28,7 @@ export interface ClientInvoiceDiscount {
  */
 export interface ClientInvoiceItem {
   readonly title: string;
-  readonly description: string | null;
+  readonly description?: string | null | undefined;
   readonly quantity: string;
   readonly unit?: string | null | undefined;
   readonly vat_rate: string;
@@ -48,11 +48,11 @@ export interface ClientInvoiceItem {
  * An address embedded in a client invoice client.
  */
 export interface ClientInvoiceAddress {
-  readonly street_address: string | null;
-  readonly city: string | null;
-  readonly zip_code: string | null;
+  readonly street_address?: string | null | undefined;
+  readonly city?: string | null | undefined;
+  readonly zip_code?: string | null | undefined;
   readonly province_code?: string | null | undefined;
-  readonly country_code: string | null;
+  readonly country_code?: string | null | undefined;
 }
 
 /**
@@ -65,20 +65,20 @@ export interface ClientInvoiceAddress {
 export interface ClientInvoiceClient {
   readonly id: string;
   readonly type: "individual" | "company" | "freelancer";
-  readonly name: string | null;
+  readonly name?: string | null | undefined;
   readonly first_name?: string | null | undefined;
   readonly last_name?: string | null | undefined;
-  readonly email: string | null;
-  readonly vat_number: string | null;
-  readonly tax_identification_number: string | null;
-  readonly address: string | null;
-  readonly city: string | null;
-  readonly zip_code: string | null;
+  readonly email?: string | null | undefined;
+  readonly vat_number?: string | null | undefined;
+  readonly tax_identification_number?: string | null | undefined;
+  readonly address?: string | null | undefined;
+  readonly city?: string | null | undefined;
+  readonly zip_code?: string | null | undefined;
   readonly province_code?: string | null | undefined;
-  readonly country_code: string | null;
+  readonly country_code?: string | null | undefined;
   readonly recipient_code?: string | null | undefined;
-  readonly locale: string | null;
-  readonly billing_address: ClientInvoiceAddress | null;
+  readonly locale?: string | null | undefined;
+  readonly billing_address?: ClientInvoiceAddress | null | undefined;
   readonly delivery_address?: ClientInvoiceAddress | null | undefined;
 }
 

--- a/packages/core/src/types/quote.schema.test.ts
+++ b/packages/core/src/types/quote.schema.test.ts
@@ -266,4 +266,76 @@ describe("QuoteSchema", () => {
     const result = QuoteSchema.parse(withoutAttachment);
     expect(result.attachment_id).toBeUndefined();
   });
+
+  // Fields NOT in Qonto's Quote `required:` list (see body comment in
+  // quote.schema.ts for the canonical required list) — regression: L2
+  // audit #601. Per OpenAPI semantics, fields outside `required:` MAY be
+  // omitted entirely (not just null).
+  it.each([
+    "approved_at",
+    "canceled_at",
+    "quote_url",
+    "contact_email",
+    "terms_and_conditions",
+    "header",
+    "footer",
+    "discount",
+    "invoice_ids",
+  ] as const)("accepts Quote with %s omitted entirely (regression: L2 audit #601)", (field) => {
+    const input = Object.fromEntries(Object.entries(validQuote).filter(([k]) => k !== field));
+    const result = QuoteSchema.parse(input);
+    if (field === "discount") {
+      expect(result.discount).toBeNull(); // `.default(null)` supplies null for missing input
+    } else {
+      expect((result as Record<string, unknown>)[field]).toBeUndefined();
+    }
+  });
+});
+
+// Nested-schema regression tests for #601 L2 audit: per Qonto's quote-endpoint
+// docs, none of QuoteItem / QuoteAddress / QuoteClient has a `required:` list
+// — every field MAY be omitted entirely. Verified at the schema boundary so
+// real Qonto responses lacking these fields parse without error.
+
+describe("QuoteItemSchema (#601 L2 audit)", () => {
+  it.each(["description", "unit", "vat_exemption_reason", "discount"] as const)(
+    "accepts Item with %s omitted entirely (regression: L2 audit #601)",
+    (field) => {
+      const input = Object.fromEntries(Object.entries(item).filter(([k]) => k !== field));
+      expect(() => QuoteItemSchema.parse(input)).not.toThrow();
+    },
+  );
+});
+
+describe("QuoteAddressSchema (#601 L2 audit)", () => {
+  it.each(["street_address", "city", "zip_code", "province_code", "country_code"] as const)(
+    "accepts Address with %s omitted entirely (regression: L2 audit #601)",
+    (field) => {
+      const input = Object.fromEntries(Object.entries(address).filter(([k]) => k !== field));
+      expect(() => QuoteAddressSchema.parse(input)).not.toThrow();
+    },
+  );
+});
+
+describe("QuoteClientSchema (#601 L2 audit)", () => {
+  it.each([
+    "name",
+    "first_name",
+    "last_name",
+    "email",
+    "vat_number",
+    "tax_identification_number",
+    "address",
+    "city",
+    "zip_code",
+    "province_code",
+    "country_code",
+    "recipient_code",
+    "locale",
+    "billing_address",
+    "delivery_address",
+  ] as const)("accepts Client with %s omitted entirely (regression: L2 audit #601)", (field) => {
+    const input = Object.fromEntries(Object.entries(client).filter(([k]) => k !== field));
+    expect(() => QuoteClientSchema.parse(input)).not.toThrow();
+  });
 });

--- a/packages/core/src/types/quote.schema.ts
+++ b/packages/core/src/types/quote.schema.ts
@@ -27,14 +27,18 @@ export const QuoteDiscountSchema = z
   })
   .strip() satisfies z.ZodType<QuoteDiscount>;
 
+// Per Qonto's quote-endpoint docs, the nested Item schema has no `required:`
+// list — every field MAY be omitted entirely. Relaxed `.nullable()` fields to
+// `.nullable().optional()` (R-SS-1 / #604 pattern); strict fields kept as-is
+// (out of nullable-vs-optional audit scope, separate strict-to-optional class).
 export const QuoteItemSchema = z
   .object({
     title: z.string(),
-    description: z.string().nullable(),
+    description: z.string().nullable().optional(),
     quantity: z.string(),
-    unit: z.string().nullable().default(null),
+    unit: z.string().nullable().optional().default(null),
     vat_rate: z.string(),
-    vat_exemption_reason: z.string().nullable().default(null),
+    vat_exemption_reason: z.string().nullable().optional().default(null),
     unit_price: QuoteAmountSchema,
     unit_price_cents: z.number(),
     total_amount: QuoteAmountSchema,
@@ -43,42 +47,56 @@ export const QuoteItemSchema = z
     total_vat_cents: z.number(),
     subtotal: QuoteAmountSchema,
     subtotal_cents: z.number(),
-    discount: QuoteDiscountSchema.nullable().default(null),
+    discount: QuoteDiscountSchema.nullable().optional().default(null),
   })
   .strip() satisfies z.ZodType<QuoteItem>;
 
+// Per Qonto's quote-endpoint docs, the nested Address schema has no
+// `required:` list — every field MAY be omitted entirely. Relaxed to
+// `.nullable().optional()` (R-SS-1 / #604 pattern).
 export const QuoteAddressSchema = z
   .object({
-    street_address: z.string().nullable().default(null),
-    city: z.string().nullable().default(null),
-    zip_code: z.string().nullable().default(null),
-    province_code: z.string().nullable().default(null),
-    country_code: z.string().nullable().default(null),
+    street_address: z.string().nullable().optional().default(null),
+    city: z.string().nullable().optional().default(null),
+    zip_code: z.string().nullable().optional().default(null),
+    province_code: z.string().nullable().optional().default(null),
+    country_code: z.string().nullable().optional().default(null),
   })
   .strip() satisfies z.ZodType<QuoteAddress>;
 
+// Per Qonto's quote-endpoint docs, the EmbeddedClient schema has no
+// `required:` list — every field other than `id` and `type` MAY be omitted
+// entirely. Relaxed to `.nullable().optional()` (R-SS-1 / #604 pattern).
+// `id` and `type` are kept strict because they are universally returned
+// and `type` drives downstream branching (individual/company/freelancer).
 export const QuoteClientSchema = z
   .object({
     id: z.string(),
     type: z.enum(["individual", "company", "freelancer"]),
-    name: z.string().nullable().default(null),
-    first_name: z.string().nullable().default(null),
-    last_name: z.string().nullable().default(null),
-    email: z.string().nullable().default(null),
-    vat_number: z.string().nullable().default(null),
-    tax_identification_number: z.string().nullable().default(null),
-    address: z.string().nullable().default(null),
-    city: z.string().nullable().default(null),
-    zip_code: z.string().nullable().default(null),
-    province_code: z.string().nullable().default(null),
-    country_code: z.string().nullable().default(null),
-    recipient_code: z.string().nullable().default(null),
-    locale: z.string().nullable().default(null),
-    billing_address: QuoteAddressSchema.nullable().default(null),
-    delivery_address: QuoteAddressSchema.nullable().default(null),
+    name: z.string().nullable().optional().default(null),
+    first_name: z.string().nullable().optional().default(null),
+    last_name: z.string().nullable().optional().default(null),
+    email: z.string().nullable().optional().default(null),
+    vat_number: z.string().nullable().optional().default(null),
+    tax_identification_number: z.string().nullable().optional().default(null),
+    address: z.string().nullable().optional().default(null),
+    city: z.string().nullable().optional().default(null),
+    zip_code: z.string().nullable().optional().default(null),
+    province_code: z.string().nullable().optional().default(null),
+    country_code: z.string().nullable().optional().default(null),
+    recipient_code: z.string().nullable().optional().default(null),
+    locale: z.string().nullable().optional().default(null),
+    billing_address: QuoteAddressSchema.nullable().optional().default(null),
+    delivery_address: QuoteAddressSchema.nullable().optional().default(null),
   })
   .strip() satisfies z.ZodType<QuoteClient>;
 
+// Per Qonto's quote-endpoint docs (list / retrieve / create / patch),
+// `Quote.required` covers: id, organization_id, number, status, currency,
+// total_amount{,_cents}, vat_amount{,_cents}, issue_date, expiry_date,
+// created_at, items, client, organization. Every other field MAY be
+// omitted entirely. Relaxed each non-required `.nullable()` field to
+// `.nullable().optional()` (#601, mirroring #604's L2 audit pattern).
 export const QuoteSchema = z
   .object({
     id: z.string(),
@@ -93,21 +111,18 @@ export const QuoteSchema = z
     issue_date: z.string(),
     expiry_date: z.string(),
     created_at: z.string(),
-    approved_at: z.string().nullable(),
-    canceled_at: z.string().nullable(),
-    // Qonto's `Quote` schema does not list `attachment_id` in `required`,
-    // so the field may be omitted entirely (not just null). Observed in
-    // PATCH responses where the field is dropped from the payload (#496).
+    approved_at: z.string().nullable().optional(),
+    canceled_at: z.string().nullable().optional(),
     attachment_id: z.string().nullable().optional(),
-    quote_url: z.string().nullable(),
-    contact_email: z.string().nullable(),
-    terms_and_conditions: z.string().nullable(),
-    header: z.string().nullable(),
-    footer: z.string().nullable(),
-    discount: QuoteDiscountSchema.nullable().default(null),
+    quote_url: z.string().nullable().optional(),
+    contact_email: z.string().nullable().optional(),
+    terms_and_conditions: z.string().nullable().optional(),
+    header: z.string().nullable().optional(),
+    footer: z.string().nullable().optional(),
+    discount: QuoteDiscountSchema.nullable().optional().default(null),
     items: z.array(QuoteItemSchema).readonly(),
     client: QuoteClientSchema,
-    invoice_ids: z.array(z.string()).readonly(),
+    invoice_ids: z.array(z.string()).readonly().optional(),
   })
   .strip() satisfies z.ZodType<Quote>;
 

--- a/packages/core/src/types/quote.ts
+++ b/packages/core/src/types/quote.ts
@@ -28,11 +28,11 @@ export interface QuoteDiscount {
  */
 export interface QuoteItem {
   readonly title: string;
-  readonly description: string | null;
+  readonly description?: string | null | undefined;
   readonly quantity: string;
-  readonly unit: string | null;
+  readonly unit?: string | null | undefined;
   readonly vat_rate: string;
-  readonly vat_exemption_reason: string | null;
+  readonly vat_exemption_reason?: string | null | undefined;
   readonly unit_price: QuoteAmount;
   readonly unit_price_cents: number;
   readonly total_amount: QuoteAmount;
@@ -41,18 +41,18 @@ export interface QuoteItem {
   readonly total_vat_cents: number;
   readonly subtotal: QuoteAmount;
   readonly subtotal_cents: number;
-  readonly discount: QuoteDiscount | null;
+  readonly discount?: QuoteDiscount | null | undefined;
 }
 
 /**
  * An address embedded in a quote client.
  */
 export interface QuoteAddress {
-  readonly street_address: string | null;
-  readonly city: string | null;
-  readonly zip_code: string | null;
-  readonly province_code: string | null;
-  readonly country_code: string | null;
+  readonly street_address?: string | null | undefined;
+  readonly city?: string | null | undefined;
+  readonly zip_code?: string | null | undefined;
+  readonly province_code?: string | null | undefined;
+  readonly country_code?: string | null | undefined;
 }
 
 /**
@@ -61,21 +61,21 @@ export interface QuoteAddress {
 export interface QuoteClient {
   readonly id: string;
   readonly type: "individual" | "company" | "freelancer";
-  readonly name: string | null;
-  readonly first_name: string | null;
-  readonly last_name: string | null;
-  readonly email: string | null;
-  readonly vat_number: string | null;
-  readonly tax_identification_number: string | null;
-  readonly address: string | null;
-  readonly city: string | null;
-  readonly zip_code: string | null;
-  readonly province_code: string | null;
-  readonly country_code: string | null;
-  readonly recipient_code: string | null;
-  readonly locale: string | null;
-  readonly billing_address: QuoteAddress | null;
-  readonly delivery_address: QuoteAddress | null;
+  readonly name?: string | null | undefined;
+  readonly first_name?: string | null | undefined;
+  readonly last_name?: string | null | undefined;
+  readonly email?: string | null | undefined;
+  readonly vat_number?: string | null | undefined;
+  readonly tax_identification_number?: string | null | undefined;
+  readonly address?: string | null | undefined;
+  readonly city?: string | null | undefined;
+  readonly zip_code?: string | null | undefined;
+  readonly province_code?: string | null | undefined;
+  readonly country_code?: string | null | undefined;
+  readonly recipient_code?: string | null | undefined;
+  readonly locale?: string | null | undefined;
+  readonly billing_address?: QuoteAddress | null | undefined;
+  readonly delivery_address?: QuoteAddress | null | undefined;
 }
 
 /**
@@ -94,16 +94,16 @@ export interface Quote {
   readonly issue_date: string;
   readonly expiry_date: string;
   readonly created_at: string;
-  readonly approved_at: string | null;
-  readonly canceled_at: string | null;
+  readonly approved_at?: string | null | undefined;
+  readonly canceled_at?: string | null | undefined;
   readonly attachment_id?: string | null | undefined;
-  readonly quote_url: string | null;
-  readonly contact_email: string | null;
-  readonly terms_and_conditions: string | null;
-  readonly header: string | null;
-  readonly footer: string | null;
-  readonly discount: QuoteDiscount | null;
+  readonly quote_url?: string | null | undefined;
+  readonly contact_email?: string | null | undefined;
+  readonly terms_and_conditions?: string | null | undefined;
+  readonly header?: string | null | undefined;
+  readonly footer?: string | null | undefined;
+  readonly discount?: QuoteDiscount | null | undefined;
   readonly items: readonly QuoteItem[];
   readonly client: QuoteClient;
-  readonly invoice_ids: readonly string[];
+  readonly invoice_ids?: readonly string[] | undefined;
 }


### PR DESCRIPTION
## Summary

Closes the Quote + ClientInvoice slice of the L2 strictness audit (epic #603 Wave A) that #604 explicitly excluded to avoid scope overlap with this issue. Same docs-vs-schema gap class as #496/#602: Qonto's OpenAPI semantics let a field NOT in `required:` be omitted entirely, but qontoctl's `z.<type>().nullable()` still requires presence.

- **48 RELAX** — fields NOT in Qonto OpenAPI `required:` → `.nullable().optional()` (Quote: 33 fields across 4 schemas; ClientInvoice: 15 fields across 3 nested schemas).
- **6 KEEP** — ClientInvoice top-level fields IN `required:` whose value is nullable per Qonto (`issue_date`, `due_date`, `contact_email`, `terms_and_conditions`, `header`, `footer`). Consolidated citing comment in schema body (R-SS-2 presence-guarantee).
- **+48 regression tests** — one per newly-relaxed field, following design §6.2 pattern (`accepts {Schema} with {field} omitted entirely`). Compact `it.each([...] as const)` for the larger surfaces; individual `it()` for singletons. Core test count: 1175 → 1223.

OpenAPI required lists verified 2026-05-18 via direct fetch from `docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/{quotes,client-invoices}/...`.

CLI consumer fix: `clientDisplayName` in `cli/src/commands/{quote,client-invoice}.ts` switched from `!== null` to `!= null` to narrow out both null and undefined, since the nested EmbeddedClient `name` fields are now optional (matching the existing precedent comment for `first_name`/`last_name`).

## Test plan

- [x] `pnpm build` — all 5 packages build cleanly (TypeScript strict)
- [x] `pnpm test` — 1223 core tests pass (+48), all other packages unchanged
- [x] `pnpm lint` — clean across all 8 packages
- [x] `pnpm format:check` — clean
- [x] `pnpm license-check` — clean
- [x] `node scripts/check-coverage-drift.js` — clean
- [x] Audit re-run on the two formerly-excluded files: 7 KEEP candidates remain — 6 documented required-but-nullable fields + the `items.nullable().transform()` items-null-normalization (regression #575)
- [x] `pnpm test:e2e` (local) — Quote E2E (9 tests) and ClientInvoice E2E (24+16 tests) all pass; the 74 unrelated failures are pre-existing in the local environment (confirmed by running the same suites on origin/main)

Fixes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)