### PR TITLE
(fix) resolve MCP diagnose through the server's launch --profile (#658)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@qontoctl/mcp`** + **`qontoctl`**: the MCP `diagnose` tool now resolves credentials through the server's launch `--profile` / `--config`, in lockstep with every data tool. Previously `createServer` passed the profile-aware client factory to every register function **except** `registerDiagnoseTools`, and the diagnose tool built its own config resolution from `QONTOCTL_CONFIG_FILE` only (`buildMcpResolveOptions`) — blind to the `--profile` the umbrella `qontoctl mcp --profile <name>` was launched with. The net effect: under a profile launch with no top-level `~/.qontoctl.yaml`, `account_list` (and every other tool) authenticated correctly while `diagnose` (no args) reported `No credentials found` — the one tool you reach for to confirm health falsely signalling that the whole MCP integration was broken; it only worked when an explicit `profile` argument was passed to the tool call. `CreateServerOptions` now carries an optional `resolveOptions` (`Pick<ResolveOptions, "path" | "profile">`) captured at launch via the CLI's `buildResolveOptions` (the exact resolver-input transform `createClient` already applies for the data tools) and threaded into `registerDiagnoseTools`. The diagnose tool resolves through it, falling back to `QONTOCTL_CONFIG_FILE` for the standalone `qontoctl-mcp` binary, which has no CLI flags. An explicit `profile` tool argument still overrides the launch profile, and the launch profile is now surfaced in the diagnose report so a missing-profile situation is obvious. `buildResolveOptions` (and its `ConfigResolveSelection` type) is now exported from `@qontoctl/cli` (#658).
+- **Docs**: corrected the "the MCP server has no CLI flags" claim in `docs/configuration.md`, `docs/sandbox-testing.md`, and the `@qontoctl/mcp` `config.ts` comment — that holds only for the standalone `qontoctl-mcp` binary; the `qontoctl mcp` subcommand accepts `--config` / `--profile` (now honored by `diagnose`). `docs/troubleshooting.md` § Running via MCP notes that a profile-launched server resolves `diagnose` through that profile automatically (#658).
+
 ## [2.0.5] — 2026-05-22
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,11 +41,15 @@ match is selected:
   supplied alongside `QONTOCTL_CONFIG_FILE` or `--profile` and the resolved
   paths disagree, `--config` wins and a one-line stderr warning surfaces the
   override.
-- **MCP server** (`qontoctl mcp`): no CLI flags exist. The server captures
-  `QONTOCTL_CONFIG_FILE` at **startup** and passes it to the resolver as the
-  `path` option (priority 1 in the table). Subsequent `process.env` mutations
-  cannot redirect later loads. With no env var set, the resolver falls through
-  to the home default at priority 4.
+- **MCP server** (`qontoctl mcp`): accepts the same inheritable flags as the
+  CLI — `--config` / `--profile` (plus `--auth`) — captured **at startup** and
+  threaded to every tool, **including `diagnose`** ([#658](https://github.com/alexey-pelykh/qontoctl/issues/658)).
+  Resolution then follows the same 1 → 4 precedence as the CLI: `--config` (1),
+  else `QONTOCTL_CONFIG_FILE` (2), else the `--profile`-derived
+  `~/.qontoctl/{profile}.yaml` (3), else the home default (4). Options are
+  frozen at startup, so subsequent `process.env` mutations cannot redirect
+  later loads. The **standalone `qontoctl-mcp` binary** has no CLI flags —
+  `QONTOCTL_CONFIG_FILE` is its only file-selection mechanism.
 - **E2E test harness** (`pnpm test:e2e`): the harness in
   `packages/e2e/src/sandbox.ts` injects `QONTOCTL_CONFIG_FILE` into spawned
   CLI subprocesses, pointing at the repo's `.qontoctl.yaml` (gitignored).

--- a/docs/sandbox-testing.md
+++ b/docs/sandbox-testing.md
@@ -97,8 +97,10 @@ QONTOCTL_CONFIG_FILE="$PWD/.qontoctl.yaml" qontoctl mcp
 
 In MCP host configs, the same env var goes in the `env` block — see
 [`docs/configuration.md`](./configuration.md#mcp-client-wiring) for the
-full pattern. The MCP server has no CLI flags, so `QONTOCTL_CONFIG_FILE`
-is the only way to point it at a non-default file.
+full pattern. The standalone `qontoctl-mcp` binary has no CLI flags, so
+`QONTOCTL_CONFIG_FILE` is the only way to point it at a non-default file; the
+`qontoctl mcp` subcommand shown above additionally accepts `--config` /
+`--profile`.
 
 ## Approving sandbox SCA challenges
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -176,6 +176,12 @@ read-only:
 }
 ```
 
+When the server is launched with a profile — `qontoctl mcp --profile production`
+(or `--config <path>`) — `diagnose` resolves credentials through that same
+launch profile automatically, so the `profile` argument can be omitted; pass it
+only to probe a _different_ profile than the one the server was started with
+([#658](https://github.com/alexey-pelykh/qontoctl/issues/658)).
+
 Output is the same JSON shape as `qontoctl diagnose --diagnose-output json`.
 
 ## Relationship to `qontoctl auth status`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,13 @@ export { handleCliError } from "./error-handler.js";
 
 export { executeWithCliSca, type CliScaOptions } from "./sca.js";
 
-export { addInheritableOptions, addWriteOptions, resolveGlobalOptions } from "./inherited-options.js";
+export {
+  addInheritableOptions,
+  addWriteOptions,
+  buildResolveOptions,
+  resolveGlobalOptions,
+  type ConfigResolveSelection,
+} from "./inherited-options.js";
 
 export {
   createAttachmentCommand,

--- a/packages/e2e/src/diagnose/mcp.e2e.test.ts
+++ b/packages/e2e/src/diagnose/mcp.e2e.test.ts
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { DiagnosticReportSchema } from "@qontoctl/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { stringify as stringifyYaml } from "yaml";
 import { CLI_PATH, firstTextFromMcpResult } from "../helpers.js";
-import { cliEnv, hasApiKeyCredentials } from "../sandbox.js";
+import { cliEnv, getCredentials, hasApiKeyCredentials } from "../sandbox.js";
 
 /**
  * Diagnose MCP E2E. Mirrors the CLI E2E happy path plus the input-schema
@@ -78,5 +82,74 @@ describe.skipIf(!hasApiKeyCredentials())("diagnose MCP (e2e)", () => {
     expect(text).not.toMatch(/\bBearer\s+[A-Za-z0-9._~+/=-]{20,}/);
     expect(text).not.toMatch(/\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/);
     expect(text).not.toMatch(/\b\d{13,19}\b/);
+  });
+});
+
+/**
+ * #658 regression at the integration seam: the umbrella `qontoctl mcp
+ * --profile <name>` server must resolve the `diagnose` tool through the launch
+ * profile, exactly like the data tools. Reproduces the reported scenario —
+ * credentials live ONLY in a profile file (`~/.qontoctl/<profile>.yaml`), with
+ * NO `QONTOCTL_CONFIG_FILE` env — by pointing the spawned server's HOME at a
+ * temp dir holding that profile file. Before the fix, `diagnose` (no args)
+ * ignored the launch `--profile` and reported "No credentials found".
+ *
+ * The profile config is built from `getCredentials()` (env in CI, file
+ * locally) rather than copying the repo `.qontoctl.yaml`, so it works in CI
+ * (which has no repo config file, only api-key env secrets).
+ */
+describe.skipIf(!hasApiKeyCredentials())("diagnose MCP — launch --profile resolution (e2e, #658)", () => {
+  const PROFILE = "e2e-profile";
+  let client: Client;
+  let transport: StdioClientTransport;
+  let tempHome: string;
+
+  beforeAll(async () => {
+    tempHome = mkdtempSync(join(tmpdir(), "qontoctl-mcp-profile-e2e-"));
+    mkdirSync(join(tempHome, ".qontoctl"), { recursive: true });
+
+    const creds = getCredentials();
+    const apiKey: Record<string, string> = {};
+    if (creds.organizationSlug !== undefined) apiKey["organization-slug"] = creds.organizationSlug;
+    if (creds.secretKey !== undefined) apiKey["secret-key"] = creds.secretKey;
+    const configObj: Record<string, unknown> = { "api-key": apiKey, auth: { preference: "api-key" } };
+    // Preserve sandbox routing when a staging token is configured (local), so
+    // requests hit the same host as the env-path suite above.
+    if (creds.stagingToken !== undefined) configObj["oauth"] = { "staging-token": creds.stagingToken };
+    writeFileSync(join(tempHome, ".qontoctl", `${PROFILE}.yaml`), stringifyYaml(configObj));
+
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HOME: tempHome,
+      USERPROFILE: tempHome, // Windows home resolution
+      QONTOCTL_AUTH: "api-key",
+    };
+    // Critical: the launch profile must be the ONLY resolution path. Drop any
+    // ambient QONTOCTL_CONFIG_FILE (cliEnv injects one) so the test proves
+    // `--profile` — not the env var — drives diagnose's resolution.
+    delete env["QONTOCTL_CONFIG_FILE"];
+
+    transport = new StdioClientTransport({
+      command: "node",
+      args: [CLI_PATH, "mcp", "--profile", PROFILE],
+      env,
+      stderr: "pipe",
+    });
+    client = new Client({ name: "diagnose-profile-e2e-test", version: "0.0.0" });
+    await client.connect(transport);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("resolves diagnose (no args) through the launch --profile and surfaces it", async () => {
+    const result = await client.callTool({ name: "diagnose", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const report = DiagnosticReportSchema.parse(JSON.parse(firstTextFromMcpResult(result)));
+    expect(report.results.length).toBe(9);
+    // The launch profile is honored (resolution) AND surfaced (display).
+    expect(report.profile).toBe(PROFILE);
   });
 });

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -6,13 +6,18 @@ import type { ResolveOptions } from "@qontoctl/core";
 const CONFIG_FILE_ENV = "QONTOCTL_CONFIG_FILE";
 
 /**
- * Build the `path` portion of {@link ResolveOptions} for the MCP server's
- * config load, sourced from the `QONTOCTL_CONFIG_FILE` env var.
+ * Build the `path` portion of {@link ResolveOptions} from the
+ * `QONTOCTL_CONFIG_FILE` env var — the config-file selection mechanism for
+ * the standalone `qontoctl-mcp` server, which has no CLI flags.
  *
- * The MCP server has no CLI flags, so the env var is its only mechanism for
- * pointing at a non-default config file (CI, multi-config dev workflows,
- * agent-driven setups). Reading the env explicitly at the MCP layer — and
- * passing it through as `path` — makes three properties true:
+ * For the standalone server the env var is the only file-selection mechanism
+ * (CI, multi-config dev workflows, agent-driven setups). The umbrella
+ * `qontoctl mcp` subcommand additionally accepts `--config` / `--profile`,
+ * resolves them via the CLI's `buildResolveOptions`, and threads the result
+ * to every tool — including `diagnose` (#658); this helper is the env-only
+ * fallback used when no such launch options are supplied. Reading the env
+ * explicitly at the MCP layer — and passing it through as `path` — makes
+ * three properties true:
  *
  *  1. **Symmetry with the CLI**: `qontoctl --config <path>` and
  *     `QONTOCTL_CONFIG_FILE=<path> qontoctl mcp` route through the same

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -3,7 +3,7 @@
 
 import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { HttpClient } from "@qontoctl/core";
+import type { HttpClient, ResolveOptions } from "@qontoctl/core";
 import {
   registerAttachmentTools,
   registerAccountTools,
@@ -43,6 +43,18 @@ const packageJson = require("../package.json") as { version: string };
 
 export interface CreateServerOptions {
   readonly getClient: () => Promise<HttpClient>;
+  /**
+   * Base config-resolution selection captured at server launch — the same
+   * `{ path?, profile? }` the data-tool client factory (`getClient`) resolves
+   * through. Threaded into the `diagnose` tool so it resolves credentials via
+   * the launch `--profile` / `--config` instead of being blind to them (#658).
+   *
+   * Omitted by the standalone `qontoctl-mcp` entry point, which has no CLI
+   * flags — `diagnose` then falls back to reading `QONTOCTL_CONFIG_FILE`
+   * directly (via `buildMcpResolveOptions`), matching that entry point's own
+   * `getClient`.
+   */
+  readonly resolveOptions?: Pick<ResolveOptions, "path" | "profile">;
 }
 
 export function createServer(options?: CreateServerOptions): McpServer {
@@ -65,7 +77,7 @@ export function createServer(options?: CreateServerOptions): McpServer {
   registerClientTools(server, getClient);
   registerClientInvoiceTools(server, getClient);
   registerCreditNoteTools(server, getClient);
-  registerDiagnoseTools(server);
+  registerDiagnoseTools(server, options?.resolveOptions);
   registerEInvoicingTools(server, getClient);
   registerInsuranceTools(server, getClient);
   registerInternationalTools(server, getClient);

--- a/packages/mcp/src/testing/mcp-helpers.ts
+++ b/packages/mcp/src/testing/mcp-helpers.ts
@@ -3,7 +3,7 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { HttpClient } from "@qontoctl/core";
+import { HttpClient, type ResolveOptions } from "@qontoctl/core";
 import { createServer } from "../server.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
@@ -19,21 +19,31 @@ export interface McpTestContext {
  *
  * Pass `stagingToken` to construct the underlying HttpClient in sandbox mode,
  * which flips `client.isSandbox` and routes requests through the sandbox host.
+ *
+ * Pass `resolveOptions` to simulate a server launched with `--profile` /
+ * `--config` (umbrella `qontoctl mcp`). It is threaded into `createServer`
+ * so the `diagnose` tool resolves config through the same base the data tools
+ * use (#658). The data-tool `getClient` here is a fixed stub, so
+ * `resolveOptions` only affects diagnose's own resolution path.
  */
 export async function connectInMemory(
   fetchSpy: ReturnType<typeof import("vitest").vi.fn>,
-  options?: { maxRetries?: number; stagingToken?: string },
+  options?: { maxRetries?: number; stagingToken?: string; resolveOptions?: Pick<ResolveOptions, "path" | "profile"> },
 ): Promise<McpTestContext> {
+  const { resolveOptions, ...httpOptions } = options ?? {};
   const httpClient = new HttpClient({
     baseUrl:
-      options?.stagingToken !== undefined
+      httpOptions.stagingToken !== undefined
         ? "https://thirdparty-sandbox.staging.qonto.co"
         : "https://thirdparty.qonto.com",
     authorization: "slug:secret",
-    ...options,
+    ...httpOptions,
   });
 
-  const server = createServer({ getClient: () => Promise.resolve(httpClient) });
+  const server = createServer({
+    getClient: () => Promise.resolve(httpClient),
+    ...(resolveOptions !== undefined ? { resolveOptions } : {}),
+  });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
   const mcpClient = new Client({ name: "test", version: "0.0.0" });

--- a/packages/mcp/src/tools/diagnose.test.ts
+++ b/packages/mcp/src/tools/diagnose.test.ts
@@ -152,3 +152,83 @@ describe("diagnose MCP tool", () => {
     expect(report.profile).toBe("default");
   });
 });
+
+describe("diagnose MCP tool — launch --profile / --config threading (#658)", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let tempDir: string;
+  let launchConfigPath: string;
+  let originalConfigEnv: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "qontoctl-diagnose-mcp-launch-"));
+    launchConfigPath = join(tempDir, "acme.yaml");
+    writeFileSync(
+      launchConfigPath,
+      [
+        "api-key:",
+        "  organization-slug: acme-org",
+        "  secret-key: acme-secret-key",
+        "auth:",
+        "  preference: api-key",
+        "",
+      ].join("\n"),
+    );
+    // Critically: NO QONTOCTL_CONFIG_FILE env. The fix must resolve through the
+    // threaded launch options, not the env fallback — unsetting the env is what
+    // makes this a faithful reproduction of the `--profile`-launch scenario
+    // (umbrella `qontoctl mcp --profile X` with no ambient env var).
+    originalConfigEnv = process.env["QONTOCTL_CONFIG_FILE"];
+    delete process.env["QONTOCTL_CONFIG_FILE"];
+
+    fetchSpy = vi.fn();
+    fetchSpy.mockReturnValue(
+      jsonResponse({ organization: { slug: "acme-org", legal_name: "Acme Co", bank_accounts: [] } }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    if (originalConfigEnv === undefined) {
+      delete process.env["QONTOCTL_CONFIG_FILE"];
+    } else {
+      process.env["QONTOCTL_CONFIG_FILE"] = originalConfigEnv;
+    }
+    vi.restoreAllMocks();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("resolves diagnose through the launch config when no tool arg and no env (the #658 regression)", async () => {
+    // Before the fix, registerDiagnoseTools received no launch options; with
+    // the env unset and no tool-arg profile it fell back to the home default
+    // and reported missing credentials. The threaded resolveOptions must now
+    // drive resolution — proven by configPath echoing the launch path.
+    const { mcpClient } = await connectInMemory(fetchSpy, { resolveOptions: { path: launchConfigPath } });
+    const result = await mcpClient.callTool({ name: "diagnose", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const report = JSON.parse(firstText(result)) as { configPath?: string };
+    expect(report.configPath).toBe(launchConfigPath);
+  });
+
+  it("surfaces the launch profile in the report when no tool arg is given", async () => {
+    const { mcpClient } = await connectInMemory(fetchSpy, {
+      resolveOptions: { path: launchConfigPath, profile: "acme" },
+    });
+    const result = await mcpClient.callTool({ name: "diagnose", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const report = JSON.parse(firstText(result)) as { profile: string; configPath?: string };
+    // Without the fix the report would show the default profile even though
+    // the server was launched with `--profile acme`.
+    expect(report.profile).toBe("acme");
+    expect(report.configPath).toBe(launchConfigPath);
+  });
+
+  it("lets an explicit profile tool argument override the launch profile", async () => {
+    const { mcpClient } = await connectInMemory(fetchSpy, {
+      resolveOptions: { path: launchConfigPath, profile: "acme" },
+    });
+    const result = await mcpClient.callTool({ name: "diagnose", arguments: { profile: "override" } });
+    expect(result.isError).not.toBe(true);
+    const report = JSON.parse(firstText(result)) as { profile: string };
+    expect(report.profile).toBe("override");
+  });
+});

--- a/packages/mcp/src/tools/diagnose.ts
+++ b/packages/mcp/src/tools/diagnose.ts
@@ -13,6 +13,7 @@ import {
   resolveConfig,
   runDiagnose,
   type DiagnoseContext,
+  type ResolveOptions,
 } from "@qontoctl/core";
 import { buildMcpResolveOptions } from "../config.js";
 
@@ -35,8 +36,20 @@ const packageJson = require("../../package.json") as { version: string };
  * `HttpClient` factory — diagnose specifically needs mode-pinned
  * clients (no fallback chain) so it can probe each credential mode
  * in isolation.
+ *
+ * @param resolveOptions - Base config-resolution selection captured at
+ *   server launch (the same `{ path?, profile? }` the data-tool client
+ *   factory resolves through). Threaded so diagnose resolves credentials
+ *   via the launch `--profile` / `--config` rather than being blind to
+ *   them (#658). When omitted (standalone `qontoctl-mcp` — no CLI flags),
+ *   diagnose falls back to `QONTOCTL_CONFIG_FILE` via
+ *   {@link buildMcpResolveOptions}, matching that entry point's `getClient`.
+ *   An explicit `profile` tool argument still overrides the launch profile.
  */
-export function registerDiagnoseTools(server: McpServer): void {
+export function registerDiagnoseTools(
+  server: McpServer,
+  resolveOptions?: Pick<ResolveOptions, "path" | "profile">,
+): void {
   server.registerTool(
     "diagnose",
     {
@@ -48,8 +61,13 @@ export function registerDiagnoseTools(server: McpServer): void {
     },
     async (args) => {
       try {
-        const { config, endpoint, path } = await resolveProfileConfig(args.profile);
-        const ctx = buildContext(args.profile, config, endpoint, path);
+        const { config, endpoint, path } = await resolveProfileConfig(args.profile, resolveOptions);
+        // Active profile for the report: the explicit tool argument when
+        // given, else the profile the server was launched with (threaded via
+        // resolveOptions), else "default". Surfacing the launch profile makes
+        // a missing-profile situation obvious in the output (#658).
+        const effectiveProfile = args.profile ?? resolveOptions?.profile;
+        const ctx = buildContext(effectiveProfile, config, endpoint, path);
         const report = await runDiagnose(ctx);
         const validated = DiagnosticReportSchema.parse(report);
         const redaction = buildRedactionContext(config);
@@ -94,10 +112,18 @@ function buildContext(
   };
 }
 
-async function resolveProfileConfig(profile: string | undefined) {
-  const base = buildMcpResolveOptions();
+async function resolveProfileConfig(
+  profile: string | undefined,
+  resolveOptions: Pick<ResolveOptions, "path" | "profile"> | undefined,
+) {
+  // Base selection: the launch options threaded from the server (umbrella
+  // `qontoctl mcp --profile`/`--config`), else the standalone entry point's
+  // QONTOCTL_CONFIG_FILE env. Either way diagnose resolves through the SAME
+  // base the data-tool client factory uses — that parity is the fix for #658.
+  const base = resolveOptions ?? buildMcpResolveOptions();
   return resolveConfig({
     ...(base ?? {}),
+    // An explicit tool-call `profile` overrides the launch profile.
     ...(profile !== undefined ? { profile } : {}),
   });
 }

--- a/packages/qontoctl/src/cli.ts
+++ b/packages/qontoctl/src/cli.ts
@@ -4,6 +4,7 @@
 
 import {
   addInheritableOptions,
+  buildResolveOptions,
   createAttachmentCommand,
   createClient,
   createClientCommand,
@@ -22,6 +23,7 @@ import {
   registerStatementCommands,
   registerTransferCommands,
   resolveGlobalOptions,
+  type GlobalOptions,
 } from "@qontoctl/cli";
 import { runStdioServer } from "@qontoctl/mcp/stdio";
 
@@ -45,8 +47,16 @@ registerTransferCommands(program);
 const mcpCommand = program.command("mcp").description("Start MCP server on stdio (for Claude Desktop, Cursor, etc.)");
 addInheritableOptions(mcpCommand);
 mcpCommand.action(async () => {
+  // Capture the launch options once. Both the data-tool client factory and
+  // the diagnose tool resolve config through these same options, so diagnose
+  // honours the server's `--profile` / `--config` instead of being blind to
+  // them (#658). `buildResolveOptions` is the exact resolver-input transform
+  // `createClient` applies internally, keeping diagnose in lockstep with the
+  // data tools.
+  const launchOptions = resolveGlobalOptions<GlobalOptions>(mcpCommand);
   await runStdioServer({
-    getClient: () => createClient(resolveGlobalOptions(mcpCommand)),
+    getClient: () => createClient(launchOptions),
+    resolveOptions: buildResolveOptions(launchOptions),
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #658 — the MCP `diagnose` tool ignored the server's launch `--profile` / `--config` and misreported missing credentials.

Under `qontoctl mcp --profile <name>` (with credentials only in `~/.qontoctl/<name>.yaml` and no top-level `~/.qontoctl.yaml`), every data tool (`account_list`, …) authenticated correctly, but `diagnose` (no args) returned `No credentials found` — the one tool you reach for to confirm health falsely signalling that the whole MCP integration was broken. It only worked when an explicit `profile` argument was passed to the tool call.

## Root cause

- `createServer` (`packages/mcp/src/server.ts`) passed the profile-aware client factory (`getClient`) to every register function **except** `registerDiagnoseTools(server)`.
- `diagnose` built its own config resolution from `QONTOCTL_CONFIG_FILE` only (`buildMcpResolveOptions`) — blind to the `--profile` the umbrella `qontoctl mcp` command was launched with (wired via `resolveGlobalOptions(mcpCommand)` in `packages/qontoctl/src/cli.ts`).

Not a precedence bug and not a 2.0.4→2.0.5 regression (per the issue's analysis — confirmed).

## Fix

Thread the launch's base config-resolution selection into the diagnose tool so it resolves through the **same** options as the data tools:

- `CreateServerOptions` gains an optional `resolveOptions: Pick<ResolveOptions, "path" | "profile">`, threaded into `registerDiagnoseTools`.
- The umbrella `cli.ts` captures the launch options once and passes `resolveOptions: buildResolveOptions(launchOptions)` — the exact resolver-input transform `createClient` already applies for the data tools, guaranteeing parity.
- `diagnose` resolves through the threaded options, **falling back to `QONTOCTL_CONFIG_FILE`** for the standalone `qontoctl-mcp` binary (which genuinely has no CLI flags).
- An explicit `profile` tool argument still overrides the launch profile, and the **active profile is now surfaced** in the report so a missing-profile situation is obvious.
- `buildResolveOptions` (+ `ConfigResolveSelection`) is now exported from `@qontoctl/cli`.

## Testing

- **3 new `@qontoctl/mcp` unit tests** (`diagnose.test.ts`) — resolution via threaded launch options, launch-profile surfaced in the report, and tool-arg override. **Verified to fail** when the fix logic is reverted (genuine regression guards).
- **1 new E2E** (`diagnose/mcp.e2e.test.ts`) — spawns the real `qontoctl mcp --profile e2e-profile` with credentials only in a temp-HOME profile file and **no** `QONTOCTL_CONFIG_FILE`; asserts `diagnose` (no args) is healthy and reports the launch profile. CI-safe (profile config built from `getCredentials()`).
- Full local suites green: `pnpm build`, `pnpm lint`, `pnpm format:check`, `pnpm coverage-drift-check`; `@qontoctl/mcp` 398 unit, `@qontoctl/cli` 803 unit.
- `pnpm test:e2e` (full): all **api-key-compatible** suites (the CI path) pass. The 26 failing files are **all** OAuth-gated and fail only because this checkout's OAuth refresh token is expired (`diagnose` itself reports `auth.oauth-health: fail — OAuth token refresh failed`; a documented local fragility — Qonto rotates refresh tokens on every use). CI is api-key-only and skips those suites. This change cannot affect OAuth-refresh behavior.

## Docs

Corrected the stale "the MCP server has no CLI flags" claim in `docs/configuration.md`, `docs/sandbox-testing.md`, and the `config.ts` comment (it holds only for the standalone `qontoctl-mcp` binary; `qontoctl mcp` accepts `--config` / `--profile`). Added a note in `docs/troubleshooting.md` § Running via MCP. CHANGELOG `[Unreleased]` updated.

Closes #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
