### PR TITLE
(fix) contract-probe: unwrap ZodReadonly in walkKeys + helpers (#622)

### DIFF
--- a/scripts/contract-probe.test.ts
+++ b/scripts/contract-probe.test.ts
@@ -512,3 +512,170 @@ describe("unwrapForDescent — ZodDefault nested-descent regression (#620)", () 
     expect(diff.missing_fields.map((m) => m.field)).toContain("config.required");
   });
 });
+
+// ---------------------------------------------------------------------------
+// walkKeys + unwrap helpers — ZodReadonly wrapper regressions (#622)
+//
+// Same wrapper-short-circuit class as #616 / #620, but for `ZodReadonly`.
+// `.readonly()` affects only mutability — it does NOT change null/absence
+// acceptance. But because none of the existing branches in walkKeys /
+// unwrapForDescent / unwrapToObject match `ZodReadonly`, the loop short-
+// circuits on entry whenever ZodReadonly is the outermost wrapper, or when
+// ZodReadonly is sandwiched between an outer and inner strictness wrapper.
+//
+// Empirically zero false positives today (QuoteSchema.items and .invoice_ids
+// happen to not stack nullability inside `.readonly()`), but a future
+// declaration like `z.array(...).nullable().readonly()` would silently drop
+// the upstream `.nullable()`. Fix the latent gap before it lands.
+//
+// Real introspection only, no mocks (#616 REQ-A5 discipline reasserted).
+// ---------------------------------------------------------------------------
+
+describe("walkKeys — ZodReadonly wrapper regressions (#622)", () => {
+  // REQ-C1: bare `.readonly()` on a non-strictness inner type — no flag
+  // change. Mirrors QuoteSchema.items shape. Accidentally correct pre-fix
+  // (the break short-circuit happens to produce `{false, false}` which is
+  // the right answer when the inner type carries no strictness), but pinned
+  // so a future refactor can't regress it.
+  it("REQ-C1: z.array(...).readonly() is non-nullable + required", () => {
+    const schema = z.object({ items: z.array(z.string()).readonly() }).strip();
+    expect(walkKeys(schema).get("items")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // REQ-C1: `.readonly().optional()` — `.optional()` outer wraps `.readonly()`.
+  // Mirrors QuoteSchema.invoice_ids shape. Pre-fix the loop unwraps `.optional()`
+  // (isOptional=true), descends to ZodReadonly, then breaks — accidentally
+  // correct because the inner type carries no nullability.
+  it("REQ-C1: z.array(...).readonly().optional() is required-optional, non-nullable", () => {
+    const schema = z.object({ invoice_ids: z.array(z.string()).readonly().optional() }).strip();
+    expect(walkKeys(schema).get("invoice_ids")).toEqual({ isNullable: false, isOptional: true });
+  });
+
+  // REQ-C1: `.nullable().readonly()` — readonly is OUTERMOST, wraps nullable.
+  // Pre-fix: loop enters, ZodReadonly doesn't match any branch → `break` on
+  // entry → both flags stay false → WRONG. The inner `.nullable()` is lost.
+  // This is the canonical latent failure case the issue describes.
+  it("REQ-C1: z.array(...).nullable().readonly() preserves nullability through outer readonly", () => {
+    const schema = z.object({ items: z.array(z.string()).nullable().readonly() }).strip();
+    expect(walkKeys(schema).get("items")).toEqual({ isNullable: true, isOptional: false });
+  });
+
+  // REQ-C1: `.readonly().nullable()` — nullable is OUTERMOST. Pre-fix: loop
+  // unwraps `.nullable()` (isNullable=true), descends to ZodReadonly, then
+  // breaks → accidentally correct. Pinned to guard against the fix breaking
+  // the working order.
+  it("REQ-C1: z.array(...).readonly().nullable() is nullable", () => {
+    const schema = z.object({ items: z.array(z.string()).readonly().nullable() }).strip();
+    expect(walkKeys(schema).get("items")).toEqual({ isNullable: true, isOptional: false });
+  });
+
+  // REQ-C1: `.nullable().readonly().optional()` — readonly is sandwiched.
+  // Pre-fix: loop unwraps `.optional()` (isOptional=true), descends to
+  // ZodReadonly, then breaks → upstream `.nullable()` is LOST → WRONG. Post-
+  // fix: descends through ZodReadonly to reach the inner `.nullable()`.
+  it("REQ-C1: z.array(...).nullable().readonly().optional() is nullable + optional", () => {
+    const schema = z.object({ items: z.array(z.string()).nullable().readonly().optional() }).strip();
+    expect(walkKeys(schema).get("items")).toEqual({ isNullable: true, isOptional: true });
+  });
+
+  // REQ-C1: real `QuoteSchema.items` and `.invoice_ids` — pin the observed-
+  // production shapes. Both happen to be accidentally-correct pre-fix; this
+  // is a status-quo regression guard, not a RED test.
+  it("REQ-C1: real QuoteSchema.items shape produces the expected flags", () => {
+    const schema = unwrapToObject(QuoteSchema as unknown as z.ZodType);
+    expect(schema).not.toBeNull();
+    expect(walkKeys(schema!).get("items")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  it("REQ-C1: real QuoteSchema.invoice_ids shape produces the expected flags", () => {
+    const schema = unwrapToObject(QuoteSchema as unknown as z.ZodType);
+    expect(schema).not.toBeNull();
+    expect(walkKeys(schema!).get("invoice_ids")).toEqual({ isNullable: false, isOptional: true });
+  });
+
+  // BUT NOT: a genuinely non-nullable readonly array that returns null is
+  // still flagged as a strictness mismatch. The fix must not silence drift —
+  // `.readonly()` is mutability-only, so `z.array(...).readonly()` is still
+  // non-nullable.
+  it("BUT NOT: a non-nullable z.array(...).readonly() field returning null is still flagged", () => {
+    const schema = z.object({ items: z.array(z.string()).readonly() }).strip();
+    const diff = diffSchema(schema, { items: null });
+    expect(diff.strictness_mismatches.map((m) => m.field)).toContain("items");
+  });
+});
+
+describe("unwrapToObject — ZodReadonly top-level regression (#622)", () => {
+  // REQ-C2: a top-level `.readonly()` wrapper must resolve to its inner
+  // ZodObject. Pre-fix: ZodReadonly matches none of the branches, `def.out`
+  // doesn't exist → returns null → the probe would refuse a hypothetical
+  // `z.object({...}).readonly()` schema reference even though it is object-
+  // shaped. No production schema uses this shape today, but the helper-
+  // parity gap is what the issue's SL-1 audit asks us to close.
+  it("REQ-C2: descends a top-level .readonly() wrapper to its inner ZodObject", () => {
+    const schema = z.object({ id: z.string() }).strip().readonly();
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped).toBeInstanceOf(z.ZodObject);
+    expect(walkKeys(unwrapped!).get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // REQ-C2: ZodReadonly stacked with ZodOptional / ZodNullable / ZodDefault
+  // must still resolve.
+  it("REQ-C2: descends .optional().nullable().readonly() stacked wrappers", () => {
+    const schema = z.object({ id: z.string() }).strip().optional().nullable().readonly();
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(walkKeys(unwrapped!).has("id")).toBe(true);
+  });
+
+  // BUT NOT: unwrapToObject only resolves to ZodObject. A top-level
+  // `.readonly()` over a ZodArray descends through ZodReadonly to ZodArray,
+  // which is not ZodObject — the fall-through still returns null (the
+  // probe's documented object-shaped-only contract).
+  it("BUT NOT: returns null for a top-level z.array(...).readonly()", () => {
+    const schema = z.array(z.string()).readonly();
+    expect(unwrapToObject(schema as unknown as z.ZodType)).toBeNull();
+  });
+});
+
+describe("unwrapForDescent — ZodReadonly nested-descent regression (#622)", () => {
+  // REQ-C3: a nested `.readonly()`-wrapped object must have its keys walked.
+  // Without the fix, diffSchema would silently treat `config` as a leaf and
+  // miss the nested `unknown_nested` extra field (false-negative drift —
+  // the same symmetric counterpart to #616 that #620 fixed for ZodDefault).
+  it("REQ-C3: diffSchema surfaces extras inside a .readonly()-wrapped nested object", () => {
+    const schema = z
+      .object({
+        config: z.object({ x: z.string() }).strip().readonly(),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: { x: "ok", unknown_nested: "val" } });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("config.unknown_nested");
+  });
+
+  // REQ-C3: same drift visibility for a `.readonly()`-wrapped nested array.
+  // Mirrors QuoteSchema.items shape: extras inside QuoteItemSchema elements
+  // would be silently invisible pre-fix.
+  it("REQ-C3: diffSchema surfaces extras inside a z.array(...).readonly() nested array", () => {
+    const schema = z
+      .object({
+        items: z.array(z.object({ id: z.string() }).strip()).readonly(),
+      })
+      .strip();
+    const diff = diffSchema(schema, { items: [{ id: "1", extra: "val" }] });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("items[].extra");
+  });
+
+  // BUT NOT: genuine missing-required drift inside a `.readonly()`-wrapped
+  // nested object is still flagged. The fix must restore visibility into
+  // the wrapped subtree without silencing legitimate findings.
+  it("BUT NOT: missing required field inside .readonly()-wrapped nested object is still flagged", () => {
+    const schema = z
+      .object({
+        config: z.object({ required: z.string(), opt: z.string().optional() }).strip().readonly(),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: {} });
+    expect(diff.missing_fields.map((m) => m.field)).toContain("config.required");
+  });
+});

--- a/scripts/contract-probe.ts
+++ b/scripts/contract-probe.ts
@@ -144,10 +144,11 @@ interface EndpointsFile {
 
 /**
  * Extract the field map from a Zod object schema, capturing nullable / optional
- * flags. Unwraps `ZodOptional` / `ZodNullable` / `ZodDefault` (via the Zod 4
- * `_zod.def.innerType` chain) and `ZodPipe` (via `_zod.def.in`) iteratively,
- * order-independent, so `.nullable().optional()`, `.default(null)`, and
- * `.transform()` chains all classify correctly (#616).
+ * flags. Unwraps `ZodOptional` / `ZodNullable` / `ZodDefault` / `ZodReadonly`
+ * (via the Zod 4 `_zod.def.innerType` chain) and `ZodPipe` (via `_zod.def.in`)
+ * iteratively, order-independent, so `.nullable().optional()`,
+ * `.default(null)`, `.readonly()`, and `.transform()` chains all classify
+ * correctly (#616, #622).
  *
  * Schemas not satisfying `instanceof z.ZodObject` should be rejected by the
  * caller before invoking this helper — the function assumes a `.shape` field.
@@ -163,20 +164,27 @@ export function walkKeys(schema: z.ZodObject<z.ZodRawShape>): Map<string, KeySpe
     let isOptional = false;
     // Unwrap strictness-affecting wrappers iteratively, in any order. The
     // iteration cap mirrors unwrapToObject (depth > 16 is implausible).
-    //   ZodOptional → accepts absence
-    //   ZodNullable → accepts null
-    //   ZodDefault  → `.default(v)` supplies a value when the input is absent,
-    //                 so the field accepts absence; descend to surface any
-    //                 nested `.nullable()` (e.g. `z.T().nullable().optional()
-    //                 .default(null)`, the BeneficiarySchema.email / QuoteSchema
-    //                 .discount shape).
-    //   ZodPipe     → `.transform(fn)` produces a pipe whose `in` side is the
-    //                 schema the raw response is validated against; descend
-    //                 into `in` so an upstream `.nullable()` is not lost
-    //                 (e.g. `z.array(...).nullable().transform(...)`, the
-    //                 ClientInvoiceSchema.items shape).
-    // Without ZodDefault / ZodPipe handling the outermost wrapper short-circuits
-    // the loop, leaving both flags false → false-positive drift (#616).
+    //   ZodOptional  → accepts absence
+    //   ZodNullable  → accepts null
+    //   ZodDefault   → `.default(v)` supplies a value when the input is absent,
+    //                  so the field accepts absence; descend to surface any
+    //                  nested `.nullable()` (e.g. `z.T().nullable().optional()
+    //                  .default(null)`, the BeneficiarySchema.email /
+    //                  QuoteSchema.discount shape).
+    //   ZodReadonly  → `.readonly()` affects only mutability (not null/absence
+    //                  acceptance); descend `_zod.def.innerType` without
+    //                  changing flags, so an inner `.nullable()` / `.optional()`
+    //                  is not lost when readonly is the outermost or a
+    //                  sandwiched wrapper (e.g. `z.array(...).nullable()
+    //                  .readonly()`, latent for QuoteSchema.items shape — #622).
+    //   ZodPipe      → `.transform(fn)` produces a pipe whose `in` side is the
+    //                  schema the raw response is validated against; descend
+    //                  into `in` so an upstream `.nullable()` is not lost
+    //                  (e.g. `z.array(...).nullable().transform(...)`, the
+    //                  ClientInvoiceSchema.items shape).
+    // Without ZodDefault / ZodReadonly / ZodPipe handling the outermost
+    // wrapper short-circuits the loop, leaving both flags false → false-
+    // positive drift (#616) OR upstream strictness silently dropped (#622).
     for (let i = 0; i < 16; i++) {
       if (inner instanceof z.ZodOptional) {
         isOptional = true;
@@ -190,6 +198,12 @@ export function walkKeys(schema: z.ZodObject<z.ZodRawShape>): Map<string, KeySpe
       }
       if (inner instanceof z.ZodDefault) {
         isOptional = true;
+        inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
+        continue;
+      }
+      if (inner instanceof z.ZodReadonly) {
+        // No flag change — `.readonly()` is mutability-only; descend to
+        // surface any wrapped `.nullable()` / `.optional()` / `.default()`.
         inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
         continue;
       }
@@ -303,20 +317,33 @@ function walkDiff(
 
 /**
  * Unwrap a schema for nested-traversal purposes — descends through
- * ZodOptional / ZodNullable / ZodDefault / ZodPipe to reach the underlying
- * structural schema (ZodObject, ZodArray, or leaf). Unlike {@link unwrapToObject}
- * this does NOT enforce that the result is an object — leaves and arrays are
- * legitimate descent targets.
+ * ZodOptional / ZodNullable / ZodDefault / ZodReadonly / ZodPipe to reach the
+ * underlying structural schema (ZodObject, ZodArray, or leaf). Unlike
+ * {@link unwrapToObject} this does NOT enforce that the result is an object —
+ * leaves and arrays are legitimate descent targets.
  *
  * ZodDefault descent (#620, sibling of #616): a field declared
  * `z.object({...}).default({...})` wraps the structural schema in a ZodDefault;
  * without the ZodDefault branch the loop would short-circuit and the nested
  * object's keys would be invisible to {@link diffSchema}.
+ *
+ * ZodReadonly descent (#622, sibling of #620): a field declared
+ * `z.array(...).readonly()` or `z.object({...}).readonly()` wraps the
+ * structural schema in a ZodReadonly; without the ZodReadonly branch the loop
+ * would short-circuit and drift inside the wrapped subtree would be silently
+ * invisible (false-negative class — `.readonly()` is mutability-only, so the
+ * wrapper carries no strictness, but descent into the inner type must still
+ * happen for diff visibility).
  */
 function unwrapForDescent(schema: z.ZodType): z.ZodType {
   let inner: z.ZodType = schema;
   for (let i = 0; i < 16; i++) {
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable || inner instanceof z.ZodDefault) {
+    if (
+      inner instanceof z.ZodOptional ||
+      inner instanceof z.ZodNullable ||
+      inner instanceof z.ZodDefault ||
+      inner instanceof z.ZodReadonly
+    ) {
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }
@@ -500,14 +527,21 @@ function resolveSchema(name: string): z.ZodObject<z.ZodRawShape> {
 
 /**
  * Unwrap a Zod schema to its underlying ZodObject through ZodOptional /
- * ZodNullable / ZodDefault / ZodPipe (e.g., `z.preprocess(fn, object)` returns
- * ZodPipe where `out` is the target object). Returns `null` when the schema
- * cannot be reduced to an object.
+ * ZodNullable / ZodDefault / ZodReadonly / ZodPipe (e.g.,
+ * `z.preprocess(fn, object)` returns ZodPipe where `out` is the target
+ * object). Returns `null` when the schema cannot be reduced to an object.
  *
  * ZodDefault unwrap (#620, sibling of #616): a top-level schema declared
  * `z.object({...}).default({...})` wraps the ZodObject in a ZodDefault;
  * without the ZodDefault branch the probe would refuse to resolve it,
  * even though the underlying schema is object-shaped.
+ *
+ * ZodReadonly unwrap (#622, sibling of #620): a top-level schema declared
+ * `z.object({...}).readonly()` wraps the ZodObject in a ZodReadonly; without
+ * the ZodReadonly branch the probe would refuse to resolve it, even though
+ * the underlying schema is object-shaped. No live production endpoint uses
+ * this shape today, but the helper-parity gap is closed here to keep the
+ * three unwrap paths in lockstep.
  *
  * Exported for use by the diff/walk pipeline AND by tests verifying schema
  * compatibility before invoking the probe against a live endpoint.
@@ -520,7 +554,12 @@ export function unwrapToObject(schema: z.ZodType): z.ZodObject<z.ZodRawShape> | 
     if (inner instanceof z.ZodObject) {
       return inner as z.ZodObject<z.ZodRawShape>;
     }
-    if (inner instanceof z.ZodOptional || inner instanceof z.ZodNullable || inner instanceof z.ZodDefault) {
+    if (
+      inner instanceof z.ZodOptional ||
+      inner instanceof z.ZodNullable ||
+      inner instanceof z.ZodDefault ||
+      inner instanceof z.ZodReadonly
+    ) {
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }


### PR DESCRIPTION
## Summary

Sibling of #616 (SL-3) / #620 (SL-1). The three unwrap paths in
`scripts/contract-probe.ts` (`walkKeys`, `unwrapForDescent`, `unwrapToObject`)
all short-circuit on `ZodReadonly` because none of the existing branches
match it. Latent — **zero false positives today** — but the same wrapper-
short-circuit class #616 fixed for `ZodDefault`/`ZodPipe` and #620 then
closed in the sibling helpers for `ZodDefault`.

`QuoteSchema.items` and `QuoteSchema.invoice_ids` use `.readonly()`; their
post-fix flags are unchanged (they happen not to nest nullability inside
the readonly wrapper), but a future declaration like
`z.array(...).nullable().readonly()` would silently drop the upstream
`.nullable()` — that latent gap is what this PR closes.

Closes #622.

## What changed

- **`scripts/contract-probe.ts`** — `ZodReadonly` branch added to all three
  unwrap paths, descending `_zod.def.innerType` (same shape as
  `ZodOptional` / `ZodNullable` / `ZodDefault`). **No strictness flag
  change** — `.readonly()` is mutability-only. Docstrings updated to
  enumerate `ZodReadonly` alongside the prior wrappers.
  - `walkKeys`: dedicated `if` branch (matches the existing per-wrapper
    structure) without flipping `isNullable`/`isOptional`.
  - `unwrapForDescent`: folded into the existing `ZodOptional ||
    ZodNullable || ZodDefault` OR-chain.
  - `unwrapToObject`: folded into the same OR-chain (mirrors
    `unwrapForDescent`).
- **`scripts/contract-probe.test.ts`** — +14 regression tests across three
  new describe blocks (one per helper). Real introspection only, no mocks
  (#616 REQ-A5 discipline reasserted):
  - **walkKeys (REQ-C1, 8 tests)**: bare `.readonly()`, `.readonly().optional()`
    (QuoteSchema.invoice_ids shape), `.nullable().readonly()` (canonical
    latent failure case), `.readonly().nullable()`,
    `.nullable().readonly().optional()` (sandwiched-readonly latent failure),
    real `QuoteSchema.items` + `.invoice_ids` shapes, and BUT-NOT for a
    genuinely non-nullable readonly array returning null.
  - **unwrapToObject (REQ-C2, 3 tests)**: top-level `.readonly()` resolves;
    stacked `.optional().nullable().readonly()` resolves; BUT-NOT —
    top-level `.readonly()` over `ZodArray` still returns `null`.
  - **unwrapForDescent (REQ-C3, 3 tests)**: extras inside a
    `.readonly()`-wrapped nested object surface; extras inside a
    `.readonly()`-wrapped nested array surface; BUT-NOT — missing
    required field inside the wrapped subtree is still flagged.

## RED-first confirmation

Pre-fix run (tests applied without the helper changes): **7/14 new tests FAIL**, 48/55 pass.

| Failure class | Tests |
|---|---|
| Sandwiched readonly drops upstream nullable (`.nullable().readonly()` and `.nullable().readonly().optional()`) | 2 |
| Top-level `.readonly()` wrapper not resolved by `unwrapToObject` (bare + stacked) | 2 |
| Nested `.readonly()`-wrapped subtree invisible to `diffSchema` (object extras + array extras + missing) | 3 |

The other 7 new tests pass pre-fix as designed — accidentally-correct
status-quo guards (the inner type happens to carry no strictness) and the
two BUT-NOT guards that must hold in both states.

Post-fix run: **55/55 pass**.

## Why this is latent (not a live defect)

- Empirically **0 false positives** today: the post-#616 / #620 live runs
  show no readonly-related drift mis-reports. `QuoteSchema.items` and
  `.invoice_ids` happen to not stack `.nullable()` inside `.readonly()`.
- It is a latent correctness gap of the same class as #616 / #620, not a
  reproduced bug. The fix closes the missed-traversal class before it can
  land, completing the helper-parity theme #620 raised under SL-1.

## Acceptance criteria

| AC | Status | Evidence |
|----|--------|----------|
| REQ-C1 `walkKeys` descends `ZodReadonly` order-independently | ✅ | 8 walkKeys tests (REQ-C1) |
| REQ-C2 `unwrapToObject` resolves `.readonly()`-wrapped ZodObject | ✅ | 3 unwrapToObject tests (REQ-C2) |
| REQ-C3 `unwrapForDescent` descends `.readonly()` for diff visibility | ✅ | 3 unwrapForDescent tests (REQ-C3) |
| BUT NOT: drift still surfaces inside `.readonly()` subtree | ✅ | BUT-NOT tests in each describe |
| Real introspection only, no mocks (#616 REQ-A5) | ✅ | All tests use `z.*` constructors + real @qontoctl/core schemas |

## Test plan

- [x] `pnpm contract-probe-test` — 55 passed (41 prior + 14 new); RED→GREEN confirmed (7 pre-fix FAIL → 0 post-fix FAIL)
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (FULL TURBO cache hit)
- [x] `pnpm test` — 789/789 pass (CLI + core + MCP + qontoctl)
- [x] `pnpm coverage-drift-check` — clean (no new surfaces)
- [x] `pnpm license-check` — clean
- [x] `pnpm test:e2e` — 244 pass, 74 fail, 65 skipped (env-flake; SCA write-path / lifecycle cascades in transfers/cards/webhooks/bulk-transfers). Failures **provably independent** of this change: `grep -rn contract-probe packages/` returns zero matches — no E2E test imports the script. The contract probe is a separate dev-time script; touching its introspection helpers cannot affect E2E behavior. Likely cause: parallel-batch OAuth race with sibling worktrees / sandbox SCA service intermittency (same environmental flake class CLAUDE.md § E2E Testing documents for `cards/` / `clients/` / `profile/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)