### PR TITLE
(fix) contract-probe: ZodPipe direction-aware unwrap in walkKeys + helpers (#623)

### DIFF
--- a/scripts/contract-probe.test.ts
+++ b/scripts/contract-probe.test.ts
@@ -679,3 +679,209 @@ describe("unwrapForDescent — ZodReadonly nested-descent regression (#622)", ()
     expect(diff.missing_fields.map((m) => m.field)).toContain("config.required");
   });
 });
+
+// ---------------------------------------------------------------------------
+// walkKeys + unwrap helpers — ZodPipe direction regressions (#623)
+//
+// Same wrapper-short-circuit class as #616 / #622, but for the *direction*
+// inside `ZodPipe`. PR #619 made `walkKeys` descend `def.in` because
+// `.transform(fn)` produces `ZodPipe { in: source, out: ZodTransform }`. That
+// is correct for `.transform()` but inverted for `z.preprocess(fn, target)`
+// which produces `ZodPipe { in: ZodTransform, out: target }` — the target
+// (which carries any `.nullable()` / `.optional()`) lives on `def.out`. With
+// the #619-era code, a field declared `z.preprocess(fn, z.string().nullable())`
+// would land on ZodTransform inside `walkKeys` and short-circuit the loop,
+// dropping the inner `.nullable()` and emitting a false-positive
+// `strictness_mismatch` for a genuinely-nullable preprocessed field.
+//
+// Empirically zero false positives today (no current @qontoctl/core schema
+// uses field-level `z.preprocess`), but the same wrapper-short-circuit class
+// as #616 / #620 / #622 — fix the latent gap before it lands. Audit also
+// extends to `unwrapForDescent` (pre-fix descended `def.out` unconditionally
+// → landed on ZodTransform for `.transform()` → falls through as leaf →
+// skipped nested-element drift inside `ClientInvoiceSchema.items`-shaped
+// fields) and `unwrapToObject` (pre-fix tried `def.out` first, but ZodTransform
+// IS a ZodType → entered the wrong side → exhausted the 16-step budget →
+// returned `null`, refusing a top-level `z.object({...}).transform(fn)`).
+//
+// Real introspection only, no mocks (#616 REQ-A5 discipline reasserted).
+// ---------------------------------------------------------------------------
+
+describe("walkKeys — ZodPipe direction regressions (#623)", () => {
+  // REQ-D1: `z.preprocess(fn, z.string().nullable())` — preprocess is the
+  // canonical RED case. Pre-fix: walkKeys descended def.in (ZodTransform) →
+  // loop short-circuits → both flags false → WRONG. Post-fix: detects
+  // ZodTransform on def.in → descends def.out → reaches `.nullable()`.
+  it("REQ-D1: z.preprocess(fn, z.string().nullable()) is nullable", () => {
+    const schema = z
+      .object({
+        f: z.preprocess((v) => v, z.string().nullable()),
+      })
+      .strip();
+    expect(walkKeys(schema).get("f")).toEqual({ isNullable: true, isOptional: false });
+  });
+
+  // REQ-D1: `z.preprocess(fn, z.string().optional().default(null))` — both
+  // strictness flags must propagate through the preprocess target side.
+  it("REQ-D1: z.preprocess(fn, z.string().nullable().optional().default(null)) is nullable + optional", () => {
+    const schema = z
+      .object({
+        f: z.preprocess((v) => v, z.string().nullable().optional().default(null)),
+      })
+      .strip();
+    expect(walkKeys(schema).get("f")).toEqual({ isNullable: true, isOptional: true });
+  });
+
+  // REQ-D1 regression guard: `.transform()` direction (the #619 case) must
+  // still work post-fix. Direction selection picks def.in when def.out is
+  // ZodTransform, mirroring the original PR #619 behavior.
+  it("REQ-D1 regression: z.array(...).nullable().transform(...) still preserves nullability", () => {
+    const schema = z
+      .object({
+        items: z
+          .array(z.object({ id: z.string() }).strip())
+          .nullable()
+          .transform((v) => v ?? []),
+      })
+      .strip();
+    expect(walkKeys(schema).get("items")).toMatchObject({ isNullable: true });
+  });
+
+  // REQ-D1: bare `z.pipe(A, B)` — neither side is a ZodTransform. Convention:
+  // descend def.in (input side is what the raw payload is validated against).
+  // Pre-fix #619 behavior was already def.in for this case; pinned to guard
+  // against the direction-aware refactor regressing the convention.
+  it("REQ-D1: bare z.pipe(z.<T>().nullable(), z.<T>()) descends def.in (input-side)", () => {
+    const schema = z
+      .object({
+        f: z.pipe(z.string().nullable(), z.string()),
+      })
+      .strip();
+    expect(walkKeys(schema).get("f")).toEqual({ isNullable: true, isOptional: false });
+  });
+
+  // BUT NOT: a genuinely non-nullable preprocessed field returning null is
+  // still flagged as a strictness mismatch. The direction-aware fix must not
+  // silence drift — only restore visibility into the correct side of the pipe.
+  it("BUT NOT: a non-nullable preprocessed field returning null is still flagged", () => {
+    const schema = z
+      .object({
+        f: z.preprocess((v) => v, z.string()),
+      })
+      .strip();
+    const diff = diffSchema(schema, { f: null });
+    expect(diff.strictness_mismatches.map((m) => m.field)).toContain("f");
+  });
+});
+
+describe("unwrapToObject — ZodPipe direction regressions (#623)", () => {
+  // REQ-D2: top-level `z.preprocess(fn, z.object({...}))` — target object on
+  // def.out must be reachable. Pre-fix this happened to work because the
+  // helper tried def.out first; pinned as a regression guard for the
+  // direction-aware refactor.
+  it("REQ-D2: descends a top-level z.preprocess(fn, z.object({...})) to its ZodObject", () => {
+    const schema = z.preprocess((v) => v, z.object({ id: z.string() }).strip());
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped).toBeInstanceOf(z.ZodObject);
+    expect(walkKeys(unwrapped!).get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // REQ-D2: top-level `z.object({...}).transform(fn)` — source object on
+  // def.in must be reachable. Pre-fix: def.out was ZodTransform (IS a ZodType)
+  // → helper descended to ZodTransform → loop exhausted 16 iterations →
+  // returned null → probe refused the schema. Post-fix: direction-aware
+  // descent picks def.in when def.out is ZodTransform.
+  it("REQ-D2: descends a top-level z.object({...}).transform(fn) to its source ZodObject", () => {
+    const schema = z
+      .object({ id: z.string() })
+      .strip()
+      .transform((v) => v);
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped).toBeInstanceOf(z.ZodObject);
+    expect(walkKeys(unwrapped!).get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // REQ-D2: bare top-level `z.pipe(z.object({...}), z.object({...}))` —
+  // convention descends def.in (input-side validation target).
+  it("REQ-D2: descends a bare z.pipe(z.object({...}), z.object({...})) to def.in ZodObject", () => {
+    const schema = z.pipe(z.object({ id: z.string() }).strip(), z.object({ id: z.string() }).strip());
+    const unwrapped = unwrapToObject(schema as unknown as z.ZodType);
+    expect(unwrapped).not.toBeNull();
+    expect(unwrapped).toBeInstanceOf(z.ZodObject);
+    expect(walkKeys(unwrapped!).get("id")).toEqual({ isNullable: false, isOptional: false });
+  });
+
+  // BUT NOT: a top-level `z.preprocess(fn, z.array(...))` resolves through
+  // ZodPipe to ZodArray — not ZodObject — so the helper still returns null,
+  // honoring the probe's object-shaped-only contract.
+  it("BUT NOT: returns null for a top-level z.preprocess(fn, z.array(...))", () => {
+    const schema = z.preprocess((v) => v, z.array(z.string()));
+    expect(unwrapToObject(schema as unknown as z.ZodType)).toBeNull();
+  });
+});
+
+describe("unwrapForDescent — ZodPipe direction regressions (#623)", () => {
+  // REQ-D3: a nested `z.preprocess(fn, z.object({...}))` field must have its
+  // keys walked. Pre-fix this worked (def.out was already preferred), so this
+  // is a regression guard for the direction-aware refactor.
+  it("REQ-D3: diffSchema surfaces extras inside a nested z.preprocess(fn, z.object({...}))", () => {
+    const schema = z
+      .object({
+        config: z.preprocess((v) => v, z.object({ x: z.string() }).strip()),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: { x: "ok", unknown_nested: "val" } });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("config.unknown_nested");
+  });
+
+  // REQ-D3: a nested `.transform()` over an object must have its keys walked.
+  // Pre-fix: unwrapForDescent descended def.out (ZodTransform), bailed out as
+  // a leaf → diffSchema treated the field as a leaf → silently invisible
+  // (false-negative class — the symmetric counterpart that #620 / #622 fixed
+  // for ZodDefault / ZodReadonly). Post-fix: descends def.in.
+  it("REQ-D3: diffSchema surfaces extras inside a nested z.object({...}).transform(fn)", () => {
+    const schema = z
+      .object({
+        config: z
+          .object({ x: z.string() })
+          .strip()
+          .transform((v) => v),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: { x: "ok", unknown_nested: "val" } });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("config.unknown_nested");
+  });
+
+  // REQ-D3: a nested `.transform()` over an array must surface element-level
+  // drift via `items[].field` path qualification. Mirrors the
+  // `ClientInvoiceSchema.items` shape (`z.array(...).nullable().transform(...)`)
+  // for which walkKeys correctly captured nullability post-#619 but
+  // unwrapForDescent silently treated the array as a leaf.
+  it("REQ-D3: diffSchema surfaces extras inside a nested z.array(...).transform(fn) elements", () => {
+    const schema = z
+      .object({
+        items: z
+          .array(z.object({ id: z.string() }).strip())
+          .nullable()
+          .transform((v) => v ?? []),
+      })
+      .strip();
+    const diff = diffSchema(schema, { items: [{ id: "1", extra: "val" }] });
+    expect(diff.extra_fields.map((f) => f.field)).toContain("items[].extra");
+  });
+
+  // BUT NOT: genuine missing-required drift inside a preprocess-wrapped
+  // nested object is still flagged. The fix must restore visibility into the
+  // wrapped subtree without silencing legitimate findings.
+  it("BUT NOT: missing required field inside preprocess-wrapped nested object is still flagged", () => {
+    const schema = z
+      .object({
+        config: z.preprocess((v) => v, z.object({ required: z.string(), opt: z.string().optional() }).strip()),
+      })
+      .strip();
+    const diff = diffSchema(schema, { config: {} });
+    expect(diff.missing_fields.map((m) => m.field)).toContain("config.required");
+  });
+});

--- a/scripts/contract-probe.ts
+++ b/scripts/contract-probe.ts
@@ -143,12 +143,45 @@ interface EndpointsFile {
 // ---------------------------------------------------------------------------
 
 /**
+ * Pick the structural side of a `ZodPipe` for strictness extraction / nested
+ * descent (#623). Direction is determined by which side holds a `ZodTransform`:
+ *
+ *   - `.transform(fn)` ⇒ `ZodPipe { in: source, out: ZodTransform }` ⇒ `def.in`
+ *   - `z.preprocess(fn, target)` ⇒ `ZodPipe { in: ZodTransform, out: target }` ⇒ `def.out`
+ *   - bare `z.pipe(A, B)` ⇒ neither side is a ZodTransform ⇒ `def.in` by
+ *     convention (the raw response is validated against the input side).
+ *
+ * Returns `null` when no descent target is available (malformed pipe), letting
+ * callers `break` out of their unwrap loop instead of recursing forever.
+ *
+ * Shared by `walkKeys`, `unwrapForDescent`, and `unwrapToObject` to keep the
+ * three unwrap paths in lockstep (helper-parity discipline reasserted from
+ * #620 / #622).
+ */
+function selectPipeStrictnessSide(pipe: z.ZodType): z.ZodType | null {
+  const def = (pipe as unknown as { _zod?: { def?: { in?: unknown; out?: unknown } } })._zod?.def;
+  if (def === undefined) return null;
+  const pipeIn = def.in;
+  const pipeOut = def.out;
+  const inIsTransform = pipeIn instanceof z.ZodTransform;
+  const outIsTransform = pipeOut instanceof z.ZodTransform;
+  // `z.preprocess(fn, target)` — descend the target on `def.out`.
+  if (inIsTransform && !outIsTransform && pipeOut instanceof z.ZodType) return pipeOut;
+  // `.transform(fn)` — descend the source on `def.in`. Also the default for
+  // bare `z.pipe(A, B)` (neither side is a ZodTransform): the input-side is
+  // what the raw payload is validated against.
+  if (pipeIn instanceof z.ZodType) return pipeIn;
+  return null;
+}
+
+/**
  * Extract the field map from a Zod object schema, capturing nullable / optional
  * flags. Unwraps `ZodOptional` / `ZodNullable` / `ZodDefault` / `ZodReadonly`
- * (via the Zod 4 `_zod.def.innerType` chain) and `ZodPipe` (via `_zod.def.in`)
- * iteratively, order-independent, so `.nullable().optional()`,
- * `.default(null)`, `.readonly()`, and `.transform()` chains all classify
- * correctly (#616, #622).
+ * (via the Zod 4 `_zod.def.innerType` chain) and `ZodPipe` (via
+ * direction-aware descent of `_zod.def.in` or `_zod.def.out`) iteratively,
+ * order-independent, so `.nullable().optional()`, `.default(null)`,
+ * `.readonly()`, `.transform()`, and `z.preprocess()` chains all classify
+ * correctly (#616, #622, #623).
  *
  * Schemas not satisfying `instanceof z.ZodObject` should be rejected by the
  * caller before invoking this helper — the function assumes a `.shape` field.
@@ -177,14 +210,25 @@ export function walkKeys(schema: z.ZodObject<z.ZodRawShape>): Map<string, KeySpe
     //                  is not lost when readonly is the outermost or a
     //                  sandwiched wrapper (e.g. `z.array(...).nullable()
     //                  .readonly()`, latent for QuoteSchema.items shape — #622).
-    //   ZodPipe      → `.transform(fn)` produces a pipe whose `in` side is the
-    //                  schema the raw response is validated against; descend
-    //                  into `in` so an upstream `.nullable()` is not lost
-    //                  (e.g. `z.array(...).nullable().transform(...)`, the
-    //                  ClientInvoiceSchema.items shape).
+    //   ZodPipe      → direction-aware (#623). Both `.transform(fn)` and
+    //                  `z.preprocess(fn, target)` produce ZodPipe but with the
+    //                  ZodTransform on opposite sides:
+    //                    - `.transform()` ⇒ `{ in: source, out: ZodTransform }`
+    //                      → descend `def.in` (source carries strictness).
+    //                    - `z.preprocess()` ⇒ `{ in: ZodTransform, out: target }`
+    //                      → descend `def.out` (target carries strictness).
+    //                    - bare `z.pipe(A, B)` (no ZodTransform either side) ⇒
+    //                      descend `def.in` by convention — the raw response
+    //                      is validated against the input side first.
+    //                  Direction-blind descent into `def.in` (the #619 fix's
+    //                  initial shape) was correct for `.transform()` but would
+    //                  silently land on ZodTransform for `z.preprocess()`,
+    //                  short-circuiting the loop and dropping any nested
+    //                  `.nullable()` / `.optional()` on the target schema.
     // Without ZodDefault / ZodReadonly / ZodPipe handling the outermost
     // wrapper short-circuits the loop, leaving both flags false → false-
-    // positive drift (#616) OR upstream strictness silently dropped (#622).
+    // positive drift (#616) OR upstream strictness silently dropped
+    // (#622, #623).
     for (let i = 0; i < 16; i++) {
       if (inner instanceof z.ZodOptional) {
         isOptional = true;
@@ -208,9 +252,9 @@ export function walkKeys(schema: z.ZodObject<z.ZodRawShape>): Map<string, KeySpe
         continue;
       }
       if (inner instanceof z.ZodPipe) {
-        const pipeIn = (inner as unknown as { _zod: { def: { in?: unknown } } })._zod.def.in;
-        if (!(pipeIn instanceof z.ZodType)) break;
-        inner = pipeIn;
+        const next = selectPipeStrictnessSide(inner);
+        if (next === null) break;
+        inner = next;
         continue;
       }
       break;
@@ -334,6 +378,14 @@ function walkDiff(
  * invisible (false-negative class — `.readonly()` is mutability-only, so the
  * wrapper carries no strictness, but descent into the inner type must still
  * happen for diff visibility).
+ *
+ * ZodPipe direction (#623, sibling of #622): direction-aware descent via
+ * {@link selectPipeStrictnessSide} so `.transform(fn)` descends `def.in` (the
+ * source) while `z.preprocess(fn, target)` descends `def.out` (the target).
+ * Pre-fix, the helper unconditionally descended `def.out`, which landed on
+ * `ZodTransform` for `.transform()` chains — neither ZodObject nor ZodArray,
+ * so `walkDiff` treated the field as a leaf and skipped nested-element drift
+ * (latent for `ClientInvoiceSchema.items` shape post-#619).
  */
 function unwrapForDescent(schema: z.ZodType): z.ZodType {
   let inner: z.ZodType = schema;
@@ -347,14 +399,10 @@ function unwrapForDescent(schema: z.ZodType): z.ZodType {
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }
-    const def = (inner as unknown as { _zod?: { def?: { out?: unknown; in?: unknown } } })._zod?.def;
-    if (
-      def !== undefined &&
-      def.out instanceof z.ZodType &&
-      !(inner instanceof z.ZodObject) &&
-      !(inner instanceof z.ZodArray)
-    ) {
-      inner = def.out;
+    if (inner instanceof z.ZodPipe) {
+      const next = selectPipeStrictnessSide(inner);
+      if (next === null) return inner;
+      inner = next;
       continue;
     }
     return inner;
@@ -527,9 +575,10 @@ function resolveSchema(name: string): z.ZodObject<z.ZodRawShape> {
 
 /**
  * Unwrap a Zod schema to its underlying ZodObject through ZodOptional /
- * ZodNullable / ZodDefault / ZodReadonly / ZodPipe (e.g.,
- * `z.preprocess(fn, object)` returns ZodPipe where `out` is the target
- * object). Returns `null` when the schema cannot be reduced to an object.
+ * ZodNullable / ZodDefault / ZodReadonly / ZodPipe (direction-aware via
+ * {@link selectPipeStrictnessSide} — `.transform()` descends `def.in`,
+ * `z.preprocess(fn, object)` descends `def.out`). Returns `null` when the
+ * schema cannot be reduced to an object.
  *
  * ZodDefault unwrap (#620, sibling of #616): a top-level schema declared
  * `z.object({...}).default({...})` wraps the ZodObject in a ZodDefault;
@@ -542,6 +591,14 @@ function resolveSchema(name: string): z.ZodObject<z.ZodRawShape> {
  * the underlying schema is object-shaped. No live production endpoint uses
  * this shape today, but the helper-parity gap is closed here to keep the
  * three unwrap paths in lockstep.
+ *
+ * ZodPipe direction (#623, sibling of #622): pre-fix the helper tried
+ * `def.out` first and only fell back to `def.in` when `def.out` was not a
+ * ZodType. For a top-level `z.object({...}).transform(fn)` schema,
+ * `def.out` was the `ZodTransform` (which IS a ZodType) → the loop landed
+ * on ZodTransform, exhausted its 16-step budget, and returned `null` —
+ * refusing to resolve a schema whose structural side was object-shaped on
+ * `def.in`. Direction-aware descent fixes both shapes symmetrically.
  *
  * Exported for use by the diff/walk pipeline AND by tests verifying schema
  * compatibility before invoking the probe against a live endpoint.
@@ -563,15 +620,10 @@ export function unwrapToObject(schema: z.ZodType): z.ZodObject<z.ZodRawShape> | 
       inner = (inner as unknown as { _zod: { def: { innerType: z.ZodType } } })._zod.def.innerType;
       continue;
     }
-    // ZodPipe (e.g., from z.preprocess(fn, target)) — the target is `.out`
-    const def = (inner as unknown as { _zod?: { def?: { out?: unknown; in?: unknown } } })._zod?.def;
-    if (def !== undefined && def.out instanceof z.ZodType) {
-      inner = def.out;
-      continue;
-    }
-    if (def !== undefined && def.in instanceof z.ZodType) {
-      // Some pipe forms have only `in` — try unwrapping that too as a fallback
-      inner = def.in;
+    if (inner instanceof z.ZodPipe) {
+      const next = selectPipeStrictnessSide(inner);
+      if (next === null) return null;
+      inner = next;
       continue;
     }
     return null;


### PR DESCRIPTION
## Summary

Sibling of #616 / #620 / #622. PR #619 made `walkKeys` descend `ZodPipe` via `_zod.def.in` — correct for `.transform(fn)` which produces `ZodPipe { in: source, out: ZodTransform }`. But `z.preprocess(fn, target)` produces the **opposite** shape: `ZodPipe { in: ZodTransform, out: target }`. A field declared `z.preprocess(fn, z.string().nullable())` would land on `ZodTransform` inside `walkKeys`, short-circuit the loop, and emit a false-positive `strictness_mismatch` for a genuinely-nullable field.

Latent today (no current `@qontoctl/core` schema uses field-level `z.preprocess`) but the same wrapper-short-circuit class as #616 — fix the gap before it lands. Audit (per the #620 helper-parity theme) also surfaced symmetric latent gaps in `unwrapForDescent` and `unwrapToObject`; both fixed here.

Closes #623.

## What changed

Direction selection is now centralized in a new `selectPipeStrictnessSide()` helper shared by all three unwrap paths (helper-parity discipline reasserted from #620 / #622):

| Pipe shape | `def.in` | `def.out` | Descend |
|---|---|---|---|
| `.transform(fn)` | source | `ZodTransform` | `def.in` |
| `z.preprocess(fn, target)` | `ZodTransform` | target | `def.out` |
| bare `z.pipe(A, B)` | A | B | `def.in` (input-side validation convention) |

**`scripts/contract-probe.ts`**:
- New `selectPipeStrictnessSide(pipe)` helper — direction-aware descent target, returns `null` for malformed pipes.
- `walkKeys` ZodPipe branch routes through the new helper.
- `unwrapForDescent` ZodPipe branch routes through the new helper. Pre-fix it unconditionally descended `def.out` → landed on `ZodTransform` for `.transform()` chains → not `ZodObject`/`ZodArray` → falls through as leaf → `walkDiff` skipped nested-element drift inside `ClientInvoiceSchema.items`-shaped fields (latent false-negative).
- `unwrapToObject` ZodPipe branch routes through the new helper. Pre-fix tried `def.out` first and fell back to `def.in` only when `def.out` was NOT a ZodType. `ZodTransform` **is** a ZodType → loop descended to `ZodTransform` → exhausted its 16-step budget → returned `null`, refusing a top-level `z.object({...}).transform(fn)`.
- Docstrings updated to spell out direction-aware semantics on all three helpers.

**`scripts/contract-probe.test.ts`** — +13 regression tests (REQ-D), real introspection, no mocks (#616 REQ-A5 discipline reasserted).

## Acceptance criteria

| AC | Status | Evidence |
|----|--------|----------|
| REQ-D1 `z.preprocess(fn, …nullable())` ⇒ nullable | ✅ | RED pre-fix; unit test |
| REQ-D1 `z.preprocess(fn, …nullable().optional().default(null))` ⇒ both flags | ✅ | RED pre-fix; unit test |
| REQ-D1 `.array().nullable().transform()` regression guard | ✅ | unit test |
| REQ-D1 bare `z.pipe(A, B)` descends def.in convention | ✅ | unit test |
| REQ-D2 top-level `z.preprocess(fn, z.object())` resolves | ✅ | regression guard; unit test |
| REQ-D2 top-level `z.object().transform(fn)` resolves | ✅ | RED pre-fix; unit test |
| REQ-D2 bare top-level `z.pipe(obj, obj)` resolves | ✅ | unit test |
| REQ-D3 nested `z.preprocess(fn, z.object())` extras surface | ✅ | regression guard; unit test |
| REQ-D3 nested `z.object().transform(fn)` extras surface | ✅ | RED pre-fix; unit test |
| REQ-D3 nested `z.array(…).transform(fn)` element extras surface | ✅ | RED pre-fix; unit test |
| BUT NOT 1: non-nullable preprocessed `null` still flagged | ✅ | guard test |
| BUT NOT 2: top-level `z.preprocess(fn, z.array(…))` still returns null | ✅ | guard test |
| BUT NOT 3: missing required in preprocess-wrapped nested still flagged | ✅ | guard test |

**RED→GREEN verified**: reverting just the production-code fix (keeping tests) → 5/13 new tests fail pre-fix → all 13 pass post-fix. Full suite: **68/68 contract-probe tests pass** (55 prior + 13 new).

## Test plan

- [x] `pnpm contract-probe-test` → 68/68 passed
- [x] `pnpm exec tsc -p scripts/tsconfig.json` → exit 0 (strict)
- [x] `pnpm format:check` → all files clean
- [x] `pnpm lint` → 8/8 turbo tasks pass
- [x] RED→GREEN verified by reverting `contract-probe.ts` only and re-running tests
- [ ] CI green on this PR (including the `contract-probe-test` step from PR #619)

🤖 Generated with [Claude Code](https://claude.com/claude-code)