### PR TITLE
(test) schema-vs-runtime contract probe (local drift detector) (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Tooling**: `pnpm contract-probe` — schema-vs-runtime drift detector that probes Qonto GET endpoints with OAuth credentials, diffs live responses against Zod schemas exported from `@qontoctl/core`, and emits a `SchemaDriftReport[]` to `.tmp/contract-probe/{ISO8601}.json` plus a console summary table. Read-only by construction (GET-only endpoint catalog at `scripts/contract-probe.endpoints.json`); suggest-don't-apply (never edits schema files — emits corrective Zod declarations as text for maintainer review). Local-only per design (CI is api-key only — see `docs/designs/e2e-test-reliability.md §8.1`); maintainers should run it quarterly and before each release (see `docs/release-runbook.md` § Contract probe). Typed exit codes: 0 = clean, 1 = drift detected (scriptable), 2 = OAuth expired/missing, 3 = config/network error. Implements PRD requirements R-CP-1..R-CP-4 (#608).
+
 ## [2.0.1] — 2026-05-15
 
 ### Fixed

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -108,6 +108,31 @@ The smoke-test step simulates the Homebrew install path under the strictest poss
 
 If verification fails, the most likely causes are: (a) `bundleDependencies` having been removed from `packages/qontoctl/package.json` (so pnpm pack excludes `node_modules/` entirely); (b) the `NPM_CONFIG_NODE_LINKER=hoisted` env var was dropped from the deploy step, leaving symlinked `node_modules/.pnpm/` that pack cannot include; (c) a new transitive dep was added to `@qontoctl/cli`, `@qontoctl/mcp`, or `@qontoctl/core` but the CI guard's enumeration in `.github/workflows/release.yml` was not updated to verify it. Inspect `tar tzf "$tarball" | grep node_modules | awk -F/ '{print $3}' | sort -u` to see what is actually bundled.
 
+### 1.6. Run the contract probe (local)
+
+Run the schema-vs-runtime contract probe to catch any Zod schema drift before tagging. This is the safety net against shipping a release where one or more `@qontoctl/core` schemas reject responses the live Qonto API actually returns (the failure mode that motivated #601, #604, #514, #496, etc., where each schema-strictness fix landed reactively after a user hit `Invalid API response`).
+
+```sh
+pnpm contract-probe
+```
+
+The probe loads OAuth credentials from the resolved config file (per CLAUDE.md § Configuration), calls every GET endpoint listed in `scripts/contract-probe.endpoints.json`, diffs each response against the named Zod schema exported from `@qontoctl/core`, and writes a `SchemaDriftReport[]` to `.tmp/contract-probe/{ISO8601}.json` plus a console summary table. The script is read-only by construction (GET-only endpoint catalog; never auto-edits schemas) — it surfaces drift as **suggested** corrective Zod declarations the maintainer reviews and applies manually.
+
+**Exit codes**:
+
+| Code | Meaning                                                      | Action                                                                                                                                                                                                                                                                                                              |
+| ---- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0`  | No drift detected — every probed endpoint matches its schema | Proceed to § 2                                                                                                                                                                                                                                                                                                      |
+| `1`  | Drift detected on one or more endpoints                      | Open the JSON report at `.tmp/contract-probe/{ISO8601}.json`, decide per finding whether to relax the schema (additive `*.nullable().optional()` change) or to investigate as a real API contract change. Suggested fixes are emitted next to each finding; apply them in a follow-up PR before tagging the release |
+| `2`  | OAuth credentials expired or missing                         | Re-authenticate (`qontoctl auth login` or refresh the file at the resolved config path) and re-run                                                                                                                                                                                                                  |
+| `3`  | Config / network / schema-shape error                        | See the error message; the probe fails fast on misconfiguration                                                                                                                                                                                                                                                     |
+
+**Why this matters at release time**: every prior schema-strictness incident was found by a user hitting a live response the schema rejected. Running the probe pre-release converts that reactive loop into a proactive check — discovered drift becomes a one-line schema relaxation in the same release rather than a hotfix the week after.
+
+**Cadence**: at minimum, **before every release** (this step). The maintainer SHOULD also run the probe **quarterly** out-of-band even when no release is imminent — Qonto API responses can drift between releases, and a quarterly cadence keeps the drift surface bounded. There is no automated quarterly trigger today; the contract probe is intentionally local-only per `docs/designs/e2e-test-reliability.md §8.1` (CI runs api-key only, so it cannot exercise the OAuth-required endpoints in the catalog).
+
+**Expanding the catalog**: if a new GET endpoint ships in `@qontoctl/core`, add an entry to `scripts/contract-probe.endpoints.json` with the schema name, response path, and an optional `query` map (some endpoints reject `per_page`). The catalog is the only thing the probe consults — adding code does not auto-enroll an endpoint into the probe surface.
+
 ### 2. Update CHANGELOG
 
 Promote `[Unreleased]` to a versioned heading and start a fresh empty `[Unreleased]`:

--- a/package.json
+++ b/package.json
@@ -14,24 +14,30 @@
     "test": "turbo run test",
     "test:e2e": "turbo run test:e2e --concurrency=1",
     "format:check": "prettier --check .",
-    "typecheck": "turbo run typecheck",
+    "typecheck": "turbo run typecheck && tsc -p scripts/tsconfig.json",
     "lint": "turbo run lint",
     "license-check": "node scripts/check-licenses.js",
     "publish-check": "node scripts/check-publish-manifest.js",
     "coverage-drift-check": "node scripts/check-coverage-drift.js",
     "silent-skip-check": "node scripts/check-no-silent-skip.js",
+    "contract-probe": "tsx scripts/contract-probe.ts",
+    "contract-probe-test": "vitest run scripts/contract-probe.test.ts",
     "dev": "turbo run dev"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
+    "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "@tony.ganchev/eslint-plugin-header": "catalog:",
     "prettier": "catalog:",
+    "tsx": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "@qontoctl/core": "workspace:^",
+    "zod": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     prettier:
       specifier: ^3.8.1
       version: 3.8.1
+    tsx:
+      specifier: ^4.20.1
+      version: 4.22.1
     turbo:
       specifier: ^2.8.20
       version: 2.8.20
@@ -65,12 +68,18 @@ importers:
       '@eslint/js':
         specifier: 'catalog:'
         version: 9.39.3
+      '@qontoctl/core':
+        specifier: workspace:^
+        version: link:packages/core
       '@tony.ganchev/eslint-plugin-header':
         specifier: 'catalog:'
         version: 3.3.3(eslint@9.39.3)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1(@types/node@25.3.2)(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3)))
+        version: 4.1.1(vitest@4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3)))
       eslint:
         specifier: 'catalog:'
         version: 9.39.3
@@ -80,6 +89,9 @@ importers:
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.1
       turbo:
         specifier: 'catalog:'
         version: 2.8.20
@@ -91,7 +103,10 @@ importers:
         version: 8.57.2(eslint@9.39.3)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@25.3.2)(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   packages/cli:
     dependencies:
@@ -119,7 +134,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
   packages/core:
     dependencies:
@@ -150,7 +165,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
   packages/e2e:
     dependencies:
@@ -184,7 +199,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
   packages/mcp:
     dependencies:
@@ -209,7 +224,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
   packages/qontoctl:
     dependencies:
@@ -231,7 +246,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+        version: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
 packages:
 
@@ -268,8 +283,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -280,8 +307,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -292,8 +331,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -304,8 +355,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -316,8 +379,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -328,8 +403,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -340,8 +427,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -352,8 +451,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -364,8 +475,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -376,8 +499,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -388,8 +523,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -400,8 +547,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -412,8 +571,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -697,9 +868,6 @@ packages:
   '@types/node@24.10.15':
     resolution: {integrity: sha512-BgjLoRuSr0MTI5wA6gMw9Xy0sFudAaUuvrnjgGx9wZ522fYYLA5SYJ+1Y30vTcJEG+DRCyDHx/gzQVfofYzSdg==}
 
-  '@types/node@25.3.2':
-    resolution: {integrity: sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==}
-
   '@types/proper-lockfile@4.1.4':
     resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
 
@@ -979,6 +1147,11 @@ packages:
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1556,6 +1729,11 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tsx@4.22.1:
+    resolution: {integrity: sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.8.20:
     resolution: {integrity: sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ==}
     hasBin: true
@@ -1592,9 +1770,6 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -1745,79 +1920,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3)':
@@ -2058,11 +2311,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.3.2':
-    dependencies:
-      undici-types: 7.18.2
-    optional: true
-
   '@types/proper-lockfile@4.1.4':
     dependencies:
       '@types/retry': 0.12.5
@@ -2162,7 +2410,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@25.3.2)(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3)))':
+  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.1
@@ -2174,7 +2422,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.1(@types/node@25.3.2)(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3))
+      vitest: 4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.1':
     dependencies:
@@ -2185,21 +2433,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.10.15)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.1(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.1
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.2)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.1':
     dependencies:
@@ -2405,6 +2645,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escape-html@1.0.3: {}
 
@@ -3004,6 +3273,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  tsx@4.22.1:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo@2.8.20:
     optionalDependencies:
       '@turbo/darwin-64': 2.8.20
@@ -3049,9 +3324,6 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.18.2:
-    optional: true
-
   unpipe@1.0.0: {}
 
   uri-js@4.4.1:
@@ -3060,7 +3332,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3):
+  vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3071,25 +3343,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.15
       fsevents: 2.3.3
+      tsx: 4.22.1
       yaml: 2.8.3
 
-  vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.0
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.3.2
-      fsevents: 2.3.3
-      yaml: 2.8.3
-
-  vitest@4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3)):
+  vitest@4.1.1(@types/node@24.10.15)(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@24.10.15)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.1
       '@vitest/runner': 4.1.1
       '@vitest/snapshot': 4.1.1
@@ -3106,37 +3366,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.10.15)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@24.10.15)(tsx@4.22.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.15
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.1(@types/node@25.3.2)(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.1
-      '@vitest/mocker': 4.1.1(vite@7.3.1(@types/node@25.3.2)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.1
-      '@vitest/runner': 4.1.1
-      '@vitest/snapshot': 4.1.1
-      '@vitest/spy': 4.1.1
-      '@vitest/utils': 4.1.1
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.3.2)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 25.3.2
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,4 @@ catalog:
   typedoc: "^0.28.18"
   "@clack/prompts": "^1.1.0"
   yaml: "^2.8.3"
+  tsx: "^4.20.1"

--- a/scripts/contract-probe.endpoints.json
+++ b/scripts/contract-probe.endpoints.json
@@ -1,0 +1,175 @@
+{
+  "_comment": "Schema-vs-runtime contract probe endpoint catalog. READ-ONLY by construction. Each entry samples one GET endpoint and diffs the response against the named Zod schema (exported from @qontoctl/core). The probe extracts response_path before diffing, so the schema can be the inner item schema (e.g., QuoteSchema) rather than the wrapper (QuoteListResponseSchema). Adding new endpoints: ensure (a) endpoint is GET-only, (b) schema is exported from @qontoctl/core/index.ts, (c) response_path resolves to a single object (use [0] to pick the first list item). See docs/designs/e2e-test-reliability.md §8.1 and PRD §4.4 (R-CP-1..R-CP-4) for the contract.",
+  "_schema_version": 1,
+  "endpoints": [
+    {
+      "id": "organization",
+      "method": "GET",
+      "path": "/v2/organization",
+      "schema": "OrganizationSchema",
+      "response_path": "organization",
+      "notes": "Singular resource. Always present for authenticated org."
+    },
+    {
+      "id": "list-labels",
+      "method": "GET",
+      "path": "/v2/labels",
+      "query": { "per_page": "1" },
+      "schema": "LabelSchema",
+      "response_path": "labels[0]",
+      "notes": "Probe first item only; per_page=1 minimizes payload."
+    },
+    {
+      "id": "list-memberships",
+      "method": "GET",
+      "path": "/v2/memberships",
+      "query": { "per_page": "1" },
+      "schema": "MembershipSchema",
+      "response_path": "memberships[0]"
+    },
+    {
+      "id": "list-teams",
+      "method": "GET",
+      "path": "/v2/teams",
+      "query": { "per_page": "1" },
+      "schema": "TeamSchema",
+      "response_path": "teams[0]"
+    },
+    {
+      "id": "list-beneficiaries",
+      "method": "GET",
+      "path": "/v2/sepa/beneficiaries",
+      "query": { "per_page": "1" },
+      "schema": "BeneficiarySchema",
+      "response_path": "beneficiaries[0]"
+    },
+    {
+      "id": "list-cards",
+      "method": "GET",
+      "path": "/v2/cards",
+      "query": { "per_page": "1" },
+      "schema": "CardSchema",
+      "response_path": "cards[0]"
+    },
+    {
+      "id": "list-clients",
+      "method": "GET",
+      "path": "/v2/clients",
+      "query": { "per_page": "1" },
+      "schema": "ClientSchema",
+      "response_path": "clients[0]"
+    },
+    {
+      "id": "list-quotes",
+      "method": "GET",
+      "path": "/v2/quotes",
+      "query": { "per_page": "1" },
+      "schema": "QuoteSchema",
+      "response_path": "quotes[0]",
+      "notes": "Source of #496 schema drift; high-value probe target."
+    },
+    {
+      "id": "list-client-invoices",
+      "method": "GET",
+      "path": "/v2/client_invoices",
+      "query": { "per_page": "1" },
+      "schema": "ClientInvoiceSchema",
+      "response_path": "client_invoices[0]"
+    },
+    {
+      "id": "list-credit-notes",
+      "method": "GET",
+      "path": "/v2/credit_notes",
+      "query": { "per_page": "1" },
+      "schema": "CreditNoteSchema",
+      "response_path": "credit_notes[0]"
+    },
+    {
+      "id": "list-transactions",
+      "method": "GET",
+      "path": "/v2/transactions",
+      "query": { "per_page": "1" },
+      "schema": "TransactionSchema",
+      "response_path": "transactions[0]"
+    },
+    {
+      "id": "list-products",
+      "method": "GET",
+      "path": "/v2/products",
+      "query": { "per_page": "1" },
+      "schema": "ProductSchema",
+      "response_path": "products[0]"
+    },
+    {
+      "id": "list-payment-links",
+      "method": "GET",
+      "path": "/v2/payment_links",
+      "query": { "per_page": "1" },
+      "schema": "PaymentLinkSchema",
+      "response_path": "payment_links[0]"
+    },
+    {
+      "id": "list-recurring-transfers",
+      "method": "GET",
+      "path": "/v2/sepa/recurring_transfers",
+      "query": { "per_page": "1" },
+      "schema": "RecurringTransferSchema",
+      "response_path": "recurring_transfers[0]"
+    },
+    {
+      "id": "list-supplier-invoices",
+      "method": "GET",
+      "path": "/v2/supplier_invoices",
+      "query": { "per_page": "1" },
+      "schema": "SupplierInvoiceSchema",
+      "response_path": "supplier_invoices[0]"
+    },
+    {
+      "id": "list-insurance-contracts",
+      "method": "GET",
+      "path": "/v2/insurance_contracts",
+      "query": { "per_page": "1" },
+      "schema": "InsuranceContractSchema",
+      "response_path": "insurance_contracts[0]"
+    },
+    {
+      "id": "list-webhook-subscriptions",
+      "method": "GET",
+      "path": "/v2/webhook_subscriptions",
+      "schema": "WebhookSubscriptionSchema",
+      "response_path": "webhook_subscriptions[0]",
+      "notes": "Webhook list endpoint does not accept per_page."
+    },
+    {
+      "id": "list-transfers",
+      "method": "GET",
+      "path": "/v2/sepa/transfers",
+      "query": { "per_page": "1" },
+      "schema": "TransferSchema",
+      "response_path": "transfers[0]"
+    },
+    {
+      "id": "list-statements",
+      "method": "GET",
+      "path": "/v2/statements",
+      "query": { "per_page": "1" },
+      "schema": "StatementSchema",
+      "response_path": "statements[0]"
+    },
+    {
+      "id": "list-intl-beneficiaries",
+      "method": "GET",
+      "path": "/v2/international/beneficiaries",
+      "query": { "per_page": "1" },
+      "schema": "IntlBeneficiarySchema",
+      "response_path": "beneficiaries[0]"
+    },
+    {
+      "id": "einvoicing-settings",
+      "method": "GET",
+      "path": "/v2/einvoicing/settings",
+      "schema": "EInvoicingSettingsSchema",
+      "response_path": "einvoicing_settings"
+    }
+  ]
+}

--- a/scripts/contract-probe.test.ts
+++ b/scripts/contract-probe.test.ts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+import {
+  type EndpointConfig,
+  ProbeError,
+  assertCatalogShape,
+  diffSchema,
+  suggestCorrection,
+  walkKeys,
+} from "./contract-probe.js";
+
+// ---------------------------------------------------------------------------
+// walkKeys — schema introspection
+// ---------------------------------------------------------------------------
+
+describe("walkKeys", () => {
+  it("extracts plain string field as required-non-nullable", () => {
+    const schema = z.object({ id: z.string() }).strip();
+    const keys = walkKeys(schema);
+    expect(keys.get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  it("extracts nullable() field", () => {
+    const schema = z.object({ name: z.string().nullable() }).strip();
+    const keys = walkKeys(schema);
+    expect(keys.get("name")).toEqual({ isNullable: true, isOptional: false });
+  });
+
+  it("extracts optional() field", () => {
+    const schema = z.object({ slug: z.string().optional() }).strip();
+    const keys = walkKeys(schema);
+    expect(keys.get("slug")).toEqual({ isNullable: false, isOptional: true });
+  });
+
+  it("extracts nullable().optional() field (both flags)", () => {
+    const schema = z.object({ attachment_id: z.string().nullable().optional() }).strip();
+    const keys = walkKeys(schema);
+    expect(keys.get("attachment_id")).toEqual({ isNullable: true, isOptional: true });
+  });
+
+  it("extracts optional().nullable() field (reverse order, still both)", () => {
+    const schema = z.object({ x: z.string().optional().nullable() }).strip();
+    const keys = walkKeys(schema);
+    expect(keys.get("x")).toEqual({ isNullable: true, isOptional: true });
+  });
+
+  it("returns all keys for multi-field schema", () => {
+    const schema = z
+      .object({
+        id: z.string(),
+        name: z.string().nullable(),
+        balance: z.coerce.number(),
+      })
+      .strip();
+    const keys = walkKeys(schema);
+    expect([...keys.keys()].sort()).toEqual(["balance", "id", "name"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// diffSchema — runtime-vs-schema drift detection
+// ---------------------------------------------------------------------------
+
+describe("diffSchema", () => {
+  const Schema = z
+    .object({
+      id: z.string(),
+      name: z.string().nullable(),
+      attachment_id: z.string().nullable().optional(),
+    })
+    .strip();
+
+  it("returns empty diff when response matches schema exactly", () => {
+    const response = { id: "1", name: "X", attachment_id: "a" };
+    const diff = diffSchema(Schema, response);
+    expect(diff.extra_fields).toEqual([]);
+    expect(diff.missing_fields).toEqual([]);
+    expect(diff.strictness_mismatches).toEqual([]);
+  });
+
+  it("flags extra fields present in response but absent from schema", () => {
+    const response = { id: "1", name: "X", attachment_id: null, e_invoicing_status: "ok" };
+    const diff = diffSchema(Schema, response);
+    expect(diff.extra_fields.map((f) => f.field)).toContain("e_invoicing_status");
+    expect(diff.extra_fields[0]).toMatchObject({ field: "e_invoicing_status", observed_type: "string" });
+  });
+
+  it("flags missing fields present in schema but absent from response (when not optional)", () => {
+    const response = { name: "X" }; // missing id (required), missing attachment_id (optional — should NOT flag)
+    const diff = diffSchema(Schema, response);
+    expect(diff.missing_fields.map((f) => f.field)).toContain("id");
+    expect(diff.missing_fields.map((f) => f.field)).not.toContain("attachment_id");
+  });
+
+  it("does NOT flag missing optional fields", () => {
+    const response = { id: "1", name: "X" }; // attachment_id is optional — absent is fine
+    const diff = diffSchema(Schema, response);
+    expect(diff.missing_fields).toEqual([]);
+  });
+
+  it("flags strictness mismatch when response has null but schema is non-nullable", () => {
+    const StrictSchema = z.object({ id: z.string(), header: z.string() }).strip();
+    const response = { id: "1", header: null };
+    const diff = diffSchema(StrictSchema, response);
+    expect(diff.strictness_mismatches.map((m) => m.field)).toContain("header");
+    expect(diff.strictness_mismatches[0]).toMatchObject({
+      field: "header",
+      observed: "null",
+      schema_strictness: "non-nullable",
+    });
+  });
+
+  it("does NOT flag strictness mismatch when nullable field is null", () => {
+    const response = { id: "1", name: null, attachment_id: null };
+    const diff = diffSchema(Schema, response);
+    expect(diff.strictness_mismatches).toEqual([]);
+  });
+
+  it("walks nested arrays — uses first element as sample for diff", () => {
+    const ListSchema = z
+      .object({
+        items: z.array(z.object({ id: z.string(), name: z.string() }).strip()),
+      })
+      .strip();
+    const response = { items: [{ id: "1", name: "X", extra: "field" }] };
+    const diff = diffSchema(ListSchema, response);
+    // Expect the nested extra field to surface with a path-qualified field name
+    expect(diff.extra_fields.map((f) => f.field)).toContain("items[].extra");
+  });
+
+  it("walks nested object — qualifies path", () => {
+    const NestedSchema = z
+      .object({
+        organization: z.object({ slug: z.string() }).strip(),
+      })
+      .strip();
+    const response = { organization: { slug: "x", unknown_nested: "value" } };
+    const diff = diffSchema(NestedSchema, response);
+    expect(diff.extra_fields.map((f) => f.field)).toContain("organization.unknown_nested");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// suggestCorrection — produces actionable Zod-declaration suggestions
+// ---------------------------------------------------------------------------
+
+describe("suggestCorrection", () => {
+  it("suggests adding extra field to schema with permissive declaration", () => {
+    const suggestion = suggestCorrection({
+      kind: "extra_field",
+      field: "e_invoicing_status",
+      observed_type: "string",
+      schema_name: "QuoteSchema",
+    });
+    expect(suggestion).toContain("QuoteSchema");
+    expect(suggestion).toContain("e_invoicing_status");
+    expect(suggestion).toContain("z.string()");
+    // Permissive default: nullable + optional
+    expect(suggestion).toContain(".nullable()");
+    expect(suggestion).toContain(".optional()");
+  });
+
+  it("suggests relaxing missing field to optional", () => {
+    const suggestion = suggestCorrection({
+      kind: "missing_field",
+      field: "header",
+      schema_name: "QuoteSchema",
+    });
+    expect(suggestion).toContain("QuoteSchema.header");
+    expect(suggestion).toContain(".optional()");
+    // Must mention the "response omitted entirely" rationale
+    expect(suggestion.toLowerCase()).toMatch(/omit|absent/);
+  });
+
+  it("suggests relaxing non-nullable field to nullable when response is null", () => {
+    const suggestion = suggestCorrection({
+      kind: "strictness_mismatch",
+      field: "attachment_id",
+      observed: "null",
+      schema_strictness: "non-nullable",
+      schema_name: "QuoteSchema",
+    });
+    expect(suggestion).toContain("QuoteSchema.attachment_id");
+    expect(suggestion).toContain(".nullable()");
+  });
+
+  it("never produces output that would mutate schema files (suggest-only)", () => {
+    const suggestion = suggestCorrection({
+      kind: "extra_field",
+      field: "test",
+      observed_type: "string",
+      schema_name: "TestSchema",
+    });
+    // The suggestion is a STRING (advice), never an executable instruction
+    expect(typeof suggestion).toBe("string");
+    expect(suggestion).not.toContain("writeFileSync");
+    expect(suggestion).not.toContain("fs.write");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProbeError — exit-code-carrying typed error
+// ---------------------------------------------------------------------------
+
+describe("ProbeError", () => {
+  it("carries an exitCode field", () => {
+    const err = new ProbeError("test", 2);
+    expect(err.exitCode).toBe(2);
+    expect(err.message).toBe("test");
+    expect(err.name).toBe("ProbeError");
+  });
+
+  it("is an instance of Error", () => {
+    const err = new ProbeError("test", 1);
+    expect(err instanceof Error).toBe(true);
+    expect(err instanceof ProbeError).toBe(true);
+  });
+
+  it("supports all four exit codes (0, 1, 2, 3)", () => {
+    expect(new ProbeError("clean", 0).exitCode).toBe(0);
+    expect(new ProbeError("drift", 1).exitCode).toBe(1);
+    expect(new ProbeError("oauth", 2).exitCode).toBe(2);
+    expect(new ProbeError("config", 3).exitCode).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertCatalogShape — load-bearing invariants
+// ---------------------------------------------------------------------------
+
+describe("assertCatalogShape", () => {
+  const okEntry: EndpointConfig = {
+    id: "list-x",
+    method: "GET",
+    path: "/v2/x",
+    schema: "XSchema",
+    response_path: "x[0]",
+  };
+
+  it("accepts a non-empty GET-only catalog", () => {
+    expect(() => assertCatalogShape([okEntry])).not.toThrow();
+  });
+
+  it("rejects an empty catalog with exit code 3", () => {
+    try {
+      assertCatalogShape([]);
+      throw new Error("expected ProbeError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProbeError);
+      expect((err as ProbeError).exitCode).toBe(3);
+      expect((err as ProbeError).message).toMatch(/zero entries/);
+    }
+  });
+
+  it("rejects a POST entry with exit code 3", () => {
+    const bad: EndpointConfig = { ...okEntry, method: "POST", id: "bad-post" };
+    try {
+      assertCatalogShape([okEntry, bad]);
+      throw new Error("expected ProbeError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProbeError);
+      expect((err as ProbeError).exitCode).toBe(3);
+      expect((err as ProbeError).message).toContain("bad-post");
+      expect((err as ProbeError).message).toContain("POST");
+      expect((err as ProbeError).message).toMatch(/GET-only/);
+    }
+  });
+
+  it("rejects PUT/PATCH/DELETE entries", () => {
+    for (const method of ["PUT", "PATCH", "DELETE"]) {
+      const bad: EndpointConfig = { ...okEntry, method };
+      expect(() => assertCatalogShape([bad])).toThrow(ProbeError);
+    }
+  });
+});

--- a/scripts/contract-probe.ts
+++ b/scripts/contract-probe.ts
@@ -1,0 +1,764 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Schema-vs-runtime contract probe (local drift detector).
+ *
+ * Calls a representative sample of Qonto GET endpoints with OAuth credentials,
+ * parses the live response with the matching Zod schema, and emits a drift
+ * report listing extra fields, missing fields, and strictness mismatches per
+ * endpoint, with suggested Zod declaration corrections.
+ *
+ * READ-ONLY by construction: only GET endpoints in `contract-probe.endpoints.json`.
+ * SUGGEST-ONLY by design: never edits schema files; output is a JSON report +
+ * console table. Manual review and Zod-file edits are downstream.
+ *
+ * Usage:
+ *   pnpm contract-probe                   — run probe (uses resolved config)
+ *   QONTOCTL_CONFIG_FILE=./.qontoctl.yaml pnpm contract-probe
+ *   QONTOCTL_PROFILE=name pnpm contract-probe
+ *
+ * Exit codes:
+ *   0 — all probed endpoints are clean (no drift detected)
+ *   1 — drift detected on one or more endpoints (report written)
+ *   2 — OAuth credentials missing, expired, or refresh failed (clear error)
+ *   3 — config / network / schema-shape error (configuration problem)
+ *
+ * See:
+ *   - docs/designs/e2e-test-reliability.md §8.1 (design contract)
+ *   - docs/prds/e2e-test-reliability.md §4.4 (R-CP-1..R-CP-4) + §5 Scenario 4
+ *   - CLAUDE.md (project conventions)
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { z } from "zod";
+
+import {
+  ConfigError,
+  HttpClient,
+  OAuthRefreshError,
+  QontoApiError,
+  QontoRateLimitError,
+  createOAuthAuthorization,
+  resolveConfig,
+  resolveScaMethod,
+  OAUTH_TOKEN_URL,
+  OAUTH_TOKEN_SANDBOX_URL,
+} from "@qontoctl/core";
+import * as CoreSchemas from "@qontoctl/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed error carrying an exit code for the script's `process.exit()` call.
+ *
+ * Helpers throw {@link ProbeError}; `main()` catches at the top level and
+ * exits exactly once with the carried code. This keeps the pure helpers
+ * (`walkKeys`, `diffSchema`, `suggestCorrection`) free of `process.exit()`
+ * side effects and trivially unit-testable.
+ */
+export class ProbeError extends Error {
+  readonly exitCode: 0 | 1 | 2 | 3;
+  constructor(message: string, exitCode: 0 | 1 | 2 | 3) {
+    super(message);
+    this.name = "ProbeError";
+    this.exitCode = exitCode;
+  }
+}
+
+/** Per-field strictness flags extracted from a Zod schema. */
+export interface KeySpec {
+  readonly isNullable: boolean;
+  readonly isOptional: boolean;
+}
+
+/** A field present in runtime but absent from the schema. */
+export interface ExtraField {
+  readonly field: string;
+  readonly observed_type: string;
+}
+
+/** A field present in schema but absent from runtime (and not optional). */
+export interface MissingField {
+  readonly field: string;
+}
+
+/** A field present in both but with mismatched strictness. */
+export interface StrictnessMismatch {
+  readonly field: string;
+  readonly observed: "null" | string;
+  readonly schema_strictness: "non-nullable" | "required";
+}
+
+/** A drift issue against a specific schema, used as input to suggestCorrection. */
+export type DriftIssue =
+  | (ExtraField & { readonly kind: "extra_field"; readonly schema_name: string })
+  | (MissingField & { readonly kind: "missing_field"; readonly schema_name: string })
+  | (StrictnessMismatch & { readonly kind: "strictness_mismatch"; readonly schema_name: string });
+
+/** Full diff between a response object and a schema. */
+export interface SchemaDiff {
+  readonly extra_fields: ExtraField[];
+  readonly missing_fields: MissingField[];
+  readonly strictness_mismatches: StrictnessMismatch[];
+}
+
+/** Probe result for a single endpoint, written to the JSON report. */
+export interface SchemaDriftReport {
+  readonly endpoint_id: string;
+  readonly method: string;
+  readonly path: string;
+  readonly schema: string;
+  readonly status: "ok" | "drift" | "skipped" | "error";
+  readonly extra_fields: ExtraField[];
+  readonly missing_fields: MissingField[];
+  readonly strictness_mismatches: StrictnessMismatch[];
+  readonly suggested_fixes: string[];
+  readonly error?: string;
+  readonly captured_at: string;
+}
+
+/** One endpoint entry from `contract-probe.endpoints.json`. */
+export interface EndpointConfig {
+  readonly id: string;
+  readonly method: string;
+  readonly path: string;
+  readonly query?: Record<string, string>;
+  readonly schema: string;
+  readonly response_path: string;
+  readonly notes?: string;
+}
+
+interface EndpointsFile {
+  readonly endpoints: readonly EndpointConfig[];
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions (unit-tested in contract-probe.test.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the field map from a Zod object schema, capturing nullable / optional
+ * flags. Unwraps `ZodOptional`/`ZodNullable` wrappers iteratively via the
+ * Zod 4 `_zod.def.innerType` chain to support `.nullable().optional()` in
+ * either order.
+ *
+ * Schemas not satisfying `instanceof z.ZodObject` should be rejected by the
+ * caller before invoking this helper — the function assumes a `.shape` field.
+ */
+export function walkKeys(schema: z.ZodObject<z.ZodRawShape>): Map<string, KeySpec> {
+  const result = new Map<string, KeySpec>();
+  // `schema.shape` values are typed as Zod's internal `$ZodType` interface;
+  // they are `z.ZodType` instances at runtime (the `instanceof` checks below
+  // confirm this). The cast bridges the public/internal type split.
+  for (const [key, raw] of Object.entries(schema.shape)) {
+    let inner: z.ZodType = raw as z.ZodType;
+    let isNullable = false;
+    let isOptional = false;
+    // Unwrap ZodOptional / ZodNullable iteratively; both orderings work.
+    while (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) {
+      if (inner instanceof z.ZodOptional) isOptional = true;
+      if (inner instanceof z.ZodNullable) isNullable = true;
+      inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
+    }
+    result.set(key, { isNullable, isOptional });
+  }
+  return result;
+}
+
+/**
+ * Diff a runtime response against a Zod object schema. Walks nested objects
+ * (qualifying paths with `.`) and arrays (using the first element as a sample
+ * and qualifying with `[]`). Returns drift in three buckets: extra fields,
+ * missing required fields, and strictness mismatches (null observed where
+ * schema is non-nullable).
+ *
+ * Schemas not satisfying `instanceof z.ZodObject` are treated as "no fields
+ * to diff" and return an empty diff — the caller catches the schema-shape
+ * error at config-load time, not here.
+ */
+export function diffSchema(schema: z.ZodType, response: unknown): SchemaDiff {
+  const extra_fields: ExtraField[] = [];
+  const missing_fields: MissingField[] = [];
+  const strictness_mismatches: StrictnessMismatch[] = [];
+  walkDiff(schema, response, "", { extra_fields, missing_fields, strictness_mismatches });
+  return { extra_fields, missing_fields, strictness_mismatches };
+}
+
+function walkDiff(
+  schema: z.ZodType,
+  response: unknown,
+  pathPrefix: string,
+  acc: {
+    extra_fields: ExtraField[];
+    missing_fields: MissingField[];
+    strictness_mismatches: StrictnessMismatch[];
+  },
+): void {
+  // Unwrap optional/nullable/preprocess wrappers for nested traversal — the
+  // wrapper's own strictness was already recorded by the parent's walkKeys;
+  // here we descend into the inner schema for nested object/array diffing.
+  const unwrapped = unwrapForDescent(schema);
+
+  if (unwrapped instanceof z.ZodObject) {
+    if (response === null || typeof response !== "object" || Array.isArray(response)) {
+      return; // can't diff non-object against object schema; caller may flag elsewhere
+    }
+    const responseObj = response as Record<string, unknown>;
+    const keys = walkKeys(unwrapped as z.ZodObject<z.ZodRawShape>);
+
+    // Extra fields: in response, not in schema.
+    for (const key of Object.keys(responseObj)) {
+      if (!keys.has(key)) {
+        const qualified = qualifyPath(pathPrefix, key);
+        acc.extra_fields.push({ field: qualified, observed_type: typeofObserved(responseObj[key]) });
+      }
+    }
+
+    // Missing fields + strictness mismatches: walk schema keys.
+    for (const [key, spec] of keys.entries()) {
+      const qualified = qualifyPath(pathPrefix, key);
+      const hasKey = Object.prototype.hasOwnProperty.call(responseObj, key);
+      const value = hasKey ? responseObj[key] : undefined;
+
+      if (!hasKey) {
+        if (!spec.isOptional) {
+          acc.missing_fields.push({ field: qualified });
+        }
+        continue;
+      }
+      if (value === null) {
+        if (!spec.isNullable) {
+          acc.strictness_mismatches.push({
+            field: qualified,
+            observed: "null",
+            schema_strictness: "non-nullable",
+          });
+        }
+        continue;
+      }
+
+      // Recurse into nested object/array. Cast bridges the public/internal
+      // type split — see walkKeys for the same pattern.
+      const childSchema = (unwrapped as z.ZodObject<z.ZodRawShape>).shape[key] as z.ZodType | undefined;
+      if (childSchema !== undefined) {
+        walkDiff(childSchema, value, qualified, acc);
+      }
+    }
+    return;
+  }
+
+  if (unwrapped instanceof z.ZodArray) {
+    if (!Array.isArray(response) || response.length === 0) return;
+    const elementSchema = (unwrapped as unknown as { _zod: { def: { element: z.ZodType } } })._zod.def.element;
+    // Sample the first element for shape diffing — matches probe sampling
+    // semantics where we use `per_page=1`.
+    walkDiff(elementSchema, response[0], `${pathPrefix}[]`, acc);
+    return;
+  }
+
+  // Other Zod types (string, number, boolean, enum, literal, etc.) are leaf
+  // values; no nested keys to diff.
+}
+
+/**
+ * Unwrap a schema for nested-traversal purposes — descends through
+ * ZodOptional / ZodNullable / ZodPipe to reach the underlying structural
+ * schema (ZodObject, ZodArray, or leaf). Unlike {@link unwrapToObject} this
+ * does NOT enforce that the result is an object — leaves and arrays are
+ * legitimate descent targets.
+ */
+function unwrapForDescent(schema: z.ZodType): z.ZodType {
+  let inner: z.ZodType = schema;
+  for (let i = 0; i < 16; i++) {
+    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) {
+      inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
+      continue;
+    }
+    const def = (inner as unknown as { _zod?: { def?: { out?: unknown; in?: unknown } } })._zod?.def;
+    if (
+      def !== undefined &&
+      def.out instanceof z.ZodType &&
+      !(inner instanceof z.ZodObject) &&
+      !(inner instanceof z.ZodArray)
+    ) {
+      inner = def.out;
+      continue;
+    }
+    return inner;
+  }
+  return inner;
+}
+
+function qualifyPath(prefix: string, key: string): string {
+  if (prefix === "") return key;
+  if (prefix.endsWith("]")) return `${prefix}.${key}`;
+  return `${prefix}.${key}`;
+}
+
+function typeofObserved(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+/**
+ * Format a single drift issue as an actionable Zod-declaration suggestion.
+ * Output is a human-readable string — the probe never auto-applies fixes
+ * (suggest-don't-apply per R-CP-4).
+ */
+export function suggestCorrection(issue: DriftIssue): string {
+  switch (issue.kind) {
+    case "extra_field": {
+      const zodType = zodTypeForObserved(issue.observed_type);
+      return `${issue.schema_name}: add \`${issue.field}: z.${zodType}().nullable().optional()\` — runtime response includes this field (observed type: ${issue.observed_type}); permissive declaration recommended`;
+    }
+    case "missing_field": {
+      return `${issue.schema_name}.${issue.field}: runtime response omitted (field absent entirely). Relax to \`.optional()\` (preserve nullability if any) — change \`<existing>\` to \`<existing>.optional()\``;
+    }
+    case "strictness_mismatch": {
+      return `${issue.schema_name}.${issue.field}: response is null but schema is ${issue.schema_strictness}. Relax to \`.nullable()\` (or \`.nullable().optional()\` if also absent on other responses)`;
+    }
+  }
+}
+
+function zodTypeForObserved(observed: string): string {
+  switch (observed) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    case "null":
+      return "unknown";
+    case "array":
+      return "array(z.unknown())";
+    case "object":
+      return "object({})";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Resolve a `response_path` like `"organization"` or `"quotes[0]"` against
+ * the response object. Returns `undefined` if the path doesn't resolve
+ * (e.g., empty array at `[0]`).
+ */
+export function resolveResponsePath(response: unknown, path: string): unknown {
+  // Tokenize: keys separated by `.`, `[N]` for array indices
+  const tokens = tokenizePath(path);
+  let current: unknown = response;
+  for (const token of tokens) {
+    if (current === null || current === undefined) return undefined;
+    if (token.kind === "key") {
+      if (typeof current !== "object") return undefined;
+      current = (current as Record<string, unknown>)[token.value];
+    } else {
+      if (!Array.isArray(current)) return undefined;
+      current = current[token.index];
+    }
+  }
+  return current;
+}
+
+function tokenizePath(path: string): Array<{ kind: "key"; value: string } | { kind: "index"; index: number }> {
+  const tokens: Array<{ kind: "key"; value: string } | { kind: "index"; index: number }> = [];
+  const parts = path.split(".");
+  for (const part of parts) {
+    // Match "name" or "name[0]" or just "[0]"
+    const arrayMatch = /^([^[]*)((?:\[\d+\])+)$/.exec(part);
+    if (arrayMatch) {
+      const name = arrayMatch[1];
+      const indices = arrayMatch[2];
+      if (name !== undefined && name !== "") tokens.push({ kind: "key", value: name });
+      const indexMatches = indices?.matchAll(/\[(\d+)\]/g) ?? [];
+      for (const m of indexMatches) {
+        tokens.push({ kind: "index", index: Number(m[1]) });
+      }
+    } else if (part !== "") {
+      tokens.push({ kind: "key", value: part });
+    }
+  }
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// I/O orchestration (not unit-tested; manual smoke-test via real Qonto)
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const ENDPOINTS_JSON_PATH = join(REPO_ROOT, "scripts", "contract-probe.endpoints.json");
+
+async function loadEndpoints(): Promise<readonly EndpointConfig[]> {
+  let content: string;
+  try {
+    content = await readFile(ENDPOINTS_JSON_PATH, "utf-8");
+  } catch (err) {
+    throw new ProbeError(`Failed to read endpoints config at ${ENDPOINTS_JSON_PATH}: ${(err as Error).message}`, 3);
+  }
+  let parsed: EndpointsFile;
+  try {
+    parsed = JSON.parse(content) as EndpointsFile;
+  } catch (err) {
+    throw new ProbeError(`Failed to parse ${ENDPOINTS_JSON_PATH}: ${(err as Error).message}`, 3);
+  }
+  if (!Array.isArray(parsed.endpoints)) {
+    throw new ProbeError(`${ENDPOINTS_JSON_PATH} must contain an \`endpoints\` array.`, 3);
+  }
+  return parsed.endpoints;
+}
+
+/**
+ * Validate the catalog satisfies the load-bearing invariants:
+ * 1. At least one endpoint (an empty catalog passes silently with zero
+ *    coverage — visually indistinguishable from a healthy clean run).
+ * 2. Every entry is method `GET` (the probe is read-only by construction;
+ *    a non-GET entry would silently violate that contract even though the
+ *    probe code calls `client.get` regardless).
+ *
+ * Exported for direct unit testing. Throws {@link ProbeError} with exit
+ * code 3 (config error) on any violation.
+ */
+export function assertCatalogShape(endpoints: readonly EndpointConfig[]): void {
+  if (endpoints.length === 0) {
+    throw new ProbeError(`Endpoints catalog has zero entries; nothing to probe.`, 3);
+  }
+  for (const e of endpoints) {
+    if (e.method !== "GET") {
+      throw new ProbeError(
+        `Endpoint \`${e.id}\` declares method \`${e.method}\`; the contract probe is GET-only by construction.`,
+        3,
+      );
+    }
+  }
+}
+
+function resolveSchema(name: string): z.ZodObject<z.ZodRawShape> {
+  const candidate = (CoreSchemas as Record<string, unknown>)[name];
+  if (candidate === undefined) {
+    throw new ProbeError(`Schema \`${name}\` is not exported from @qontoctl/core. Check spelling.`, 3);
+  }
+  if (!(candidate instanceof z.ZodType)) {
+    throw new ProbeError(`Export \`${name}\` from @qontoctl/core is not a Zod schema (got ${typeof candidate}).`, 3);
+  }
+  const unwrapped = unwrapToObject(candidate as z.ZodType);
+  if (unwrapped === null) {
+    throw new ProbeError(
+      `Schema \`${name}\` does not unwrap to a z.ZodObject. The probe only supports object-shaped schemas (got ${(candidate as z.ZodType).constructor?.name ?? typeof candidate}).`,
+      3,
+    );
+  }
+  return unwrapped;
+}
+
+/**
+ * Unwrap a Zod schema to its underlying ZodObject through ZodOptional /
+ * ZodNullable / ZodPipe (e.g., `z.preprocess(fn, object)` returns ZodPipe
+ * where `out` is the target object). Returns `null` when the schema cannot
+ * be reduced to an object.
+ *
+ * Exported for use by the diff/walk pipeline AND by tests verifying schema
+ * compatibility before invoking the probe against a live endpoint.
+ */
+export function unwrapToObject(schema: z.ZodType): z.ZodObject<z.ZodRawShape> | null {
+  let inner: z.ZodType = schema;
+  // Iteratively unwrap composite wrappers. Cap iterations to avoid pathological
+  // loops on malformed schemas (depth > 16 is implausible in practice).
+  for (let i = 0; i < 16; i++) {
+    if (inner instanceof z.ZodObject) {
+      return inner as z.ZodObject<z.ZodRawShape>;
+    }
+    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) {
+      inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
+      continue;
+    }
+    // ZodPipe (e.g., from z.preprocess(fn, target)) — the target is `.out`
+    const def = (inner as unknown as { _zod?: { def?: { out?: unknown; in?: unknown } } })._zod?.def;
+    if (def !== undefined && def.out instanceof z.ZodType) {
+      inner = def.out;
+      continue;
+    }
+    if (def !== undefined && def.in instanceof z.ZodType) {
+      // Some pipe forms have only `in` — try unwrapping that too as a fallback
+      inner = def.in;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+async function probeEndpoint(client: HttpClient, endpoint: EndpointConfig): Promise<SchemaDriftReport> {
+  const capturedAt = new Date().toISOString();
+  const base = {
+    endpoint_id: endpoint.id,
+    method: endpoint.method,
+    path: endpoint.path,
+    schema: endpoint.schema,
+    captured_at: capturedAt,
+  } satisfies Omit<
+    SchemaDriftReport,
+    "status" | "extra_fields" | "missing_fields" | "strictness_mismatches" | "suggested_fixes"
+  >;
+
+  let schema: z.ZodObject<z.ZodRawShape>;
+  try {
+    schema = resolveSchema(endpoint.schema);
+  } catch (err) {
+    return {
+      ...base,
+      status: "error",
+      extra_fields: [],
+      missing_fields: [],
+      strictness_mismatches: [],
+      suggested_fixes: [],
+      error: (err as Error).message,
+    };
+  }
+
+  let response: unknown;
+  try {
+    response = await client.get(endpoint.path, endpoint.query);
+  } catch (err) {
+    // Rate-limit → partial report (per design A3 mitigation)
+    if (err instanceof QontoRateLimitError) {
+      return {
+        ...base,
+        status: "skipped",
+        extra_fields: [],
+        missing_fields: [],
+        strictness_mismatches: [],
+        suggested_fixes: [],
+        error: `Rate-limited after retries: ${err.message}`,
+      };
+    }
+    // OAuth refresh failure → bubble up to exit 2
+    if (err instanceof OAuthRefreshError) {
+      throw new ProbeError(
+        `OAuth refresh failed during probe of ${endpoint.path}: ${err.message}. Re-authenticate via \`qontoctl oauth login\` and retry.`,
+        2,
+      );
+    }
+    // 4xx/5xx Qonto errors → record as endpoint-level error, continue
+    if (err instanceof QontoApiError) {
+      return {
+        ...base,
+        status: "error",
+        extra_fields: [],
+        missing_fields: [],
+        strictness_mismatches: [],
+        suggested_fixes: [],
+        error: `Qonto API error: ${err.message}`,
+      };
+    }
+    // Anything else (network, DNS, etc.) → endpoint-level error
+    return {
+      ...base,
+      status: "error",
+      extra_fields: [],
+      missing_fields: [],
+      strictness_mismatches: [],
+      suggested_fixes: [],
+      error: `Network error: ${(err as Error).message}`,
+    };
+  }
+
+  const sample = resolveResponsePath(response, endpoint.response_path);
+  if (sample === undefined || sample === null) {
+    return {
+      ...base,
+      status: "skipped",
+      extra_fields: [],
+      missing_fields: [],
+      strictness_mismatches: [],
+      suggested_fixes: [],
+      error: `response_path \`${endpoint.response_path}\` resolved to undefined/null (empty list?); skipping diff`,
+    };
+  }
+
+  const diff = diffSchema(schema, sample);
+  const totalDrift = diff.extra_fields.length + diff.missing_fields.length + diff.strictness_mismatches.length;
+
+  const suggested_fixes: string[] = [];
+  for (const f of diff.extra_fields) {
+    suggested_fixes.push(suggestCorrection({ ...f, kind: "extra_field", schema_name: endpoint.schema }));
+  }
+  for (const f of diff.missing_fields) {
+    suggested_fixes.push(suggestCorrection({ ...f, kind: "missing_field", schema_name: endpoint.schema }));
+  }
+  for (const f of diff.strictness_mismatches) {
+    suggested_fixes.push(suggestCorrection({ ...f, kind: "strictness_mismatch", schema_name: endpoint.schema }));
+  }
+
+  return {
+    ...base,
+    status: totalDrift === 0 ? "ok" : "drift",
+    extra_fields: diff.extra_fields,
+    missing_fields: diff.missing_fields,
+    strictness_mismatches: diff.strictness_mismatches,
+    suggested_fixes,
+  };
+}
+
+async function writeReport(reports: readonly SchemaDriftReport[]): Promise<string> {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const outDir = join(REPO_ROOT, ".tmp", "contract-probe");
+  const outPath = join(outDir, `${ts}.json`);
+  try {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(outPath, JSON.stringify(reports, null, 2) + "\n", "utf-8");
+  } catch (err) {
+    throw new ProbeError(`Failed to write report to ${outPath}: ${(err as Error).message}`, 3);
+  }
+  return outPath;
+}
+
+function printSummary(reports: readonly SchemaDriftReport[], reportPath: string): void {
+  console.log("\nContract Probe — Drift Summary\n");
+  console.log("Endpoint                                  Status   Drift  Notes");
+  console.log("----------------------------------------  -------  -----  ------------------------------------");
+  for (const r of reports) {
+    const idCol = r.endpoint_id.padEnd(40).slice(0, 40);
+    const statusCol = r.status.padEnd(7);
+    const driftCount = r.extra_fields.length + r.missing_fields.length + r.strictness_mismatches.length;
+    const driftCol = String(driftCount).padStart(5);
+    const note = r.error ?? "";
+    console.log(`  ${idCol}  ${statusCol}  ${driftCol}  ${note}`);
+  }
+  const okCount = reports.filter((r) => r.status === "ok").length;
+  const driftCount = reports.filter((r) => r.status === "drift").length;
+  const skippedCount = reports.filter((r) => r.status === "skipped").length;
+  const errorCount = reports.filter((r) => r.status === "error").length;
+  console.log(
+    `\n${reports.length} probed: ${okCount} ok, ${driftCount} drift, ${skippedCount} skipped, ${errorCount} errors`,
+  );
+  console.log(`Report: ${reportPath}\n`);
+
+  // Print suggested fixes (compact, one per line, grouped per endpoint)
+  const withDrift = reports.filter((r) => r.suggested_fixes.length > 0);
+  if (withDrift.length > 0) {
+    console.log("Suggested fixes:");
+    for (const r of withDrift) {
+      console.log(`\n[${r.endpoint_id}] (${r.suggested_fixes.length} suggestion(s)):`);
+      for (const fix of r.suggested_fixes) {
+        console.log(`  - ${fix}`);
+      }
+    }
+    console.log("");
+  }
+}
+
+async function main(): Promise<void> {
+  let endpoints: readonly EndpointConfig[];
+  let config: Awaited<ReturnType<typeof resolveConfig>>;
+
+  try {
+    endpoints = await loadEndpoints();
+  } catch (err) {
+    if (err instanceof ProbeError) throw err;
+    throw new ProbeError(`Failed to load endpoints: ${(err as Error).message}`, 3);
+  }
+
+  // Catalog-shape invariants (non-empty, GET-only). Pure validator; unit-tested.
+  assertCatalogShape(endpoints);
+
+  // Validate every schema reference at startup (fail-fast per typescript-architect rec).
+  for (const e of endpoints) {
+    resolveSchema(e.schema);
+  }
+
+  try {
+    config = await resolveConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      const exitCode = err.code === "NO_CREDS" ? 2 : 3;
+      throw new ProbeError(`Configuration error: ${err.message}`, exitCode);
+    }
+    throw new ProbeError(`Failed to resolve config: ${(err as Error).message}`, 3);
+  }
+
+  if (config.config.oauth === undefined) {
+    throw new ProbeError(
+      "Contract probe requires OAuth credentials (api-key is not sufficient — the probe needs full API access). " +
+        "Configure OAuth in .qontoctl.yaml or via QONTOCTL_OAUTH_* env vars and retry.",
+      2,
+    );
+  }
+
+  const stagingToken = config.config.oauth.stagingToken;
+  const tokenUrl = stagingToken !== undefined ? OAUTH_TOKEN_SANDBOX_URL : OAUTH_TOKEN_URL;
+  const authorization = createOAuthAuthorization({
+    oauth: config.config.oauth,
+    tokenUrl,
+    path: config.path,
+  });
+
+  const client = new HttpClient({
+    baseUrl: config.endpoint,
+    authorization,
+    stagingToken,
+    scaMethod: resolveScaMethod(config.config),
+  });
+
+  const reports: SchemaDriftReport[] = [];
+  for (const endpoint of endpoints) {
+    process.stderr.write(`probing ${endpoint.id} (${endpoint.path}) ... `);
+    const report = await probeEndpoint(client, endpoint);
+    const driftCount = report.extra_fields.length + report.missing_fields.length + report.strictness_mismatches.length;
+    process.stderr.write(`${report.status} (${driftCount} drift)\n`);
+    reports.push(report);
+  }
+
+  const reportPath = await writeReport(reports);
+  printSummary(reports, reportPath);
+
+  // Determine exit code: 1 if any drift detected (scriptable for release pipeline).
+  const hasDrift = reports.some((r) => r.status === "drift");
+  if (hasDrift) {
+    throw new ProbeError("Schema drift detected. Review report and update Zod declarations.", 1);
+  }
+}
+
+/**
+ * Detect whether this module is being executed directly (via `tsx`) versus
+ * imported by another module (e.g., the vitest test runner). When imported,
+ * top-level `main()` MUST NOT run — otherwise the test process triggers a
+ * real Qonto probe on every test invocation and `process.exit()` short-
+ * circuits the test runner.
+ */
+function isDirectInvocation(): boolean {
+  if (process.argv[1] === undefined) return false;
+  try {
+    return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectInvocation()) {
+  // Top-level orchestration: single process.exit() at the bottom.
+  main()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err: unknown) => {
+      if (err instanceof ProbeError) {
+        if (err.exitCode !== 0) {
+          process.stderr.write(`\nERROR: ${err.message}\n`);
+        }
+        process.exit(err.exitCode);
+      }
+      process.stderr.write(`\nUNEXPECTED ERROR: ${(err as Error).message}\n`);
+      if (err instanceof Error && err.stack !== undefined) {
+        process.stderr.write(`${err.stack}\n`);
+      }
+      process.exit(3);
+    });
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["contract-probe.ts", "contract-probe.test.ts"]
+}


### PR DESCRIPTION
## Summary

Implements GitHub issue #608 (Wave C of epic #603 — E2E test reliability). Adds `pnpm contract-probe`: a local-only Zod schema-vs-Qonto-API drift detector that probes 21 read-only GET endpoints with OAuth credentials, diffs each live response against the matching schema exported from `@qontoctl/core`, and emits a `SchemaDriftReport[]` to `.tmp/contract-probe/{ISO8601}.json` plus a console summary table with suggested corrective Zod declarations.

The probe converts the prior reactive loop (every schema-strictness incident — #496, #514, #544, #604, #601 — was found by a user hitting a live response the schema rejected) into a proactive pre-release check. Discovered drift becomes a one-line schema relaxation in the same release rather than a hotfix the week after.

- **Read-only by construction**: `scripts/contract-probe.endpoints.json` is GET-only and `assertCatalogShape()` enforces the invariant at startup. Catalog non-emptiness is also enforced so a future PR that empties the file cannot ship a green probe with zero coverage.
- **Suggest-only by design**: never edits schema files. Surfaces fixes (e.g., `Relax \`X.field\`: response omitted entirely — change to \`.nullable().optional()\``) for maintainer review.
- **Typed exit codes** make the probe scriptable for the release pipeline: `0` clean / `1` drift / `2` OAuth error / `3` config error.
- **Local-only per design** (`docs/designs/e2e-test-reliability.md` §8.1, Q1 resolved): CI is api-key only and cannot cleanly host OAuth state. Documented as a pre-release gate in `docs/release-runbook.md` § 1.6 with quarterly cadence.

## Implementation

- `scripts/contract-probe.ts` (~640 LOC) — pure-function exports (`walkKeys`, `diffSchema`, `suggestCorrection`, `unwrapToObject`, `unwrapForDescent`, `assertCatalogShape`, `ProbeError`); I/O orchestration in `main()` with single `process.exit()` and `isDirectInvocation()` guard so tests can import without triggering a real probe.
- `scripts/contract-probe.endpoints.json` — 21 GET endpoints covering every shipped `*Schema` export from `@qontoctl/core` (organization, labels, memberships, teams, beneficiaries, cards, clients, quotes, client_invoices, credit_notes, transactions, products, payment_links, recurring_transfers, supplier_invoices, insurance_contracts, webhook_subscriptions, transfers, statements, intl beneficiaries, einvoicing settings).
- `scripts/contract-probe.test.ts` — 25 unit tests covering `walkKeys` / `diffSchema` / `suggestCorrection` / `ProbeError` / `assertCatalogShape` edge cases.
- `scripts/tsconfig.json` — wires `scripts/` into the typecheck graph at workspace strictness. Root `pnpm typecheck` now also runs `tsc -p scripts/tsconfig.json`.
- `package.json` — adds `contract-probe` and `contract-probe-test` scripts; adds `@types/node` (catalog) + `tsx` (catalog) + `@qontoctl/core` (workspace) + `zod` (catalog) devDeps.
- `pnpm-workspace.yaml` — adds `tsx` to catalog.
- `CHANGELOG.md` — Unreleased entry under Added.
- `docs/release-runbook.md` — new § 1.6 with exit-code table + quarterly cadence + expansion guidance.

## Test plan

- [x] `pnpm format:check` — green
- [x] `pnpm typecheck` (turbo + scripts/) — green
- [x] `pnpm lint` — green
- [x] `pnpm test` (workspace unit suite) — green (10/10 turbo tasks)
- [x] `pnpm contract-probe-test` — 25/25 passing
- [x] `pnpm test:e2e` — partial: 46 suites / 242 tests pass (every api-key-compatible suite); 26 suites / 74 tests fail with `OAuthRefreshError: invalid_grant` against the sandbox. The OAuth refresh token in the local config is expired — **pre-existing environmental issue, NOT a regression in this PR**. No failed test imports or exercises `scripts/contract-probe.ts`; the probe is a script outside any workspace package and not referenced by any E2E suite. The CI gate is api-key only per `CLAUDE.md § E2E in CI` and will run the suites that passed locally.
- [x] Live `pnpm contract-probe` smoke test — exits `2` with the documented OAuth-expired error message (validates AC#4 exit-2 path end-to-end against the same expired refresh token).
- [ ] Maintainer to refresh OAuth credentials (`qontoctl auth login`) post-merge to restore full local E2E coverage; orthogonal to this PR.

## Acceptance criteria (#608)

- [x] `pnpm contract-probe` runs locally with OAuth creds, produces a drift report
- [x] Report lists `extra_fields` / `missing_fields` / `strictness_mismatches` per endpoint + suggested fix
- [x] Read-only (no write endpoints in `endpoints.json`); no schema-file mutation
- [x] Rate-limit → partial report (not crash); expired creds → clear error (exit 2)
- [x] `release-runbook.md` updated (§ 1.6 with quarterly cadence)