### PR TITLE
(refactor) template-interpolate DEFAULT_AUTH_PREFERENCE in --auth description text

### DIFF
--- a/packages/cli/src/commands/diagnose.ts
+++ b/packages/cli/src/commands/diagnose.ts
@@ -8,6 +8,7 @@ import {
   AUTH_PREFERENCES,
   buildDiagnoseClients,
   buildRedactionContext,
+  DEFAULT_AUTH_PREFERENCE,
   resolveAuthPreference,
   resolveConfig,
   runDiagnose,
@@ -74,7 +75,7 @@ export function registerDiagnoseCommand(program: Command): void {
     .addOption(
       new Option(
         "--auth <mode>",
-        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
+        `authentication precedence (default: "${DEFAULT_AUTH_PREFERENCE}"); *-first modes fall back when primary is unavailable`,
       ).choices([...AUTH_PREFERENCES]),
     );
 

--- a/packages/cli/src/inherited-options.ts
+++ b/packages/cli/src/inherited-options.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { join, resolve as resolvePath } from "node:path";
 import type { Command } from "commander";
 import { Option } from "commander";
-import { AUTH_PREFERENCES } from "@qontoctl/core";
+import { AUTH_PREFERENCES, DEFAULT_AUTH_PREFERENCE } from "@qontoctl/core";
 import type { GlobalOptions } from "./options.js";
 
 /**
@@ -31,7 +31,7 @@ export function addInheritableOptions(cmd: Command): Command {
     .addOption(
       new Option(
         "--auth <mode>",
-        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
+        `authentication precedence (default: "${DEFAULT_AUTH_PREFERENCE}"); *-first modes fall back when primary is unavailable`,
       ).choices([...AUTH_PREFERENCES]),
     );
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 import { Command, Option } from "commander";
-import { AUTH_PREFERENCES } from "@qontoctl/core";
+import { AUTH_PREFERENCES, DEFAULT_AUTH_PREFERENCE } from "@qontoctl/core";
 import { registerCompletionCommand } from "./completions/index.js";
 import { registerBeneficiaryCommands } from "./commands/beneficiary/index.js";
 import { registerCardCommands } from "./commands/card/index.js";
@@ -56,7 +56,7 @@ export function createProgram(): Command {
     .addOption(
       new Option(
         "--auth <mode>",
-        'authentication precedence (default: "oauth-first"); *-first modes fall back when primary is unavailable',
+        `authentication precedence (default: "${DEFAULT_AUTH_PREFERENCE}"); *-first modes fall back when primary is unavailable`,
       ).choices([...AUTH_PREFERENCES]),
     );
 


### PR DESCRIPTION
## Summary

Replace the hard-coded string literal `"oauth-first"` in the three `--auth` Option description-text sites with a template-literal interpolation of `DEFAULT_AUTH_PREFERENCE` (exported from `@qontoctl/core`). Eliminates drift risk between help text and the canonical constant.

Sites updated:

- `packages/cli/src/program.ts:59` — program-level `--help`
- `packages/cli/src/inherited-options.ts:34` — subcommand inherited `--help`
- `packages/cli/src/commands/diagnose.ts:78` — diagnose-specific `--help`

## Why

`DEFAULT_AUTH_PREFERENCE` at `packages/core/src/config/types.ts:84` is the single source of truth for the auth default. Its TSDoc anticipates a future flip as "a separate major-release decision gated on telemetry." If the constant flipped, help text would silently lie until each site was hand-updated.

Surfaced as 🟢 S1 by the Phase 2.9 fresh-context external review on #632 (`--auth` default annotation arm 2 of #631). Reviewer recommendation was "defer to a separate polish PR" to keep #631 narrowly focused; this is that PR.

## What's preserved

- Display output is identical at the current constant value (`"oauth-first"`).
- `.choices([...AUTH_PREFERENCES])` validation unchanged.
- `AuthPreference` union and `AUTH_PREFERENCES` const unchanged.
- No behavior change anywhere — display-only refactor.

## Acceptance criteria — all 4 verified

- [x] **AC-1** — Zero literal `"oauth-first"` remains in `--auth` description text. All 3 sites use `` `(default: "${DEFAULT_AUTH_PREFERENCE}")` `` template-literal interpolation; each imports `DEFAULT_AUTH_PREFERENCE` from `@qontoctl/core`.
- [x] **AC-2** — `qontoctl --help`, `qontoctl org show --help`, and `qontoctl diagnose --help` all render `(default: "oauth-first")` (current constant value). `diagnose --help` also shows `(choices: "api-key", "api-key-first", "oauth", "oauth-first")` as before.
- [x] **AC-3** — Drift-prevention verified bidirectionally. Flipping `DEFAULT_AUTH_PREFERENCE` to `"api-key"`, rebuilding, and re-running each `--help` invocation renders `(default: "api-key")` at all 3 sites. Reverting restores `(default: "oauth-first")`.
- [x] **AC-4** — `pnpm format:check`, `pnpm lint`, `pnpm test` all clean. 2417 unit tests pass across all 4 packages.

## Test plan

- [x] `pnpm build` — 5/5 tasks successful.
- [x] `pnpm format:check` — clean.
- [x] `pnpm lint` — 8/8 tasks successful.
- [x] `pnpm test` — 2417/2417 passing.
- [x] Help-render checks at program-level, subcommand (via inherited-options), and `diagnose` — all render the current constant value.
- [x] Drift-test: flip → rebuild → verify → revert → rebuild → verify.

## Out of scope

- Restructuring `AUTH_PREFERENCES` or the `AuthPreference` union — keep as-is.
- Documentation of `DEFAULT_AUTH_PREFERENCE` itself — already documented at `docs/configuration.md` § Authentication precedence.
- JSDoc reference at `packages/cli/src/options.ts:55` mentioning `(oauth-first)` in field-level TSDoc — developer-internal, not user-facing help text. Could be a follow-up.

## Related

- Closes #633.
- Follow-up to #632 (Phase 2.9 reviewer note).
- Builds on #631 (substantive `--auth` architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)