### PR TITLE
(fix) widen card_type schema from enum to open string (#672)

### DIFF
--- a/packages/core/src/cards/schemas.test.ts
+++ b/packages/core/src/cards/schemas.test.ts
@@ -187,8 +187,13 @@ describe("CardSchema", () => {
     }
   });
 
-  it("validates card_type values", () => {
-    for (const card_type of ["debit", "prepaid"]) {
+  it("accepts card_type values beyond the former debit/prepaid enum (#672)", () => {
+    // `card_type` used to be `z.enum(["debit", "prepaid"])`, which failed the
+    // ENTIRE card response whenever Qonto returned any other value (breaking
+    // `card list`/`card show`). It is now an open string, matching
+    // `CardTypeAppearancesSchema`. The non-debit/prepaid values below would each
+    // throw under the old schema — this guards against a regression.
+    for (const card_type of ["debit", "prepaid", "flash", "advertising", "virtual"]) {
       const result = CardSchema.parse(makeCard({ card_type }));
       expect(result.card_type).toBe(card_type);
     }

--- a/packages/core/src/cards/schemas.ts
+++ b/packages/core/src/cards/schemas.ts
@@ -87,7 +87,12 @@ export const CardSchema = z
     updated_at: z.string(),
     created_at: z.string(),
     shipped_at: z.string().nullable().optional(),
-    card_type: z.enum(["debit", "prepaid"]),
+    // `card_type` is an open string, not a closed enum: Qonto surfaces card
+    // types beyond "debit"/"prepaid", and a strict enum fails the WHOLE card
+    // response on any unlisted value — breaking `card list`/`card show` for the
+    // entire account, not just the one card. Mirrors `CardTypeAppearancesSchema`
+    // below, which already models `card_type` as `z.string()`. (#672)
+    card_type: z.string(),
     card_level: z.enum(["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"]),
     payment_lifespan_limit: z.number().nullable().optional(),
     payment_lifespan_spent: z.number(),

--- a/packages/core/src/types/card.ts
+++ b/packages/core/src/types/card.ts
@@ -77,7 +77,9 @@ export interface Card {
   readonly updated_at: string;
   readonly created_at: string;
   readonly shipped_at?: string | null | undefined;
-  readonly card_type: "debit" | "prepaid";
+  // Open string, not a closed union — Qonto surfaces card types beyond
+  // "debit"/"prepaid"; see `CardSchema.card_type` in ../cards/schemas.ts. (#672)
+  readonly card_type: string;
   readonly card_level: "standard" | "plus" | "metal" | "virtual" | "virtual_partner" | "flash" | "advertising";
   readonly payment_lifespan_limit?: number | null | undefined;
   readonly payment_lifespan_spent: number;


### PR DESCRIPTION
## Problem

`card list` / `card show` failed to parse a real Qonto card:

```
Invalid API response from /v2/cards/{id}: card.card_type: Invalid option: expected one of "debit"|"prepaid"
```

`Card.card_type` was `z.enum(["debit", "prepaid"])` — too narrow. When Qonto returns a `card_type` outside that set, the **entire** card response fails validation, so **every** `card list` result is rejected (not just the one card).

## Fix

Model `card_type` as an open `z.string()`, aligning it with the sibling `CardTypeAppearancesSchema` in the same file (`schemas.ts`), which already treats `card_type` as a string. Widen the hand-written `Card.card_type` TS type to match.

Chosen over extending the enum (Option B in #672) because:
- `card_type` is demonstrably an **open** set on Qonto's side (the `card_type_appearances` endpoint already models it as a string), so any fixed enum re-breaks the moment Qonto adds a value.
- The change is a strict **widening** — more permissive parsing — so it can only *remove* parse failures, never introduce one.
- No consumer branches on the literal type; every `card_type` usage is a pass-through copy into output objects (`list.ts`, `show.ts`, `create.ts`) or a test fixture.

## Tests

- New regression case in `schemas.test.ts` asserts non-`debit`/`prepaid` values (`flash`, `advertising`, `virtual`) parse — each would **throw** under the old enum.
- `pnpm vitest run packages/core/src/cards/` → **51 passed**
- mcp + cli card suites → **85 passed**
- `pnpm build` (cross-package typecheck) → **5/5**, `pnpm lint` → **8/8**, changed files prettier-clean

## Notes

- **`card_level` (same object) has the same latent fragility** — still a 7-value enum that would break the whole response on a new value. Left unfixed to keep this PR scoped to the tracked `card_type` issue; flagging for a possible follow-up.
- **Live-sandbox E2E deferred**: the local OAuth session is expired (needs interactive re-auth), so the real `card list` path wasn't re-exercised here. The fix is a permissive schema-widening fully covered by the unit regression above; a subsequent live E2E run is a confirmation, not a gate.

Closes #672