### PR TITLE
(chore) prepack: stop overwriting umbrella README with root README (#618)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`qontoctl` (umbrella)**: stop overwriting the committed `packages/qontoctl/README.md` with the root `README.md` at pack time. The umbrella's `prepack` previously ran `cp ../../README.md ../../LICENSE .`, which silently discarded the detailed npm-facing README authored in #637 (full feature list including Cards, Webhooks, Payment Links, Insurance, International Transfers, plus the comprehensive MCP tools table) on every `pnpm pack` / `npm publish`. The committed file is now authoritative; npm visitors get the rich detail instead of the slim project-landing README. Local `pnpm pack` in `packages/qontoctl/` no longer leaves a dirty working tree. Matches the pattern already used by `core`, `cli`, and `mcp` (which only `cp ../../LICENSE .`) (#618).
+
 ## [2.0.2] — 2026-05-18
 
 ### Added

--- a/packages/qontoctl/package.json
+++ b/packages/qontoctl/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
-    "prepack": "cp ../../README.md ../../LICENSE .",
+    "prepack": "cp ../../LICENSE .",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- Umbrella package's `prepack` was overwriting the committed detailed `packages/qontoctl/README.md` (622 lines — Cards/Webhooks/Payment Links/Insurance/International Transfers + full MCP tools table, authored in #637) with the slim root `README.md` (557 lines, project landing page) at every `pnpm pack` / `npm publish`. The detailed content never reached npm visitors.
- Drop `README.md` from the prepack `cp` (keep `LICENSE`). The committed `packages/qontoctl/README.md` becomes authoritative — npm includes it automatically; the deploy/pack flow propagates it correctly; local `pnpm pack` no longer dirties the working tree. Aligns with the pattern already used by `core`, `cli`, `mcp` (all `cp ../../LICENSE .` only).

## Decision rationale

Picked **Option B** (promote committed detailed README) over A (delete+gitignore) and C (generate at prepack), per the issue's options table:

- `npm view qontoctl@2.0.2 readme` confirmed the slim root README is currently shipping
- The committed umbrella README uniquely carries 8 feature areas (Cards, Teams, Webhooks, Payment Links, Insurance, International Transfers, Requests, expanded Bulk/Recurring Transfers) PLUS the comprehensive MCP tools table that the root README does NOT have — Option A would have lost this from npm
- Sync cost concern is mitigated: root and umbrella READMEs serve different audiences (GitHub project landing vs npm package detail) and can legitimately differ

## Verification

- ✅ `pnpm pack` in `packages/qontoctl/` produces a tarball whose `package/README.md` is byte-identical to the committed file (622 lines, Cards section present)
- ✅ Post-pack `git status` is clean for `packages/qontoctl/README.md` (BUT NOT clause from AC satisfied)
- ✅ End-to-end release-runbook §1.5 deploy/pack flow (`pnpm deploy --filter=./packages/qontoctl --prod .tmp/qontoctl-deploy` + `pnpm pack`) produces correct tarball; working tree stays clean
- ✅ Lint + typecheck (8/8 each), 789 unit tests, coverage-drift, license-check (100 prod deps, allowed licenses only), prettier `format:check` — all green
- ✅ No stale references to old `cp ../../README` behavior in `docs/`, `scripts/`, `.github/`

Closes #618.

## Test plan

- [ ] CI green (lint, typecheck, tests, coverage-drift, license-check, format:check across ubuntu/macos/windows)
- [ ] Local `pnpm pack` in `packages/qontoctl/` produces correct tarball (verified locally — bundleDependencies resolved against built `dist/`)
- [ ] release-runbook §1.5 deploy/pack flow remains clean (verified locally end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)