### PR TITLE
(fix) contract-probe: unwrap ZodDefault in unwrapForDescent + unwrapToObject

### DIFF
--- a/scripts/contract-probe.test.ts
+++ b/scripts/contract-probe.test.ts
@@ -426,3 +426,89 @@ describe("diffSchema — #616 production-schema false-positive regression", () =
     expect(diff.missing_fields.map((m) => m.field)).not.toContain("items");
   });
 });
+
+// ---------------------------------------------------------------------------
+// unwrapToObject + unwrapForDescent — ZodDefault wrapper regressions (#620)
+//
+// Scope-Lock SL-1 of #616: the two non-walkKeys unwrap helpers also short-
+// circuit on a ZodDefault wrapper. `unwrapToObject` (top-level) refused to
+// resolve a `z.object({...}).default({...})` schema; `unwrapForDescent`
+// (nested-descent) returned the ZodDefault wrapper, which is neither ZodObject
+// nor ZodArray — so walkDiff treated the field as a leaf and never surfaced
+// drift inside the wrapped subtree. Both paths now mirror the #616 walkKeys
+// fix: capped iteration with an explicit ZodDefault branch that descends
+// `_zod.def.innerType`. Real introspection only, no mocks (#616 REQ-A5
+// discipline, also reasserted as a BUT-NOT here).
+// ---------------------------------------------------------------------------
+
+describe("unwrapToObject — ZodDefault top-level regression (#620)", () => {
+  // REQ-B1: a top-level `.default({...})` wrapper must resolve to its inner
+  // ZodObject. Pre-fix, the loop exhausted 16 iterations and returned null
+  // because ZodDefault exposes neither ZodOptional/Nullable nor `def.out`.
+  it("REQ-B1: descends a top-level .default({...}) wrapper to its inner ZodObject", () => {
+    const schema = z.object({ id: z.string() }).strip().default({ id: "" });
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped).toBeInstanceOf(z.ZodObject);
+    expect(walkKeys(unwrapped!).get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // REQ-B1: ZodDefault stacked with ZodOptional / ZodNullable must still resolve.
+  it("REQ-B1: descends .optional().nullable().default({...}) stacked wrappers", () => {
+    const schema = z.object({ id: z.string() }).strip().optional().nullable().default({ id: "" });
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(walkKeys(unwrapped!).has("id")).toBe(true);
+  });
+
+  // BUT NOT: unwrapToObject only resolves to ZodObject. A top-level
+  // `.default([...])` over a ZodArray descends through ZodDefault to ZodArray,
+  // which is not ZodObject — the fall-through still returns null (the probe's
+  // documented contract: object-shaped schemas only).
+  it("BUT NOT: returns null for a top-level .default([...]) over a ZodArray", () => {
+    const schema = z.array(z.string()).default([]);
+    expect(unwrapToObject(schema as unknown as z.ZodType)).toBeNull();
+  });
+});
+
+describe("unwrapForDescent — ZodDefault nested-descent regression (#620)", () => {
+  // REQ-B2: a nested `.default({...})`-wrapped object must have its keys
+  // walked. Without the fix, diffSchema would silently treat `config` as a
+  // leaf and miss the nested `unknown_nested` extra field (false-negative
+  // drift — the symmetric counterpart to the #616 false-positive class).
+  it("REQ-B2: diffSchema surfaces extras inside a .default({...})-wrapped nested object", () => {
+    const schema = z
+      .object({
+        config: z.object({ x: z.string() }).strip().default({ x: "" }),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: { x: "ok", unknown_nested: "val" } });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("config.unknown_nested");
+  });
+
+  // REQ-B2: same drift visibility for a `.default([...])`-wrapped nested array.
+  // `unwrapForDescent` accepts arrays as descent targets (unlike unwrapToObject),
+  // so an element-level extra must surface with the `items[].field` path.
+  it("REQ-B2: diffSchema surfaces extras inside a .default([...])-wrapped nested array", () => {
+    const schema = z
+      .object({
+        items: z.array(z.object({ id: z.string() }).strip()).default([]),
+      })
+      .strip();
+    const diff = diffSchema(schema, { items: [{ id: "1", extra: "val" }] });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("items[].extra");
+  });
+
+  // BUT NOT: genuine missing-required drift inside a `.default({...})`-wrapped
+  // nested object is still flagged. The fix must restore visibility into the
+  // wrapped subtree without silencing legitimate findings.
+  it("BUT NOT: missing required field inside .default({...})-wrapped nested object is still flagged", () => {
+    const schema = z
+      .object({
+        config: z.object({ required: z.string(), opt: z.string().optional() }).strip().default({ required: "" }),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: {} });
+    expect(diff.missing_fields.map((m) => m.field)).toContain("config.required");
+  });
+});

--- a/scripts/contract-probe.ts
+++ b/scripts/contract-probe.ts
@@ -303,15 +303,20 @@ function walkDiff(
 
 /**
  * Unwrap a schema for nested-traversal purposes — descends through
- * ZodOptional / ZodNullable / ZodPipe to reach the underlying structural
- * schema (ZodObject, ZodArray, or leaf). Unlike {@link unwrapToObject} this
- * does NOT enforce that the result is an object — leaves and arrays are
+ * ZodOptional / ZodNullable / ZodDefault / ZodPipe to reach the underlying
+ * structural schema (ZodObject, ZodArray, or leaf). Unlike {@link unwrapToObject}
+ * this does NOT enforce that the result is an object — leaves and arrays are
  * legitimate descent targets.
+ *
+ * ZodDefault descent (#620, sibling of #616): a field declared
+ * `z.object({...}).default({...})` wraps the structural schema in a ZodDefault;
+ * without the ZodDefault branch the loop would short-circuit and the nested
+ * object's keys would be invisible to {@link diffSchema}.
  */
 function unwrapForDescent(schema: z.ZodType): z.ZodType {
   let inner: z.ZodType = schema;
   for (let i = 0; i < 16; i++) {
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) {
+    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable || inner instanceof z.ZodDefault) {
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }
@@ -495,9 +500,14 @@ function resolveSchema(name: string): z.ZodObject<z.ZodRawShape> {
 
 /**
  * Unwrap a Zod schema to its underlying ZodObject through ZodOptional /
- * ZodNullable / ZodPipe (e.g., `z.preprocess(fn, object)` returns ZodPipe
- * where `out` is the target object). Returns `null` when the schema cannot
- * be reduced to an object.
+ * ZodNullable / ZodDefault / ZodPipe (e.g., `z.preprocess(fn, object)` returns
+ * ZodPipe where `out` is the target object). Returns `null` when the schema
+ * cannot be reduced to an object.
+ *
+ * ZodDefault unwrap (#620, sibling of #616): a top-level schema declared
+ * `z.object({...}).default({...})` wraps the ZodObject in a ZodDefault;
+ * without the ZodDefault branch the probe would refuse to resolve it,
+ * even though the underlying schema is object-shaped.
  *
  * Exported for use by the diff/walk pipeline AND by tests verifying schema
  * compatibility before invoking the probe against a live endpoint.
@@ -510,7 +520,7 @@ export function unwrapToObject(schema: z.ZodType): z.ZodObject<z.ZodRawShape> | 
     if (inner instanceof z.ZodObject) {
       return inner as z.ZodObject<z.ZodRawShape>;
     }
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable) {
+    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable || inner instanceof z.ZodDefault) {
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }


### PR DESCRIPTION
## Summary

Sibling of #616 (SL-1). The two non-`walkKeys` unwrap helpers in
`scripts/contract-probe.ts` shared the same wrapper-short-circuit gap: a field
declared `z.object({...}).default({...})` (or `z.array(...).default([...])`)
was not descended.

- **`unwrapForDescent`** (nested-descent) — pre-fix returned the `ZodDefault`
  wrapper, which is neither `ZodObject` nor `ZodArray`, so `walkDiff` treated
  the field as a leaf and never surfaced drift inside the wrapped subtree
  (**false-negative** class, symmetric counterpart to the #616 false-positive
  class).
- **`unwrapToObject`** (top-level) — pre-fix exhausted the 16-iteration cap
  and returned `null`, so a top-level `z.object({...}).default({...})` would
  have been rejected as "not object-shaped" even though the underlying schema
  is.

Both helpers now add a `ZodDefault` branch that descends `_zod.def.innerType`,
folded into the existing OR chain alongside `ZodOptional` / `ZodNullable`
(mirrors the #616 `walkKeys` capped-loop pattern). Docstrings updated to
match.

Closes #620.

## Why this is latent (not part of #616)

- NOT among the 6 false positives #616 reproduced and fixed.
- Doesn't affect REQ-A4: `Quote.discount` was absent in #616's post-fix live
  run; `Beneficiary` unwraps via `def.out`; `Quote`/`ClientInvoice` top-level
  are bare `ZodObject`.
- No production endpoint currently wraps a structural schema in
  `.default({...})` / `.default([...])`, so no live drift mis-report exists
  today.
- The fix closes the missed-traversal class before it can land — same
  wrapper-short-circuit class as #616.

## What changed

- **`scripts/contract-probe.ts`** — added `inner instanceof z.ZodDefault` to
  the unwrap branch in both helpers; the existing `_zod.def.innerType`
  descent applies cleanly (ZodDefault uses the same shape as ZodOptional /
  ZodNullable). Docstrings updated.
- **`scripts/contract-probe.test.ts`** — +6 regression tests across two new
  describe blocks (one per helper). Real introspection only, no mocks
  (#616 REQ-A5 discipline reasserted):
  - `unwrapToObject`: top-level `.default({...})` resolves; stacked
    `.optional().nullable().default({...})` resolves; BUT NOT — top-level
    `.default([...])` over `ZodArray` still returns `null` (the probe's
    object-shaped-only contract holds).
  - `unwrapForDescent` (via `diffSchema`): extras inside a
    `.default({...})`-wrapped nested object surface; extras inside a
    `.default([...])`-wrapped nested array surface; BUT NOT — missing
    required field inside the wrapped subtree is still flagged.

## RED-first confirmation

Pre-fix run (fix stashed, tests applied): **5/6 new tests FAIL**, 36/41 pass.
The 6th test ("BUT NOT array-default returns null") passes pre-fix as
designed — it guards against the fix accidentally promoting `ZodArray` to
object resolution, so it must pass in both states.

Post-fix run: **41/41 pass**.

## Test plan

- [x] `pnpm contract-probe-test` — 41 passed (35 prior + 6 new); RED→GREEN
      confirmed (5/6 fail pre-fix, all 41 pass post-fix)
- [x] `pnpm typecheck` — 8/8 turbo tasks pass
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — 8/8 turbo tasks pass
- [x] `pnpm test` — 10/10 turbo tasks pass (789 CLI tests + others)
- [x] `pnpm coverage-drift-check` — clean (scripts/ surfaces aren't tracked)
- [ ] CI green on this PR

## Scope discipline

Strictly the SL-1 follow-up from #616. Out-of-scope (not addressed here):

- SL-2 (genuine `extra_fields` drift on Beneficiary/Quote/ClientInvoice/
  SupplierInvoice) — schema-maintenance follow-up, not introspection.
- SL-3 (`walkKeys` doesn't handle `ZodReadonly`) — separate wrapper-class
  follow-up; benign today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)