### PR TITLE
(test) correct hyphenated intl command tokens in intl-transfers e2e (#673)

### DIFF
--- a/packages/e2e/src/intl-transfers/cli.e2e.test.ts
+++ b/packages/e2e/src/intl-transfers/cli.e2e.test.ts
@@ -26,29 +26,49 @@ interface IntlQuote {
   readonly target_amount: number;
 }
 
+/**
+ * Sandbox-provisionable currencies probed in priority order when searching
+ * for an existing intl-beneficiary. `intl beneficiary list` requires
+ * `--currency` (a mandatory option), so each corridor must be queried
+ * explicitly.
+ */
+const PROBE_CURRENCIES = ["USD", "GBP", "CHF", "CAD", "AUD", "JPY", "HKD", "SGD"];
+
 describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () => {
   pinAuthPreference("oauth-first");
 
   describe("intl-transfer requirements", () => {
     it("returns requirements for a beneficiary", (ctx) => {
-      // First list intl beneficiaries to get an ID. The intl-beneficiary
-      // feature can be sandbox-gated; previously a bare try/catch swallowed
-      // ANY error (including auth failures — the #496 class). Use the
-      // 404-specific `skipIfNotFound` helper instead so genuine errors
-      // (401 auth failure, 5xx) still surface as test failures.
-      const stdout = skipIfNotFound("--output", "json", "intl-beneficiary", "list");
-      if (stdout === SKIP) {
-        skipMissingFixture(ctx, "intl-beneficiary list returned 404 — feature not enabled in sandbox");
+      // Find an intl beneficiary to derive requirements for. The command tree
+      // is `intl beneficiary list` (not `intl-beneficiary`), and `list`
+      // requires `--currency` (a mandatory option), so probe corridors in
+      // priority order. `skipIfNotFound` skips a 404 corridor (feature gated)
+      // while still surfacing genuine errors (401 auth, 5xx) as failures — the
+      // #496 class — instead of a bare try/catch swallowing everything.
+      let id: string | undefined;
+      for (const currency of PROBE_CURRENCIES) {
+        const stdout = skipIfNotFound("--output", "json", "intl", "beneficiary", "list", "--currency", currency);
+        if (stdout === SKIP) continue;
+        const beneficiaries = JSON.parse(stdout) as { id: string }[];
+        if (beneficiaries.length > 0 && beneficiaries[0] !== undefined) {
+          id = beneficiaries[0].id;
+          break;
+        }
       }
-      const beneficiaries = JSON.parse(stdout) as { id: string }[];
-      if (beneficiaries.length === 0) {
-        skipMissingFixture(ctx, "no international beneficiaries in sandbox for intl-transfer requirements");
+      if (id === undefined) {
+        skipMissingFixture(
+          ctx,
+          "no international beneficiaries in sandbox across probed corridors (or feature not enabled)",
+        );
       }
 
-      const id = (beneficiaries[0] as { id: string }).id;
-      const output = cli("--output", "json", "intl-transfer", "requirements", id);
+      // `<id>` is a beneficiary id; the endpoint is
+      // `/v2/international/transfers/{id}/requirements`. The JSON payload is the
+      // unwrapped requirements object, which carries `fields` (not a nested
+      // `requirements` key — the service already extracts `.requirements`).
+      const output = cli("--output", "json", "intl", "transfer", "requirements", id);
       const parsed = JSON.parse(output) as Record<string, unknown>;
-      expect(parsed).toHaveProperty("requirements");
+      expect(parsed).toHaveProperty("fields");
     });
   });
 });
@@ -79,14 +99,6 @@ describe.skipIf(!hasOAuthCredentials())("intl-transfer CLI commands (e2e)", () =
 // skips with a console warning rather than failing.
 describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("intl-transfer create (OAuth+sandbox SCA probe)", () => {
   pinAuthPreference("oauth-first");
-
-  /**
-   * Sandbox-provisionable currencies probed in priority order when
-   * searching for an existing intl-beneficiary. The Qonto API requires
-   * `--currency` on `intl beneficiary list`, so we have to query each
-   * corridor explicitly.
-   */
-  const PROBE_CURRENCIES = ["USD", "GBP", "CHF", "CAD", "AUD", "JPY", "HKD", "SGD"];
 
   function discoverIntlBeneficiary(): IntlBeneficiary | undefined {
     for (const currency of PROBE_CURRENCIES) {
@@ -142,7 +154,8 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken())("intl-transfer cre
         "--verbose",
         "--output",
         "json",
-        "intl-transfer",
+        "intl",
+        "transfer",
         "create",
         "--beneficiary",
         beneficiary.id,


### PR DESCRIPTION
## Problem

The `intl-transfer requirements` E2E test failed deterministically:

```
error: too many arguments. Expected 0 arguments but got 2.
```

A commander arity error — it exits **before any HTTP call**, so it's unrelated to auth or sandbox state.

## Root cause: test-invocation bug (not a CLI defect)

The CLI command tree is `intl` → `beneficiary`/`transfer` → subcommand (verified in `intl-beneficiary/index.ts`, `intl-transfer/index.ts`, and the unit tests, e.g. `requirements.test.ts` uses `["intl", "transfer", "requirements", ...]`). The E2E test invoked **hyphenated** names (`intl-beneficiary`, `intl-transfer`), which aren't commands — commander parsed the hyphenated token plus its subcommand as two positional args to the root program. The CLI is correct; the test was wrong (and evidently never ran successfully).

## Fixes (all in `packages/e2e/src/intl-transfers/cli.e2e.test.ts`)

- `intl-beneficiary list` → `intl beneficiary list --currency <code>`. `list` makes `--currency` **mandatory**, so the test now probes corridors in priority order (reusing `PROBE_CURRENCIES`, hoisted to module scope from the SCA-probe describe) to find a beneficiary.
- `intl-transfer requirements <id>` → `intl transfer requirements <id>`.
- Assertion `toHaveProperty("requirements")` → `toHaveProperty("fields")` — the core service already unwraps the response's `.requirements`, so the CLI's JSON payload carries `fields` (matches the unit test + `IntlTransferRequirements` type).
- **Latent same bug** fixed in the SCA-probe spawn: `intl-transfer create` → `intl transfer create` (hidden today behind an early return when no beneficiary is provisioned).

## Validation

Deterministic, against the built CLI (arity errors are pre-network, so no creds needed):

| Form | Result |
|---|---|
| `intl-beneficiary list` (old) | `error: too many arguments…` — reproduces the bug |
| `intl beneficiary list --currency USD` (new) | reaches `GET /v2/international/beneficiaries` (401, dead creds) — **past parsing** |
| `intl transfer requirements intl-ben-1` (new) | reaches `GET /v2/international/transfers/{id}/requirements` — **past parsing** |
| `intl-transfer create` (old) | `error: unknown option '--beneficiary'` — broken |
| `intl transfer create` (new) | reaches `POST /v2/international/transfers` (401) — **past parsing** |

Build (typecheck) 5/5, lint clean, prettier clean.

**Live-sandbox run deferred**: this suite is OAuth-gated (local-only; skips in CI) and the local OAuth session is expired. The command-structure fix is proven above; a live run against a provisioned beneficiary is a confirmation, not a gate.

Closes #673