### PR TITLE
(feat) introduce core/quotes service + typed send payload schemas; breaking sendClientInvoice (#637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`@qontoctl/core`**: new `packages/core/src/quotes/` service-layer module — `sendQuote(client, id, payload): Promise<void>` issues `POST /v2/quotes/{id}/send` with the JSON-serialised payload as the request body. Establishes the service seam quotes previously lacked (the existing `quote_list` / `quote_create` etc. MCP tools and CLI commands called `HttpClient.requestVoid` / `HttpClient.get` directly), bringing quotes into structural parity with `client-invoices/`. Foundation for #638 (which wires the MCP `quote_send` tool + CLI `quote send` command through this service to close the historical `quote_send` HTTP 422 `invalid_body: EOF` bug). The Qonto API contract requires `send_to` and `email_title`; `copy_to_self` defaults to `true` server-side and `email_body` is optional (#637).
+- **`@qontoctl/core`**: `SendQuoteRequestPayload` TS type + `SendQuoteRequestPayloadSchema` Zod schema, mirroring the Qonto OpenAPI `SendQuoteRequestPayload` shape exactly (`send_to: string[]`, `copy_to_self: boolean` with schema-level `.default(true)`, `email_title: string`, optional `email_body: string`). Unknown fields stripped on parse. No additional client-side validation (`min(1)` etc.) is layered at the core boundary — those belong to the MCP-tool / CLI-command inputSchemas that wrap this schema (see #638, #639). Both type and schema exported from `@qontoctl/core` (#637).
+- **`@qontoctl/core`**: `SendClientInvoiceRequestPayload` TS type + `SendClientInvoiceRequestPayloadSchema` Zod schema — identical shape to the quotes-side payload, since both endpoints accept the same OpenAPI `SendRequestPayload` schema. Both type and schema exported from `@qontoctl/core` (#637).
+
+### Changed
+
+- **`@qontoctl/core`**: **BREAKING** — `sendClientInvoice(client, id)` is now `sendClientInvoice(client, id, payload: SendClientInvoiceRequestPayload)`. Earlier versions called `POST /v2/client_invoices/{id}/send` with no body, which the Qonto API rejects with HTTP 422 `invalid_body: EOF` — the parallel-bug class to the `quote_send` 422/EOF surfaced during the #636 investigation. The new signature accepts the payload required by the Qonto contract; consumers must adjust call sites to provide `send_to` and `email_title` at minimum. TypeScript surfaces a compile error at the prior call shape, making the migration mechanical. The internal MCP tool (`client_invoice_send`) and CLI command (`client-invoice send`) call sites are temporarily wired with placeholder payloads to keep this PR compile-green; #639 lands the proper end-user flag wiring + migration guide (#637).
+
 ## [2.0.4] — 2026-05-22
 
 ### Added

--- a/packages/cli/src/commands/client-invoice.ts
+++ b/packages/cli/src/commands/client-invoice.ts
@@ -256,7 +256,13 @@ export function createClientInvoiceCommand(): Command {
     const opts = resolveGlobalOptions<GlobalOptions>(cmd);
     const client = await createClient(opts);
 
-    await sendClientInvoice(client, id);
+    // TODO(#639): expose `--to <email...>` / `--title <subject>` /
+    // `--body <text>` / `--no-copy-self` flags and forward them as the payload.
+    // The placeholder below keeps the breaking sendClientInvoice signature
+    // (introduced in #637) compile-green; runtime behaviour is already broken
+    // (HTTP 422 from Qonto for an effectively-empty send), and #639 lands the
+    // proper wiring + E2E triage sharpening.
+    await sendClientInvoice(client, id, { send_to: [], copy_to_self: true, email_title: "" });
 
     if (opts.output === "json" || opts.output === "yaml") {
       process.stdout.write(formatOutput({ sent: true, id }, opts.output) + "\n");

--- a/packages/core/src/client-invoices/index.ts
+++ b/packages/core/src/client-invoices/index.ts
@@ -28,6 +28,7 @@ export type {
   ClientInvoiceClient,
   ClientInvoiceUpload,
   CreateClientInvoiceParams,
+  SendClientInvoiceRequestPayload,
   UpdateClientInvoiceParams,
   ListClientInvoicesParams,
 } from "./types.js";
@@ -42,4 +43,5 @@ export {
   ClientInvoiceSchema,
   ClientInvoiceResponseSchema,
   ClientInvoiceListResponseSchema,
+  SendClientInvoiceRequestPayloadSchema,
 } from "./schemas.js";

--- a/packages/core/src/client-invoices/schemas.test.ts
+++ b/packages/core/src/client-invoices/schemas.test.ts
@@ -12,6 +12,7 @@ import {
   ClientInvoiceClientSchema,
   ClientInvoiceUploadSchema,
   ClientInvoiceSchema,
+  SendClientInvoiceRequestPayloadSchema,
 } from "./schemas.js";
 
 describe("ClientInvoiceAmountSchema", () => {
@@ -444,6 +445,69 @@ describe("ClientInvoiceAddressSchema (#601 L2 audit)", () => {
       expect(() => ClientInvoiceAddressSchema.parse(input)).not.toThrow();
     },
   );
+});
+
+describe("SendClientInvoiceRequestPayloadSchema", () => {
+  it("parses a valid payload (all four fields)", () => {
+    const data = {
+      send_to: ["a@example.com", "b@example.com"],
+      copy_to_self: false,
+      email_title: "Invoice for ACME",
+      email_body: "Please find the attached invoice.",
+    };
+    expect(SendClientInvoiceRequestPayloadSchema.parse(data)).toEqual(data);
+  });
+
+  it("applies default copy_to_self=true when omitted; email_body remains optional", () => {
+    const result = SendClientInvoiceRequestPayloadSchema.parse({
+      send_to: ["a@example.com"],
+      email_title: "Invoice for ACME",
+    });
+    expect(result.copy_to_self).toBe(true);
+    expect(result.email_body).toBeUndefined();
+  });
+
+  it("rejects payload missing send_to with a ZodError citing the send_to path", () => {
+    let captured: unknown;
+    try {
+      SendClientInvoiceRequestPayloadSchema.parse({ email_title: "X" });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(z.ZodError);
+    const zodError = captured as z.ZodError;
+    expect(zodError.issues.some((issue) => issue.path[0] === "send_to")).toBe(true);
+  });
+
+  it("rejects payload missing email_title with a ZodError citing the email_title path", () => {
+    let captured: unknown;
+    try {
+      SendClientInvoiceRequestPayloadSchema.parse({ send_to: ["a@example.com"] });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(z.ZodError);
+    const zodError = captured as z.ZodError;
+    expect(zodError.issues.some((issue) => issue.path[0] === "email_title")).toBe(true);
+  });
+
+  it("rejects payload with a non-email string in send_to", () => {
+    expect(() =>
+      SendClientInvoiceRequestPayloadSchema.parse({
+        send_to: ["not-an-email"],
+        email_title: "X",
+      }),
+    ).toThrow();
+  });
+
+  it("strips unknown fields", () => {
+    const result = SendClientInvoiceRequestPayloadSchema.parse({
+      send_to: ["a@example.com"],
+      email_title: "X",
+      bogus_extra: "should be stripped",
+    });
+    expect(result).not.toHaveProperty("bogus_extra");
+  });
 });
 
 describe("ClientInvoiceClientSchema (#601 L2 audit)", () => {

--- a/packages/core/src/client-invoices/schemas.ts
+++ b/packages/core/src/client-invoices/schemas.ts
@@ -211,3 +211,39 @@ export const ClientInvoiceListResponseSchema = z
     meta: PaginationMetaSchema,
   })
   .strip();
+
+/**
+ * Zod schema for the `POST /v2/client_invoices/{id}/send` request body.
+ *
+ * Mirrors the Qonto OpenAPI `SendClientInvoiceRequestPayload` shape exactly:
+ *
+ * ```yaml
+ * SendClientInvoiceRequestPayload:
+ *   type: object
+ *   required: [send_to, email_title]
+ *   properties:
+ *     send_to:      { type: array, items: { type: string, format: email } }
+ *     copy_to_self: { type: boolean, default: true }
+ *     email_title:  { type: string }
+ *     email_body:   { type: string }
+ * ```
+ *
+ * Identical shape to the quotes-side `SendQuoteRequestPayloadSchema`.
+ * `copy_to_self` applies the documented server-side default on parse so
+ * consumers may omit it. No additional client-side validation (e.g.
+ * non-empty `send_to`, non-empty `email_title`) is layered here — those
+ * constraints belong to the MCP-tool / CLI-command boundaries that wrap
+ * this schema (see #639).
+ *
+ * Unknown fields are stripped on parse to keep request bodies minimal.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices/send-a-client-invoice.md
+ */
+export const SendClientInvoiceRequestPayloadSchema = z
+  .object({
+    send_to: z.array(z.email()),
+    copy_to_self: z.boolean().default(true),
+    email_title: z.string(),
+    email_body: z.string().optional(),
+  })
+  .strip();

--- a/packages/core/src/client-invoices/service.test.ts
+++ b/packages/core/src/client-invoices/service.test.ts
@@ -426,20 +426,33 @@ describe("sendClientInvoice", () => {
     vi.restoreAllMocks();
   });
 
-  it("sends a client invoice via POST", async () => {
+  it("sends a client invoice via POST with the JSON-serialised payload and Content-Type application/json", async () => {
     fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
 
-    await sendClientInvoice(client, "inv-1");
+    const payload = {
+      send_to: ["a@example.com", "b@example.com"],
+      copy_to_self: true,
+      email_title: "Invoice for ACME",
+      email_body: "Please find the attached invoice.",
+    };
+    await sendClientInvoice(client, "inv-1", payload);
 
     const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/v2/client_invoices/inv-1/send");
     expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body as string)).toEqual(payload);
+    const headers = new Headers(opts.headers as HeadersInit);
+    expect(headers.get("content-type")).toBe("application/json");
   });
 
   it("encodes special characters in the ID", async () => {
     fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
 
-    await sendClientInvoice(client, "a/b");
+    await sendClientInvoice(client, "a/b", {
+      send_to: ["a@example.com"],
+      copy_to_self: true,
+      email_title: "X",
+    });
 
     const [url] = fetchSpy.mock.calls[0] as [URL];
     expect(url.pathname).toBe("/v2/client_invoices/a%2Fb/send");

--- a/packages/core/src/client-invoices/service.ts
+++ b/packages/core/src/client-invoices/service.ts
@@ -11,6 +11,7 @@ import type {
   ClientInvoiceUpload,
   CreateClientInvoiceParams,
   ListClientInvoicesParams,
+  SendClientInvoiceRequestPayload,
   UpdateClientInvoiceParams,
 } from "./types.js";
 const ClientInvoiceUploadResponseSchema = z.object({ upload: ClientInvoiceUploadSchema });
@@ -131,9 +132,31 @@ export async function finalizeClientInvoice(client: HttpClient, id: string): Pro
 
 /**
  * Send a client invoice to the client via email.
+ *
+ * BREAKING (#637): this function requires a third `payload` argument
+ * (see {@link SendClientInvoiceRequestPayload}). Earlier versions called
+ * `POST .../send` with no body, which the Qonto API rejected with HTTP 422
+ * `invalid_body: EOF` — the parallel-bug class to #636 arm 1 on the quotes
+ * side. Consumers must adjust call sites to provide `send_to` and
+ * `email_title` at minimum; see the migration note shipped with #639.
+ *
+ * Issues `POST /v2/client_invoices/{id}/send` with the payload serialised as
+ * the JSON request body. The HTTP client sets `Content-Type:
+ * application/json` automatically because the request carries a body (see
+ * `http-client.ts#buildHeaders`). Validation against
+ * {@link SendClientInvoiceRequestPayload} is the caller's responsibility —
+ * this service passes the payload through verbatim to keep request shaping
+ * at the call site (MCP tool / CLI command) where the end-user-facing error
+ * surface lives.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices/send-a-client-invoice.md
  */
-export async function sendClientInvoice(client: HttpClient, id: string): Promise<void> {
-  await client.requestVoid("POST", `/v2/client_invoices/${encodeURIComponent(id)}/send`);
+export async function sendClientInvoice(
+  client: HttpClient,
+  id: string,
+  payload: SendClientInvoiceRequestPayload,
+): Promise<void> {
+  await client.requestVoid("POST", `/v2/client_invoices/${encodeURIComponent(id)}/send`, { body: payload });
 }
 
 /**

--- a/packages/core/src/client-invoices/types.ts
+++ b/packages/core/src/client-invoices/types.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import type { z } from "zod";
+
+import type { SendClientInvoiceRequestPayloadSchema } from "./schemas.js";
+
 /**
  * An amount with value and currency as returned by the Qonto API.
  */
@@ -209,6 +213,26 @@ export interface UpdateClientInvoiceParams {
   readonly items?: readonly ClientInvoiceItemParams[] | undefined;
   readonly discount?: ClientInvoiceDiscountParams | undefined;
 }
+
+/**
+ * Payload for `POST /v2/client_invoices/{id}/send`.
+ *
+ * Identical shape to `SendQuoteRequestPayload` — both endpoints accept the
+ * same OpenAPI `SendRequestPayload` schema (`send_to`, `copy_to_self`,
+ * `email_title`, `email_body`).
+ *
+ * Inferred from {@link SendClientInvoiceRequestPayloadSchema} via `z.infer`,
+ * so the type reflects the schema's POST-PARSE shape. In particular,
+ * `copy_to_self` carries the schema's `.default(true)` and is therefore
+ * required at the TS layer even though the API treats it as optional with
+ * a documented server default of `true`. Direct callers may pass
+ * `copy_to_self: true` explicitly, or run the input through
+ * `SendClientInvoiceRequestPayloadSchema.parse(...)` to have the default
+ * materialised.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/client-invoices/send-a-client-invoice.md
+ */
+export type SendClientInvoiceRequestPayload = z.infer<typeof SendClientInvoiceRequestPayloadSchema>;
 
 /**
  * Parameters for listing client invoices.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -300,6 +300,7 @@ export type {
   ClientInvoiceClient,
   ClientInvoiceUpload,
   CreateClientInvoiceParams,
+  SendClientInvoiceRequestPayload,
   UpdateClientInvoiceParams,
   ListClientInvoicesParams,
 } from "./client-invoices/index.js";
@@ -314,7 +315,12 @@ export {
   ClientInvoiceSchema,
   ClientInvoiceResponseSchema,
   ClientInvoiceListResponseSchema,
+  SendClientInvoiceRequestPayloadSchema,
 } from "./client-invoices/index.js";
+
+export { sendQuote } from "./quotes/index.js";
+export type { SendQuoteRequestPayload } from "./quotes/index.js";
+export { SendQuoteRequestPayloadSchema } from "./quotes/index.js";
 
 export {
   listWebhooks,

--- a/packages/core/src/quotes/index.ts
+++ b/packages/core/src/quotes/index.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+export { sendQuote } from "./service.js";
+
+export type { SendQuoteRequestPayload } from "./types.js";
+
+export { SendQuoteRequestPayloadSchema } from "./schemas.js";

--- a/packages/core/src/quotes/schemas.test.ts
+++ b/packages/core/src/quotes/schemas.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+
+import { SendQuoteRequestPayloadSchema } from "./schemas.js";
+
+describe("SendQuoteRequestPayloadSchema", () => {
+  it("parses a valid payload (all four fields)", () => {
+    const data = {
+      send_to: ["a@example.com", "b@example.com"],
+      copy_to_self: false,
+      email_title: "Your quote",
+      email_body: "Please find the attached quote.",
+    };
+    expect(SendQuoteRequestPayloadSchema.parse(data)).toEqual(data);
+  });
+
+  it("applies default copy_to_self=true when omitted; email_body remains optional", () => {
+    const result = SendQuoteRequestPayloadSchema.parse({
+      send_to: ["a@example.com"],
+      email_title: "Your quote",
+    });
+    expect(result.copy_to_self).toBe(true);
+    expect(result.email_body).toBeUndefined();
+  });
+
+  it("rejects payload missing send_to with a ZodError citing the send_to path", () => {
+    let captured: unknown;
+    try {
+      SendQuoteRequestPayloadSchema.parse({ email_title: "X" });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(z.ZodError);
+    const zodError = captured as z.ZodError;
+    expect(zodError.issues.some((issue) => issue.path[0] === "send_to")).toBe(true);
+  });
+
+  it("rejects payload missing email_title with a ZodError citing the email_title path", () => {
+    let captured: unknown;
+    try {
+      SendQuoteRequestPayloadSchema.parse({ send_to: ["a@example.com"] });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(z.ZodError);
+    const zodError = captured as z.ZodError;
+    expect(zodError.issues.some((issue) => issue.path[0] === "email_title")).toBe(true);
+  });
+
+  it("rejects payload with a non-email string in send_to", () => {
+    expect(() =>
+      SendQuoteRequestPayloadSchema.parse({
+        send_to: ["not-an-email"],
+        email_title: "X",
+      }),
+    ).toThrow();
+  });
+
+  it("strips unknown fields", () => {
+    const result = SendQuoteRequestPayloadSchema.parse({
+      send_to: ["a@example.com"],
+      email_title: "X",
+      bogus_extra: "should be stripped",
+    });
+    expect(result).not.toHaveProperty("bogus_extra");
+  });
+});

--- a/packages/core/src/quotes/schemas.ts
+++ b/packages/core/src/quotes/schemas.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { z } from "zod";
+
+/**
+ * Zod schema for the `POST /v2/quotes/{id}/send` request body.
+ *
+ * Mirrors the Qonto OpenAPI `SendQuoteRequestPayload` shape exactly:
+ *
+ * ```yaml
+ * SendQuoteRequestPayload:
+ *   type: object
+ *   required: [send_to, email_title]
+ *   properties:
+ *     send_to:      { type: array, items: { type: string, format: email } }
+ *     copy_to_self: { type: boolean, default: true }
+ *     email_title:  { type: string }
+ *     email_body:   { type: string }
+ * ```
+ *
+ * `copy_to_self` applies the documented server-side default on parse so
+ * consumers may omit it. No additional client-side validation (e.g.
+ * non-empty `send_to`, non-empty `email_title`) is layered here — those
+ * constraints belong to the MCP-tool / CLI-command boundaries that wrap
+ * this schema (see #638, #639).
+ *
+ * Unknown fields are stripped on parse to keep request bodies minimal.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/quotes/send-a-quote.md
+ */
+export const SendQuoteRequestPayloadSchema = z
+  .object({
+    send_to: z.array(z.email()),
+    copy_to_self: z.boolean().default(true),
+    email_title: z.string(),
+    email_body: z.string().optional(),
+  })
+  .strip();

--- a/packages/core/src/quotes/service.test.ts
+++ b/packages/core/src/quotes/service.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { HttpClient } from "../http-client.js";
+import { sendQuote } from "./service.js";
+
+describe("sendQuote", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: HttpClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new HttpClient({
+      baseUrl: "https://thirdparty.qonto.com",
+      authorization: "slug:secret",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("issues POST /v2/quotes/{id}/send with the JSON-serialised payload and Content-Type application/json", async () => {
+    fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+    const payload = {
+      send_to: ["a@example.com", "b@example.com"],
+      copy_to_self: true,
+      email_title: "Your quote",
+      email_body: "Please find the attached quote.",
+    };
+    await sendQuote(client, "quote-1", payload);
+
+    const [url, opts] = fetchSpy.mock.calls[0] as [URL, RequestInit];
+    expect(url.pathname).toBe("/v2/quotes/quote-1/send");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body as string)).toEqual(payload);
+    const headers = new Headers(opts.headers as HeadersInit);
+    expect(headers.get("content-type")).toBe("application/json");
+  });
+
+  it("encodes special characters in the ID", async () => {
+    fetchSpy.mockReturnValue(Promise.resolve(new Response(null, { status: 204 })));
+
+    await sendQuote(client, "a/b", {
+      send_to: ["a@example.com"],
+      copy_to_self: true,
+      email_title: "X",
+    });
+
+    const [url] = fetchSpy.mock.calls[0] as [URL];
+    expect(url.pathname).toBe("/v2/quotes/a%2Fb/send");
+  });
+});

--- a/packages/core/src/quotes/service.ts
+++ b/packages/core/src/quotes/service.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { HttpClient } from "../http-client.js";
+import type { SendQuoteRequestPayload } from "./types.js";
+
+/**
+ * Send a quote to the client via email.
+ *
+ * Issues `POST /v2/quotes/{id}/send` with the payload serialised as the
+ * JSON request body. The HTTP client sets `Content-Type: application/json`
+ * automatically because the request carries a body (see
+ * `http-client.ts#buildHeaders`).
+ *
+ * The Qonto API requires `send_to` (non-empty per the endpoint contract,
+ * though the OpenAPI shape itself does not declare a `minItems`) and
+ * `email_title`; `copy_to_self` defaults to `true` server-side and
+ * `email_body` is optional. Validation against
+ * {@link SendQuoteRequestPayload} is the caller's responsibility — this
+ * service intentionally passes the payload through verbatim to keep
+ * request shaping at the call site (MCP tool / CLI command) where the
+ * end-user-facing error surface lives.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/quotes/send-a-quote.md
+ */
+export async function sendQuote(client: HttpClient, id: string, payload: SendQuoteRequestPayload): Promise<void> {
+  await client.requestVoid("POST", `/v2/quotes/${encodeURIComponent(id)}/send`, { body: payload });
+}

--- a/packages/core/src/quotes/types.ts
+++ b/packages/core/src/quotes/types.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { z } from "zod";
+
+import type { SendQuoteRequestPayloadSchema } from "./schemas.js";
+
+/**
+ * Payload for `POST /v2/quotes/{id}/send`.
+ *
+ * Inferred from {@link SendQuoteRequestPayloadSchema} via `z.infer`, so the
+ * type reflects the schema's POST-PARSE shape. In particular, `copy_to_self`
+ * carries the schema's `.default(true)` and is therefore required at the TS
+ * layer even though the API treats it as optional with a documented server
+ * default of `true`. Direct callers may pass `copy_to_self: true` explicitly
+ * to mirror the documented default, or run the input through
+ * `SendQuoteRequestPayloadSchema.parse(...)` to have the default materialised.
+ *
+ * Reference: https://docs.qonto.com/api-reference/business-api/expense-management/client-quotes-notes/quotes/send-a-quote.md
+ */
+export type SendQuoteRequestPayload = z.infer<typeof SendQuoteRequestPayloadSchema>;

--- a/packages/e2e/coverage.json
+++ b/packages/e2e/coverage.json
@@ -745,6 +745,11 @@
       "tests": ["packages/e2e/src/products/cli.e2e.test.ts", "packages/e2e/src/products/mcp.e2e.test.ts"],
       "notes": "E2E exercises GET /v2/products via CLI and MCP. Sandbox tenants without products surface an empty list; tests assert shape only when empty."
     },
+    "core:packages/core/src/quotes/service.ts#sendQuote": {
+      "status": "pending",
+      "tests": [],
+      "notes": "Foundation introduced by #637; E2E coverage lands with #638 (quote_send MCP/CLI wiring + sharpened sandbox-precondition triage)."
+    },
     "core:packages/core/src/recurring-transfers/service.ts#cancelRecurringTransfer": {
       "status": "pending",
       "tests": [],

--- a/packages/mcp/src/tools/client-invoice.ts
+++ b/packages/mcp/src/tools/client-invoice.ts
@@ -275,7 +275,13 @@ export function registerClientInvoiceTools(server: McpServer, getClient: () => P
     },
     async ({ id }) =>
       withClient(getClient, async (client) => {
-        await sendClientInvoice(client, id);
+        // TODO(#639): expose `send_to` / `email_title` / `email_body` /
+        // `copy_to_self` in this tool's inputSchema and forward them as the
+        // payload. The placeholder below keeps the breaking sendClientInvoice
+        // signature (introduced in #637) compile-green; runtime behaviour is
+        // already broken (HTTP 422 from Qonto for an effectively-empty send),
+        // and #639 lands the proper wiring + E2E triage sharpening.
+        await sendClientInvoice(client, id, { send_to: [], copy_to_self: true, email_title: "" });
 
         return {
           content: [


### PR DESCRIPTION
## Summary

Foundation work for #637 — introduces the typed-payload + service-layer surface that #638 (`quote_send` wiring) and #639 (`client_invoice_send` wiring + migration guide) will consume.

- **NEW** `packages/core/src/quotes/` service-layer module — `sendQuote(client, id, payload)` issues `POST /v2/quotes/{id}/send` with the JSON-serialised payload, bringing quotes into structural parity with `client-invoices/`.
- **NEW** `SendQuoteRequestPayload` TS type + `SendQuoteRequestPayloadSchema` Zod schema; identical pair added for `SendClientInvoiceRequestPayload` / `SendClientInvoiceRequestPayloadSchema` (both endpoints accept the same OpenAPI `SendRequestPayload` shape).
- **BREAKING** — `sendClientInvoice(client, id)` is now `sendClientInvoice(client, id, payload)`. TypeScript surfaces a compile error at the prior call shape (verified: `tsc` emits `error TS2554: Expected 3 arguments, but got 2.`). Previously the function called `POST .../send` with no body and the Qonto API rejected with HTTP 422 `invalid_body: EOF` — the parallel-bug class to #636 arm 1.

## Scope decisions

- **No `.min(1)` constraint on `send_to`**: schema mirrors the OpenAPI shape literally. Non-empty-array enforcement belongs at the MCP-tool / CLI-command inputSchema boundaries per the explicit split with #638/#639.
- **Internal MCP/CLI compile-fix**: `packages/mcp/src/tools/client-invoice.ts:278` and `packages/cli/src/commands/client-invoice.ts:259` get placeholder payloads (`{ send_to: [], copy_to_self: true, email_title: "" }`) annotated `TODO(#639)`. Runtime behaviour was already broken (HTTP 422 EOF on origin/main); placeholder slightly changes the 422 reason but keeps the bug for #639 to land the proper end-user wiring + migration guide.
- **Zod 4 idiom**: switched from `z.string().email()` (deprecated in 4.x; trips `@typescript-eslint/no-deprecated`) to `z.email()`. Downstream #638/#639 should mirror.
- **`copy_to_self`** uses `.default(true)` at schema level, mirroring the OpenAPI server-side default. TS type derived via `z.infer` per issue spec (output-typed; documented in JSDoc).

## Files

- NEW: `packages/core/src/quotes/{service,schemas,types,index,schemas.test,service.test}.ts` (6)
- MOD: `packages/core/src/client-invoices/{service,schemas,types,index,schemas.test,service.test}.ts` (6)
- MOD: `packages/core/src/index.ts` (re-exports)
- MOD: `packages/mcp/src/tools/client-invoice.ts`, `packages/cli/src/commands/client-invoice.ts` (compile-fix placeholders)
- MOD: `CHANGELOG.md` (Added × 3, Changed BREAKING × 1)
- MOD: `packages/e2e/coverage.json` (`sendQuote` pending entry → #638)

## AC mapping

| Gherkin AC | Evidence |
|---|---|
| sendQuote issues POST with JSON body + `Content-Type: application/json` | `quotes/service.test.ts` asserts pathname, method, JSON-parsed body, and headers — passes |
| Schema rejects missing required fields with ZodError citing path | `quotes/schemas.test.ts` (and parallel `client-invoices/schemas.test.ts`) verify `path[0] === "send_to"` / `"email_title"` issues |
| `sendClientInvoice` breaking-change surfaces TS compile error | Reproduced via `.tmp/637-breaking-check/`: `tsc` emits `error TS2554` |

All 5 unit-level spec tests from issue scope item 9 pass.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean (after `z.string().email()` → `z.email()` fix)
- [x] `pnpm format:check` — clean
- [x] `pnpm license-check` — clean (103 prod deps)
- [x] `node scripts/check-coverage-drift.js` — clean (after adding `sendQuote` pending entry)
- [x] `pnpm --filter @qontoctl/core test` — 1232 passed (+14 new). 24 pre-existing config-resolution failures exist on origin/main with identical count and are unrelated to this change.
- [x] `pnpm test:e2e` — 44 passed / 335 skipped (sandbox suites OAuth-gated; the 8 api-key-compatible `client-invoices` E2E tests ran with the placeholder and showed no regression)

## Pre-merge reviews (per issue body + #631 precedent)

Issue requests:
- `security-architect` — payload validation review (Zod schemas as authoritative typed contract; verify no overly-permissive defaults and that the breaking signature doesn't enable silent acceptance of incomplete payloads).
- `technical-architect` — review the `packages/core/src/quotes/` service-seam introduction; confirm naming/structure parity with `client-invoices/` precedent and that the export surface is minimal + additive.

## Dependencies

- Blocks: #638, #639
- Blocked by: —

🤖 Generated with [Claude Code](https://claude.com/claude-code)