### PR TITLE
(docs) annotate --auth default oauth-first in --help (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`@qontoctl/cli`**: `qontoctl --help` now annotates the `--auth` flag with `(default: "oauth-first")`, mirroring the existing `-o, --output (default: "table")` annotation. Previously the default was discoverable only via `qontoctl diagnose` (which reports `authMode: "oauth-first"` in its evidence block) — users running `--help` saw only the choices list with no indication which mode applied when the flag was omitted. The description text also gains a semantic crib (`*-first modes fall back when primary is unavailable`) so the distinction between bare-mode and `*-first` mode is visible at the flag level. Applied at all three `--auth` option-definition sites (`program.ts`, `inherited-options.ts`, `commands/diagnose.ts`). The `diagnose` command's `--auth` Option also gains a `.choices([...AUTH_PREFERENCES])` call — the previous description text inlined the valid values, and the new format delegates rendering to Commander, so this restores the `(choices: ...)` enumeration in `qontoctl diagnose --help` (parity with the other two sites; mode-name typos now rejected at parse time at this site too). `program.opts().auth` continues to resolve to `undefined` when the flag is omitted, preserving the `CLI flag > env > config > built-in default` precedence chain in `resolveAuthPreference` (#631).
+
 ## [2.0.3] — 2026-05-20
 
 ### Added

--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 import type { Command } from "commander";
 import { Option } from "commander";
 import {
+  AUTH_PREFERENCES,
   buildDiagnoseClients,
   buildRedactionContext,
   resolveAuthPreference,
@@ -73,8 +74,8 @@ export function registerDiagnoseCommand(program: Command): void {
     .addOption(
       new Option(
         "--auth <mode>",
-        "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
-      ),
+        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
+      ).choices([...AUTH_PREFERENCES]),
     );
 
   diagnose.action(async (_options: unknown, cmd: Command) => {

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -31,7 +31,7 @@ export function addInheritableOptions(cmd: Command): Command {
     .addOption(
       new Option(
         "--auth <mode>",
-        "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
+        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
       ).choices([...AUTH_PREFERENCES]),
     );
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -56,7 +56,7 @@ export function createProgram(): Command {
     .addOption(
       new Option(
         "--auth <mode>",
-        "authentication precedence: api-key (only), api-key-first, oauth (only), or oauth-first",
+        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
       ).choices([...AUTH_PREFERENCES]),
     );
 


### PR DESCRIPTION
## Summary

Refs #631 — arm 2 of 4 (does NOT close). Surfaces the `--auth` flag default in `qontoctl --help` so users running `--help` can see `(default: "oauth-first")` parallel to the existing `-o, --output (default: "table")` annotation. Previously the default was discoverable only via `qontoctl diagnose` (which reports `authMode: "oauth-first"` in its evidence block).

The description text also gains a semantic crib (`*-first modes fall back when primary is unavailable`) so the bare-mode vs `*-first` mode distinction is visible at the flag level — addressing the help-output gap from issue #631 § (e).

Display-only at the program + inherited-options sites. At the `diagnose` site, `.choices([...AUTH_PREFERENCES])` is also added (parity with the other two sites; restores `(choices: ...)` enumeration that was previously inlined in the description text — see Phase 0.0 finding below).

## Scope of this PR

This is **PR1 of a 2-PR plan from `/council`** convened on #631. **Out of scope** for this PR (deferred to PR2 / a separate `/do` invocation):

- Arm 1 of #631: widen the fallback gate in `packages/core/src/http-client.ts:476` from `OAuthRefreshError`-only to a typed `OAuthNoTokenError` (or equivalent) so the no-access-token-at-request-time case engages the fallback Authorization wired by `selectAuthChain` (currently the `AuthError` thrown at `packages/core/src/auth/oauth.ts:14-20` propagates fatally and the wired fallback never fires).
- Arm 3 of #631: symmetric question for `api-key-first` when api-key credentials are misconfigured at request time (encoded structurally in `selectAuthChain` via a new `fatal?` field per security-architect's invariant).
- Arm 4 of #631: error-message UX fix for the misleading "Verify your API key credentials" secondary line.
- E2E coverage for the four failure modes.

#631 stays open after this merges. A `/wrapup` comment will note arm 2 addressed; remaining arms 1, 3, 4 tracked on the original issue.

## What changed

| File | Change |
|---|---|
| `packages/cli/src/program.ts:56-61` | Description string updated to embed `(default: "oauth-first")` + semantic crib. `.choices([...AUTH_PREFERENCES])` unchanged (already present). |
| `packages/cli/src/inherited-options.ts:31-36` | Same description update. `.choices()` unchanged (already present). |
| `packages/cli/src/commands/diagnose.ts:73-78` | Same description update + `.choices([...AUTH_PREFERENCES])` ADDED (pre-existing structural asymmetry — diagnose redefines its globals inline rather than calling `addInheritableOptions(...)`, and never had `.choices()`. The previous description string inlined the valid mode names; the new description delegates rendering to Commander, so the missing `.choices()` would otherwise silently drop `(choices: ...)` from `qontoctl diagnose --help`). |
| `packages/cli/src/commands/diagnose.ts:7-15` | Add `AUTH_PREFERENCES` to the `@qontoctl/core` import block. |
| `CHANGELOG.md` | New entry under `[Unreleased]` § Changed with full rationale (3 sites + diagnose `.choices()` addition). |

## Why this approach (not `.default()`)

Commander v14's `Option.default(value, description)` API sets BOTH `defaultValue` (runtime injection) AND `defaultValueDescription` (display). Two rejected alternatives:

- **`.default("oauth-first")`** (runtime inject) — would break `resolveAuthPreference` precedence at `packages/core/src/auth/preference.ts:42` (`override !== undefined` becomes true on the injected default, bypassing the config/env/built-in-default layers). The `CLI flag > env > config > default` precedence chain requires `opts.auth` to remain `undefined` when the flag is omitted.
- **`.default(undefined, '"oauth-first"')`** (display-only) — empirically verified NOT to render. Commander v14's help formatter requires `defaultValue !== undefined` before rendering `defaultValueDescription`. `pnpm build` + `node packages/qontoctl/dist/cli.js --help` showed choices but NO default annotation.

Embedding the default in the description text is the workable display-only path that preserves `opts.auth === undefined`.

## Phase 0.0 polish-gate finding (iter 1)

The fresh-context polish gate caught a regression-by-omission in the initial commit (`3db8dbd`): the previous description string at `diagnose.ts` literally enumerated the valid mode names; the new description delegates rendering to Commander but `diagnose.ts` never called `.choices()`. Net effect would have been that `qontoctl diagnose --help` silently dropped the choices enumeration — a real user-visible help quality regression in the command self-described as "first command to try when something doesn't work."

Fix (`7176b5c`): add `.choices([...AUTH_PREFERENCES])` to the diagnose `--auth` Option, mirroring the other two sites. Phase 0.0 iter 2 → 🟢 CLEAN.

## Verification

- [x] `pnpm build` — 5 packages, tsc strict, clean
- [x] `pnpm format:check` — clean (CI's first matrix step)
- [x] `pnpm lint` — 8 packages clean
- [x] `pnpm --filter @qontoctl/cli test` — 789 tests passed
- [x] `node packages/qontoctl/dist/cli.js --help` — renders `(default: "oauth-first") ... (choices: ...)`
- [x] `node packages/qontoctl/dist/cli.js org show --help` (subcommand via inherited-options) — renders the same annotation
- [x] `node packages/qontoctl/dist/cli.js diagnose --help` — renders BOTH `(default: "oauth-first")` AND `(choices: "api-key", "api-key-first", "oauth", "oauth-first")` (post-`.choices()` fix)
- [x] Fresh-context polish gate (Phase 0.0) — 🟢 CLEAN on iteration 2
- [x] Repo-wide grep for `authentication precedence` old text — only the 4 in-scope files matched; no test snapshots reference the old description string
- [N/A] E2E suite — this PR is NOT E2E-touching (no E2E test exercises `--auth` flag rendering or `qontoctl --help`/`diagnose --help` text)

## Test plan

- [x] Build + unit + format + lint locally green
- [ ] CI green on this PR (3-OS matrix + CI gate + license-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)