### PR TITLE
(fix) redact request-body PII in http-client debug logging (#644)

### DIFF
--- a/packages/core/src/http-client.test.ts
+++ b/packages/core/src/http-client.test.ts
@@ -1011,6 +1011,111 @@ describe("HttpClient", () => {
       expect(bodyLog).toContain('"other":"ok"');
     });
 
+    it("redacts PII fields (send_to, email) in request body debug logs (#644)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/quotes/quote-1/send", {
+        send_to: ["recipient-a@example.com", "recipient-b@example.com"],
+        copy_to_self: true,
+        email_title: "Your quote",
+        email_body: "Body text",
+      });
+
+      const requestBodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].startsWith("Request body:"),
+      );
+      expect(requestBodyLogCalls.length).toBeGreaterThan(0);
+      const bodyLog = requestBodyLogCalls[0]?.[0] as string;
+      expect(bodyLog).not.toContain("recipient-a@example.com");
+      expect(bodyLog).not.toContain("recipient-b@example.com");
+      expect(bodyLog).toContain('"send_to":"[REDACTED]"');
+      // Non-PII fields remain visible
+      expect(bodyLog).toContain('"copy_to_self":true');
+      expect(bodyLog).toContain('"email_title":"Your quote"');
+    });
+
+    it("redacts singular email field in request body debug logs (#644)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/beneficiaries", {
+        name: "ACME Corp",
+        iban: "FR7630001007941234567890185",
+        email: "ops@acme.example",
+      });
+
+      const requestBodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].startsWith("Request body:"),
+      );
+      expect(requestBodyLogCalls.length).toBeGreaterThan(0);
+      const bodyLog = requestBodyLogCalls[0]?.[0] as string;
+      expect(bodyLog).not.toContain("ops@acme.example");
+      expect(bodyLog).not.toContain("FR7630001007941234567890185");
+      expect(bodyLog).toContain('"email":"[REDACTED]"');
+      expect(bodyLog).toContain('"iban":"[REDACTED]"');
+      expect(bodyLog).toContain('"name":"ACME Corp"');
+    });
+
+    it("redacts pre-existing sensitive fields (iban, bic, balance) in request body debug logs (#644)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ data: "ok" }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      await client.post("/v2/some-endpoint", {
+        iban: "FR7630001007941234567890185",
+        bic: "BNPAFRPPXXX",
+        balance: 12345.67,
+        label: "internal",
+      });
+
+      const requestBodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].startsWith("Request body:"),
+      );
+      const bodyLog = requestBodyLogCalls[0]?.[0] as string;
+      expect(bodyLog).not.toContain("FR7630001007941234567890185");
+      expect(bodyLog).not.toContain("BNPAFRPPXXX");
+      expect(bodyLog).not.toContain("12345.67");
+      expect(bodyLog).toContain('"iban":"[REDACTED]"');
+      expect(bodyLog).toContain('"bic":"[REDACTED]"');
+      expect(bodyLog).toContain('"balance":"[REDACTED]"');
+      expect(bodyLog).toContain('"label":"internal"');
+    });
+
+    it("logs FormData request bodies as [FormData] placeholder (no JSON redaction needed)", async () => {
+      fetchSpy.mockReturnValue(jsonResponse({ id: "att-1" }, { status: 201 }));
+      const logger = createMockLogger();
+      const client = new TestableHttpClient({
+        baseUrl: "https://thirdparty.qonto.com",
+        authorization: "slug:secret",
+        logger,
+      });
+
+      const form = new FormData();
+      form.append("file", new Blob(["binary"], { type: "application/pdf" }), "doc.pdf");
+      await client.postFormData("/v2/attachments", form);
+
+      const requestBodyLogCalls = logger.debug.mock.calls.filter(
+        (call: string[]) => typeof call[0] === "string" && call[0].startsWith("Request body:"),
+      );
+      expect(requestBodyLogCalls.length).toBeGreaterThan(0);
+      expect(requestBodyLogCalls[0]?.[0]).toBe("Request body: [FormData]");
+    });
+
     it("redacts Authorization header in debug logs", async () => {
       fetchSpy.mockReturnValue(jsonResponse({}));
       const logger = createMockLogger();

--- a/packages/core/src/http-client.ts
+++ b/packages/core/src/http-client.ts
@@ -181,9 +181,13 @@ const STAGING_TOKEN_HEADER = "X-Qonto-Staging-Token";
 /**
  * Field and header names redacted from debug log output.
  *
- * Covers two classes of secrets:
+ * Covers three classes of sensitive data:
  * - Financial data (IBAN, BIC, balances) that must not appear in logs.
  * - Authentication and SCA tokens that grant API access if leaked.
+ * - Personally identifiable information (recipient emails) carried in
+ *   request bodies — notably the `send_to` array on quote / client-invoice
+ *   send endpoints (see #637-#639) and the singular `email` field on
+ *   beneficiaries and clients.
  *
  * Header names are stored lowercase; matching is case-insensitive so the
  * same set redacts both body fields (snake_case) and HTTP header names
@@ -203,6 +207,9 @@ const SENSITIVE_FIELDS: ReadonlySet<string> = new Set([
   // Authentication and environment headers
   "authorization",
   "x-qonto-staging-token",
+  // PII: recipient and contact emails (#644)
+  "send_to",
+  "email",
 ]);
 
 function redactSensitiveFields(value: unknown): unknown {
@@ -522,7 +529,15 @@ export class HttpClient {
       );
       this.logDebug(`Request headers: ${JSON.stringify(redactSensitiveFields(headers))}`);
       if (body !== undefined) {
-        this.logDebug(isFormData ? "Request body: [FormData]" : `Request body: ${body as string}`);
+        // Redact request body for debug logging only — `body` (the
+        // stringified form sent to fetch) stays untouched. FormData
+        // requests are logged as a placeholder because their parts may be
+        // binary and are not JSON-redactable.
+        this.logDebug(
+          isFormData
+            ? "Request body: [FormData]"
+            : `Request body: ${JSON.stringify(redactSensitiveFields(options?.body))}`,
+        );
       }
 
       const startTime = performance.now();


### PR DESCRIPTION
## Summary

- Wraps the **request-body debug-log site** in `packages/core/src/http-client.ts` through `redactSensitiveFields`, mirroring the existing pattern applied to response bodies and request/response headers. Closes the PII-exposure surface flagged in the `security-architect` pre-merge review of #640.
- Extends `SENSITIVE_FIELDS` with two PII entries: **`send_to`** (recipient-email array on the `quote_send` / `client_invoice_send` endpoints introduced in #637-#639) and **`email`** (singular field on beneficiary and client records).
- Adds four targeted tests asserting request-body redaction across the canonical send-payload shape, beneficiary-shaped bodies, pre-existing financial fields, and the `[FormData]` placeholder regression guard.

## How the fix works

The HTTP layer already had a recursive case-insensitive `redactSensitiveFields(value)` walker and a tight `SENSITIVE_FIELDS` set used for response bodies, request headers, and response headers. The request-body log call was the one symmetric site that wasn't passing through the walker:

\`\`\`ts
// before
this.logDebug(isFormData ? "Request body: [FormData]" : \`Request body: \${body as string}\`);

// after
this.logDebug(
  isFormData
    ? "Request body: [FormData]"
    : \`Request body: \${JSON.stringify(redactSensitiveFields(options?.body))}\`,
);
\`\`\`

The stringified `body` passed to `fetch()` itself is unchanged — only the debug-log view is redacted.

## Scope deliberately kept narrow

The issue called out the **mechanism** (extend redaction to cover the request body) plus the **concrete PII the recent send-payload work added** (`send_to`). I added `email` as well because it's the singular form of the same PII class and appears across beneficiaries and clients. No other PII fields (`first_name`, `phone_number`, `tax_identification_number`, etc.) were added — those would benefit from a separate review pass to avoid over-redacting visible-by-design fields.

## Test plan

- [x] `pnpm --filter @qontoctl/core test http-client` — 123 / 123 pass (4 new tests added)
- [x] `pnpm test` — 10 / 10 packages green
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean (8 / 8 tasks)
- [x] `pnpm build` — clean (5 / 5 tasks)
- [x] Fresh-context adversarial validate pass (verdict CLEAN, all 4 AC PASS, no bypass / over-mask / doc-accuracy concerns)
- [x] Fresh-context polish pass (verdict CLEAN, one constructive comment tightening applied)
- [ ] Pre-merge `security-architect` review — orchestrator (`/do-all #643 #644`) handles this before merge

E2E: ran full `pnpm test:e2e` locally — the failures observed are pre-existing sandbox/credential state issues (verified by stash-pop against clean main: identical `401 unauthorized: OAuth2 authentication is required here` on the same calls). This change is debug-log-only and cannot influence HTTP request bytes.

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)