### PR TITLE
(test) E2E order-independence detection (invariant + lint + pre-release diff) (#607)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: pnpm publish-check
       - run: pnpm coverage-drift-check
       - run: pnpm silent-skip-check
+      - run: pnpm eslint-rules-test
       - run: pnpm test ${{ matrix.os == 'ubuntu-latest' && '-- -- --coverage' || '' }}
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -315,3 +315,103 @@ shared helpers used across E2E suites:
 Tests that adopt the helpers should remove their inlined copies of the
 same boilerplate to keep the codebase DRY — the helpers are the single
 source of truth for "how E2E tests talk to the CLI / MCP server".
+
+## Order-independence invariant
+
+**The invariant.** No test may depend on another test's side effects
+except within an explicit CRUD-lifecycle `describe` block using the
+[`LifecycleSkipCarrier`](../packages/e2e/src/helpers.ts) pattern. Across
+files and across sibling describes, every test must run from a clean
+starting state — its outcome must be the same whether the suite runs in
+declaration order, reverse order, or any random permutation.
+
+**Why.** The E2E suite shares a single Qonto sandbox org across all
+tests in a run. Hidden cross-test dependencies (a `let` at file scope
+populated by one test and read by another, a sandbox-state mutation
+that primes a later test, a singleton OAuth token leaked between
+suites) make the suite a slot machine: outcomes depend on which test
+ran first, which is implicit in vitest's declaration order and the
+filesystem walk that `vitest.e2e.config.ts` produces. When the order
+matters and nobody designed it to, a test failure may flip to pass on
+re-run — the silent flake that wasted ~2 weeks chasing #496 (epic
+[#603](https://github.com/alexey-pelykh/qontoctl/issues/603) §1.1).
+
+**The lifecycle-`describe` carve-out.** Tests that CRUD a resource
+inherently depend on each other (`create` populates `createdId`,
+`update` reads it). The legitimate pattern is to declare the shared
+state inside the `describe` block that owns the lifecycle:
+
+```ts
+describe.skipIf(!hasApiKeyCredentials())("client commands (e2e)", () => {
+    describe("client CRUD lifecycle", () => {
+        const lifecycleSkip: LifecycleSkipCarrier = { reason: undefined };
+        let createdClientId: string | undefined;
+
+        it("creates a client", async (ctx) => {
+            /* populates createdClientId */
+        });
+        it("shows the created client", async (ctx) => {
+            skipIfUpstreamSkipped(lifecycleSkip, ctx);
+            const id = assertLifecycleState(createdClientId, "createdClientId");
+            /* ... */
+        });
+        // updates, deletes follow the same pattern
+    });
+});
+```
+
+The shared `let` is scoped to the `describe` — vitest's
+`fileParallelism: false` (set in
+[`vitest.e2e.config.ts`](../vitest.e2e.config.ts)) guarantees the
+chain runs in declaration order within a single worker, and the
+`LifecycleSkipCarrier` propagates skips visibly without leaking state
+across sibling describes or files.
+
+**The forbidden pattern.**
+
+```ts
+// ❌ Module-scope `let` shared across `it()` blocks — order-dependent across the suite.
+let createdId: string | undefined;
+
+describe("foo", () => {
+    it("creates", () => {
+        createdId = "...";
+    });
+});
+
+describe("bar", () => {
+    it("uses", () => {
+        /* reads createdId — depends on "foo" running first */
+    });
+});
+```
+
+This is enforced two ways:
+
+1. **Lint guard** (authoring time):
+   [`eslint-rules/no-module-scope-mutable-state-in-e2e.js`](../eslint-rules/no-module-scope-mutable-state-in-e2e.js)
+   flags any `let` or `var` declared at the top level of a
+   `*.e2e.test.ts` file. Runs as part of `pnpm lint`.
+2. **Pre-release diff** (run time): `pnpm order-independence-check`
+   (script at
+   [`scripts/check-order-independence.sh`](../scripts/check-order-independence.sh))
+   runs the E2E suite twice — default file order and shuffled
+   (`--sequence.shuffle.files`) — and diffs the pass/fail/skip
+   classification of every test. A test whose outcome differs across
+   runs is flagged for state-isolation review (epic #603 R-OI-2).
+   Skip-reason text may differ legitimately; pass/fail/skip
+   _membership_ may not.
+
+When the pre-release diff flags a test, the remediation is one of:
+
+- Move the cross-test state into a CRUD-lifecycle `describe` (as
+  above), or
+- Add a `beforeEach`/`afterEach` to reset the state, or
+- If the dependency is on sandbox state (not in-process state), document
+  the precondition in
+  [`docs/qonto-sandbox-preconditions.md`](./qonto-sandbox-preconditions.md)
+  (epic #603 §7) and either satisfy the precondition or
+  `ctx.skip("sandbox-precondition: ...")`.
+
+See [`docs/designs/e2e-test-reliability.md`](./designs/e2e-test-reliability.md)
+§8.3 for the full design rationale.

--- a/eslint-rules/no-module-scope-mutable-state-in-e2e.js
+++ b/eslint-rules/no-module-scope-mutable-state-in-e2e.js
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Local ESLint rule enforcing the order-independence invariant in E2E
+ * tests (epic #603 §8.3, R-OI-2).
+ *
+ * Flags `let` and `var` declarations at the top level (Program scope) of
+ * `*.e2e.test.ts` files. Module-scope mutable bindings introduce
+ * test-order dependence: vitest loads each test file once per worker, so
+ * a binding populated by one `it()` callback is visible to every
+ * subsequent `it()` in the file. When the order matters and nobody
+ * designed it to, a test failure may flip to pass on re-run — the silent
+ * flake that hid #496 for ~2 weeks.
+ *
+ * The lifecycle-`describe` pattern keeps shared state local to a single
+ * `describe` whose `it()` blocks are intentionally ordered (see
+ * `docs/e2e-testing.md` § Order-independence invariant).
+ *
+ * Module-scope `const` is fine (immutable, cannot create order
+ * dependence). Module-scope `function` declarations are fine
+ * (pure-by-convention; mutation through them would still need a
+ * top-level binding to mutate, which this rule catches).
+ *
+ * The rule trusts ESLint's `files:` glob to scope its activation —
+ * applying it to non-E2E `.ts` files would be over-broad (production
+ * code uses module-scope `let` legitimately, e.g. lazy singletons).
+ *
+ * @type {import("eslint").Rule.RuleModule}
+ */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow module-scope mutable bindings (`let`, `var`) in E2E test files",
+    },
+    schema: [],
+    messages: {
+      moduleScopeMutable:
+        "Module-scope `{{kind}} {{name}}` in an E2E test file introduces " +
+        "test-order dependence (epic #603 R-OI-2). Move the binding inside " +
+        "the relevant `describe(...)` block (CRUD-lifecycle pattern with " +
+        "LifecycleSkipCarrier — see docs/e2e-testing.md § Order-independence " +
+        "invariant) or change to `const`.",
+    },
+  },
+  create(context) {
+    return {
+      Program(node) {
+        for (const stmt of node.body) {
+          if (stmt.type !== "VariableDeclaration") continue;
+          if (stmt.kind !== "let" && stmt.kind !== "var") continue;
+          for (const decl of stmt.declarations) {
+            const name = decl.id.type === "Identifier" ? decl.id.name : "<destructured>";
+            context.report({
+              node: decl,
+              messageId: "moduleScopeMutable",
+              data: { kind: stmt.kind, name },
+            });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/no-module-scope-mutable-state-in-e2e.test.js
+++ b/eslint-rules/no-module-scope-mutable-state-in-e2e.test.js
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * RuleTester unit tests for the order-independence ESLint rule.
+ *
+ * Runs under vitest via `pnpm eslint-rules-test` — ESLint's RuleTester
+ * delegates to a `describe`/`it` pair set on the class itself, so we
+ * wire vitest's into the static slots before invoking `.run()`.
+ *
+ * Uses the TypeScript-ESLint parser so the rule sees AST nodes
+ * identically to how it sees them in production (`*.e2e.test.ts` files).
+ */
+
+import { RuleTester } from "eslint";
+import tseslint from "typescript-eslint";
+import { afterAll, describe, it } from "vitest";
+import rule from "./no-module-scope-mutable-state-in-e2e.js";
+
+// `typescript-eslint` re-exports `@typescript-eslint/parser` as `.parser`.
+// We use it to ensure the rule sees AST nodes identically to how it sees
+// them when ESLint runs against `*.e2e.test.ts` files in production.
+const tsParser = tseslint.parser;
+
+// ESLint RuleTester delegates to mocha-style globals by default. Vitest
+// exposes the same functions but they are not global — wire them onto
+// the class so `.run()` calls vitest under the hood.
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.afterAll = afterAll;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("no-module-scope-mutable-state-in-e2e", rule, {
+  valid: [
+    // `const` at module scope is fine — immutable.
+    { code: `const FOO = "bar";` },
+
+    // `let` inside `describe` is the legitimate lifecycle pattern.
+    {
+      code: `
+        import { describe, it } from "vitest";
+        describe("client CRUD lifecycle", () => {
+          let createdClientId: string | undefined;
+          it("creates", () => { createdClientId = "x"; });
+          it("reads", () => { expect(createdClientId).toBeDefined(); });
+        });
+      `,
+    },
+
+    // `let` inside `it` is fine — fully local to the test.
+    {
+      code: `
+        import { it } from "vitest";
+        it("foo", () => { let temp = 1; expect(temp).toBe(1); });
+      `,
+    },
+
+    // `let` inside a nested function expression is fine.
+    {
+      code: `
+        const make = () => { let counter = 0; return () => ++counter; };
+      `,
+    },
+
+    // `const` arrow functions and function declarations at module scope are fine.
+    {
+      code: `
+        const helper = () => 42;
+        function other() { return 7; }
+      `,
+    },
+
+    // `let` inside `beforeAll`/`beforeEach` callback is fine.
+    {
+      code: `
+        import { describe, beforeEach } from "vitest";
+        describe("foo", () => {
+          beforeEach(() => { let setupValue = 1; });
+        });
+      `,
+    },
+  ],
+  invalid: [
+    // Bare module-scope `let` — the canonical bad pattern.
+    {
+      code: `let createdId: string | undefined;`,
+      errors: [
+        {
+          messageId: "moduleScopeMutable",
+          data: { kind: "let", name: "createdId" },
+        },
+      ],
+    },
+
+    // Module-scope `let` with assignment.
+    {
+      code: `let counter = 0;`,
+      errors: [{ messageId: "moduleScopeMutable", data: { kind: "let", name: "counter" } }],
+    },
+
+    // Module-scope `var` (legacy, but same hazard).
+    {
+      code: `var legacyState;`,
+      errors: [{ messageId: "moduleScopeMutable", data: { kind: "var", name: "legacyState" } }],
+    },
+
+    // Multiple declarations in one statement → one error per declarator.
+    {
+      code: `let a, b, c;`,
+      errors: [
+        { messageId: "moduleScopeMutable", data: { kind: "let", name: "a" } },
+        { messageId: "moduleScopeMutable", data: { kind: "let", name: "b" } },
+        { messageId: "moduleScopeMutable", data: { kind: "let", name: "c" } },
+      ],
+    },
+
+    // Destructured module-scope `let` — flagged as `<destructured>`.
+    {
+      code: `let { x, y } = { x: 1, y: 2 };`,
+      errors: [{ messageId: "moduleScopeMutable", data: { kind: "let", name: "<destructured>" } }],
+    },
+
+    // Module-scope `let` adjacent to `describe` (the smoking-gun shape).
+    {
+      code: `
+        import { describe, it } from "vitest";
+        let sharedId: string | undefined;
+        describe("foo", () => { it("creates", () => { sharedId = "x"; }); });
+        describe("bar", () => { it("reads", () => { expect(sharedId).toBe("x"); }); });
+      `,
+      errors: [{ messageId: "moduleScopeMutable", data: { kind: "let", name: "sharedId" } }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,15 @@ import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 import headerPlugin from "@tony.ganchev/eslint-plugin-header";
+import noModuleScopeMutableStateInE2e from "./eslint-rules/no-module-scope-mutable-state-in-e2e.js";
+
+// Local rules bundled into one plugin namespace for clarity.
+// New rules under `eslint-rules/` are wired here.
+const qontoctlPlugin = {
+  rules: {
+    "no-module-scope-mutable-state-in-e2e": noModuleScopeMutableStateInE2e,
+  },
+};
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -27,6 +36,16 @@ export default tseslint.config(
   {
     files: ["**/*.test.ts", "**/*.e2e.test.ts"],
     ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    // Order-independence invariant enforcement — see
+    // `docs/e2e-testing.md` § Order-independence invariant and
+    // `docs/designs/e2e-test-reliability.md` §8.3.
+    files: ["**/*.e2e.test.ts"],
+    plugins: { qontoctl: qontoctlPlugin },
+    rules: {
+      "qontoctl/no-module-scope-mutable-state-in-e2e": "error",
+    },
   },
   {
     plugins: {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "publish-check": "node scripts/check-publish-manifest.js",
     "coverage-drift-check": "node scripts/check-coverage-drift.js",
     "silent-skip-check": "node scripts/check-no-silent-skip.js",
+    "eslint-rules-test": "vitest run eslint-rules/",
+    "order-independence-check": "bash scripts/check-order-independence.sh",
     "contract-probe": "tsx scripts/contract-probe.ts",
     "contract-probe-test": "vitest run scripts/contract-probe.test.ts",
     "dev": "turbo run dev"

--- a/scripts/check-order-independence.sh
+++ b/scripts/check-order-independence.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright (C) 2026 Oleksii PELYKH
+
+# Pre-release order-independence detector for the E2E suite (epic #603
+# §8.3, R-OI-1).
+#
+# Runs `pnpm test:e2e` twice — once in default file order, once with
+# `--sequence.shuffle.files` enabled — captures the vitest JSON reporter
+# outcomes, and diffs the pass/fail/skip classification per test (via
+# scripts/diff-vitest-runs.js). A test whose outcome changes across runs
+# indicates cross-test state contamination (in-process or sandbox-level)
+# and is flagged for state-isolation review (R-OI-2).
+#
+# Skip-reason text may legitimately differ across runs (a CRUD-chain
+# upstream-skipped cascade flips to feature-not-supported when the
+# upstream becomes the first test, etc.); the pass/fail/skip _membership_
+# may not.
+#
+# Usage:
+#   pnpm order-independence-check                   # random seed, both runs
+#   VITEST_SHUFFLE_SEED=42 pnpm order-independence-check   # reproducible seed
+#   KEEP_REPORTS=1 pnpm order-independence-check    # do not delete .tmp/order-check/*.json
+#
+# Exit codes:
+#   0 — no divergence; suite is order-independent
+#   1 — divergence detected (divergent tests listed on stderr)
+#   2 — usage error or one of the runs could not produce a report
+#
+# Prerequisites:
+#   - Whatever credentials the suite needs (api-key for production, OAuth
+#     for sandbox) must be configured per docs/e2e-testing.md.
+#   - The suite is sequential (`fileParallelism: false` in
+#     vitest.e2e.config.ts), so the two runs are wall-clock back-to-back;
+#     budget ~2x the normal E2E duration.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="${REPO_ROOT}/.tmp/order-check"
+RUN1="${OUT_DIR}/run-default.json"
+RUN2="${OUT_DIR}/run-shuffled.json"
+SEED="${VITEST_SHUFFLE_SEED:-${RANDOM}}"
+
+mkdir -p "${OUT_DIR}"
+# Remove any prior report so a vitest invocation that never reaches the
+# reporter stage (build error, signal) does not leave stale data for the
+# diff helper.
+rm -f "${RUN1}" "${RUN2}"
+
+echo "==> [1/3] Running E2E suite in default file order"
+echo "          → ${RUN1}"
+# `|| true` because tests legitimately fail/skip; the diff helper reads
+# the report regardless of vitest's exit status. The reporter writes the
+# report on test completion, not on success.
+(cd "${REPO_ROOT}" && pnpm test:e2e -- --reporter=json --outputFile="${RUN1}") || true
+
+if [[ ! -s "${RUN1}" ]]; then
+  echo "Error: run 1 did not produce a JSON report at ${RUN1}." >&2
+  echo "       Inspect the output above for build/setup failures." >&2
+  exit 2
+fi
+
+echo
+echo "==> [2/3] Running E2E suite shuffled (seed=${SEED})"
+echo "          → ${RUN2}"
+(cd "${REPO_ROOT}" && pnpm test:e2e -- \
+  --reporter=json \
+  --outputFile="${RUN2}" \
+  --sequence.shuffle.files \
+  --sequence.seed="${SEED}") || true
+
+if [[ ! -s "${RUN2}" ]]; then
+  echo "Error: run 2 did not produce a JSON report at ${RUN2}." >&2
+  exit 2
+fi
+
+echo
+echo "==> [3/3] Diffing outcomes (seed=${SEED})"
+echo
+set +e
+node "${REPO_ROOT}/scripts/diff-vitest-runs.js" "${RUN1}" "${RUN2}"
+diff_exit=$?
+set -e
+
+if [[ "${KEEP_REPORTS:-0}" != "1" ]]; then
+  rm -f "${RUN1}" "${RUN2}"
+fi
+
+if [[ ${diff_exit} -ne 0 ]]; then
+  echo
+  echo "Seed used for shuffled run: ${SEED}"
+  echo "Re-run with VITEST_SHUFFLE_SEED=${SEED} to reproduce the same shuffle."
+  echo "Pass KEEP_REPORTS=1 to retain the JSON reports for inspection."
+fi
+
+exit ${diff_exit}

--- a/scripts/diff-vitest-runs.js
+++ b/scripts/diff-vitest-runs.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Diff two vitest JSON-reporter outputs to detect order-dependent tests
+ * (epic #603 §8.3, R-OI-2).
+ *
+ * Reads two reports (typically a default-order run and a
+ * `--sequence.shuffle.files` run) and reports any test whose pass/fail/skip
+ * classification differs across runs. Skip-reason text is allowed to differ
+ * legitimately (a test may skip with `feature-not-supported: X` in one run
+ * and `upstream-skipped: feature-not-supported: X` in another); the
+ * pass/fail/skip _membership_ may not change.
+ *
+ * Usage:
+ *   node scripts/diff-vitest-runs.js <run1.json> <run2.json>
+ *
+ * Exit codes:
+ *   0 — no divergence (every test classified identically across both runs)
+ *   1 — divergence found (at least one test changed pass/fail/skip)
+ *   2 — usage error (missing args, missing files, malformed JSON)
+ *
+ * See `docs/e2e-testing.md` § Order-independence invariant for remediation
+ * guidance.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const [, , run1Path, run2Path] = process.argv;
+if (run1Path === undefined || run2Path === undefined) {
+  process.stderr.write("Usage: node scripts/diff-vitest-runs.js <run1.json> <run2.json>\n");
+  process.exit(2);
+}
+for (const p of [run1Path, run2Path]) {
+  if (!existsSync(p)) {
+    process.stderr.write(`Error: ${p} does not exist\n`);
+    process.exit(2);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Vitest JSON reporter writes one object containing a `testResults` array.
+ * Each entry is a file with an `assertionResults` array; each assertion has
+ * a `fullName` and a `status` ("passed" / "failed" / "skipped" / "pending" /
+ * "todo"). We collapse skipped/pending/todo into the single bucket "skipped"
+ * because vitest's `ctx.skip()` and `it.skip()` and `it.todo()` are
+ * semantically equivalent for the order-independence check.
+ */
+function loadOutcomes(reportPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(reportPath, "utf-8"));
+  } catch (e) {
+    process.stderr.write(`Error: failed to parse ${reportPath} as JSON: ${e.message}\n`);
+    process.exit(2);
+  }
+  if (parsed === null || typeof parsed !== "object" || !Array.isArray(parsed.testResults)) {
+    process.stderr.write(`Error: ${reportPath} is not a vitest JSON report (missing testResults[])\n`);
+    process.exit(2);
+  }
+
+  const outcomes = new Map();
+  for (const file of parsed.testResults) {
+    if (file === null || typeof file !== "object" || !Array.isArray(file.assertionResults)) continue;
+    for (const assertion of file.assertionResults) {
+      if (assertion === null || typeof assertion !== "object") continue;
+      // Key by file + fullName because the same describe/it text can appear
+      // across files (e.g. multiple "creates a client" entries across
+      // different domain suites).
+      const key = `${String(file.name)}::${String(assertion.fullName)}`;
+      const status = normalizeStatus(String(assertion.status));
+      outcomes.set(key, status);
+    }
+  }
+  return outcomes;
+}
+
+/**
+ * Collapse vitest's status taxonomy to the three buckets the
+ * order-independence invariant cares about: `passed`, `failed`, `skipped`.
+ * `pending` and `todo` map to `skipped` (the test did not execute and did
+ * not fail).
+ */
+function normalizeStatus(s) {
+  if (s === "passed" || s === "failed") return s;
+  return "skipped";
+}
+
+// ---------------------------------------------------------------------------
+// Diff
+// ---------------------------------------------------------------------------
+
+const run1 = loadOutcomes(resolve(run1Path));
+const run2 = loadOutcomes(resolve(run2Path));
+
+if (run1.size === 0 && run2.size === 0) {
+  process.stderr.write(
+    "Error: both reports contain zero test outcomes — vitest probably skipped both runs entirely\n" +
+      "       (likely cause: credentials not configured; nothing to compare).\n",
+  );
+  process.exit(2);
+}
+
+const allKeys = new Set([...run1.keys(), ...run2.keys()]);
+const divergent = [];
+for (const key of allKeys) {
+  const s1 = run1.get(key);
+  const s2 = run2.get(key);
+  if (s1 !== s2) {
+    divergent.push({
+      key,
+      run1: s1 === undefined ? "<absent>" : s1,
+      run2: s2 === undefined ? "<absent>" : s2,
+    });
+  }
+}
+
+// Stable ordering: alphabetical by key (so CI runs produce diff-friendly output).
+divergent.sort((a, b) => a.key.localeCompare(b.key));
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const totalKeys = allKeys.size;
+process.stdout.write(`Compared ${String(totalKeys)} test(s) across two runs.\n`);
+
+if (divergent.length === 0) {
+  process.stdout.write(`✓ Order-independent: all tests classified identically.\n`);
+  process.exit(0);
+}
+
+process.stderr.write(`\n✗ Order-independence FAILED: ${String(divergent.length)} test(s) diverged.\n\n`);
+for (const d of divergent) {
+  process.stderr.write(`  ${d.key}\n`);
+  process.stderr.write(`    run 1 (default):  ${d.run1}\n`);
+  process.stderr.write(`    run 2 (shuffled): ${d.run2}\n`);
+}
+process.stderr.write(
+  "\nDivergent tests likely depend on state created by earlier tests (in-process\n" +
+    "module state, shared Qonto sandbox resources, or implicit ordering of\n" +
+    "describe blocks). See `docs/e2e-testing.md` § Order-independence invariant\n" +
+    "for the remediation pattern and `docs/designs/e2e-test-reliability.md` §8.3\n" +
+    "for the design rationale (epic #603 R-OI-2).\n",
+);
+process.exit(1);


### PR DESCRIPTION
## Summary

Implements the Wave C order-independence layer of epic #603 (design §8.3, R-OI-1/R-OI-2). Three coordinated artifacts:

- **Invariant doc** in `docs/e2e-testing.md` — no test may depend on another's side effects except within an explicit CRUD-lifecycle `describe` using `LifecycleSkipCarrier`. Includes lifecycle-describe carve-out (with example), forbidden-pattern callout (with example), and remediation guidance.
- **ESLint rule** `eslint-rules/no-module-scope-mutable-state-in-e2e.js` — flags module-scope `let`/`var` in `*.e2e.test.ts` at authoring time. 12 RuleTester cases (6 valid, 6 invalid). Wired into CI via a new `pnpm eslint-rules-test` step.
- **Pre-release script** `pnpm order-independence-check` (`scripts/check-order-independence.sh` + `scripts/diff-vitest-runs.js`) — runs the suite twice (default order, then `--sequence.shuffle.files`), diffs the pass/fail/skip sets per test, exits non-zero with a divergent-test list + reproducibility seed.

Closes #607 · Refs #603

## Acceptance criteria

- [x] Invariant documented in `docs/e2e-testing.md` (§ Order-independence invariant)
- [x] Lint rule flags out-of-lifecycle module-scope mutable state — `qontoctl/no-module-scope-mutable-state-in-e2e`
- [x] `check-order-independence.sh` runs suite twice + diffs outcome sets; non-zero exit on divergence
- [x] Divergent tests listed for state-isolation review (R-OI-2)

## End-to-end validation

Ran `VITEST_SHUFFLE_SEED=42 pnpm order-independence-check` against the live Qonto sandbox: 4m 43s wall, 383 tests, two full E2E passes. The first production run surfaced one pre-existing R-OI-2 finding —

```
/Users/.../attachments/mcp.e2e.test.ts::attachment MCP tools (e2e) transaction_attachment_list lists attachments for a transaction and validates through schema
    run 1 (default):  failed
    run 2 (shuffled): skipped
```

— exactly the kind of cross-test state contamination this layer is designed to surface. Tracked separately; out of scope here per design §8.3 (listing IS the deliverable; per-test remediation is downstream work).

Other E2E pass/fail counts were stable across the two runs (`{passed: 242, 242}`, `{failed: 75, 74}`, `{skipped: 66, 67}`) — only the one above changed bucket.

## Notes

- Random-seed-matrix vitest plugin remains deferred to v2 per design §8.3 — layers (1) doc, (2) lint, (3) two-run diff cover the solo-maintainer risk surface.
- `pnpm order-independence-check` is NOT wired into the CI gate — it is intentionally a pre-release / quarterly tool (matches the contract-probe posture). Adding it to CI would gate merges on third-party sandbox state, which the design explicitly rejects.
- `pnpm eslint-rules-test` IS wired into CI so the rule's own tests run on every push.

## Test plan

- [x] `pnpm format:check` — clean
- [x] `pnpm build` — all packages
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint --force` — clean across all 8 packages (no false positives on existing E2E suites)
- [x] `pnpm eslint-rules-test` — 12 passed
- [x] `pnpm silent-skip-check` — clean
- [x] `pnpm coverage-drift-check` — clean
- [x] `pnpm license-check` — clean
- [x] `pnpm publish-check` — clean
- [x] `pnpm test` — 789 unit tests passed
- [x] `pnpm order-independence-check` — 383 E2E tests, divergence detection working end-to-end
- [x] Positive lint-rule check via injected probe (`let moduleScopeContamination`) — rule fired with correct message; probe removed
- [x] Diff-helper edge cases — convergent (exit 0), divergent (exit 1), missing arg (exit 2), missing file (exit 2), malformed JSON (exit 2)