### PR TITLE
(fix) require dedicated seed for oauth-flow e2e; drop main-session poisoning fallback (#671)

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -50,12 +50,15 @@ commands/mcp-payment-links · quotes · recurring-transfers · teams · webhooks
 sca-continuation · auth/oauth-flow
 
 > The `auth/oauth-flow` suite has an **additional** gate beyond the
-> standard OAuth + staging-token check: it requires a seed refresh token
-> (`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var or `oauth.refresh-token`
-> in `.qontoctl.yaml`). The seed is consumed on every successful run, and
-> the suite is **local-only by design** — see
-> [`docs/oauth-flow-e2e.md`](./oauth-flow-e2e.md) for the rationale and
-> local rotation workflow.
+> standard OAuth + staging-token check: it requires a **dedicated** seed
+> refresh token in the `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var. It
+> deliberately does **not** fall back to `oauth.refresh-token` in
+> `.qontoctl.yaml` — the suite rotates and revokes the token it is given, so
+> using your main session's token poisoned that session mid-run (#671).
+> Without the env var the suite skips cleanly. The seed is consumed on every
+> successful run, and the suite is **local-only by design** — see
+> [`docs/oauth-flow-e2e.md`](./oauth-flow-e2e.md) for the rationale and local
+> seed-token workflow.
 
 **No credentials needed** (run anywhere):
 
@@ -112,8 +115,8 @@ the suite's reason to exist. See
 > credentials. For the OAuth-flow E2E suite specifically, see
 > [`docs/oauth-flow-e2e.md`](./oauth-flow-e2e.md) — the suite is local-only
 > by design and uses a dedicated `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`
-> env var (or `oauth.refresh-token` in `.qontoctl.yaml`) scoped to tests
-> only, not read by the runtime.
+> env var scoped to tests only, not read by the runtime (and with no
+> `.qontoctl.yaml` fallback, per #671).
 
 ## Running locally
 

--- a/docs/oauth-flow-e2e.md
+++ b/docs/oauth-flow-e2e.md
@@ -14,39 +14,34 @@ A mock-OAuth-server retrofit (record sandbox responses, replay them in CI) was e
 
 ## Running locally
 
-1. Log in to the Qonto sandbox OAuth app:
+The suite requires a **dedicated, disposable** sandbox refresh token in the `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var. It **rotates and revokes** the token it is handed, so this must never be your main working session's token. (It used to fall back to `oauth.refresh-token` in `.qontoctl.yaml`, which silently poisoned that session mid-run — the fallback was removed in [#671](https://github.com/alexey-pelykh/qontoctl/issues/671).) Without the env var the suite **skips cleanly**, leaving your main session intact.
+
+1. Mint a disposable sandbox refresh token by logging in against a throwaway sandbox profile — one you are willing to have rotated and revoked, kept separate from your everyday profile:
 
     ```sh
-    qontoctl auth login --profile sandbox
+    qontoctl auth login --profile sandbox-e2e
     ```
 
-    (Or whichever profile carries the sandbox OAuth credentials + staging token.)
+    (Any profile carrying sandbox OAuth credentials + a staging token works.)
 
-2. Run the full E2E suite — the suite picks up the freshly-issued refresh token from your profile via `oauth.refresh-token`:
+2. Export that profile's `oauth.refresh-token` value (from `~/.qontoctl/sandbox-e2e.yaml`) as the seed, then run the full E2E suite:
 
     ```sh
+    export QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG="<sandbox refresh token>"
     pnpm test:e2e
     ```
 
-3. The suite consumes the refresh token on success (Qonto rotates per exchange). To re-run, log in again:
+3. The suite consumes the seed on success (Qonto rotates per exchange). To re-run, mint a fresh token and re-export it:
 
     ```sh
-    qontoctl auth login --profile sandbox
+    qontoctl auth login --profile sandbox-e2e
+    export QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG="<fresh sandbox refresh token>"
     pnpm test:e2e
     ```
 
 This mirrors the rotation cadence experienced by any qontoctl runtime that uses OAuth — refresh tokens are runtime-mutable state and live for one exchange.
 
-## Optional: dedicated seed env var
-
-For local workflows where you want to keep your active profile's refresh token separate from the test seed, the suite also reads `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` as an override:
-
-```sh
-export QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG="<sandbox refresh token>"
-pnpm test:e2e
-```
-
-The `_LONG` suffix is a maintainer-facing reminder that this token does not flow through the runtime config-overlay chain (`QONTOCTL_REFRESH_TOKEN` was removed as a runtime env var in [#495](https://github.com/alexey-pelykh/qontoctl/issues/495) precisely because env-overlay semantics are incompatible with per-exchange rotation). It is still consumed on every successful run.
+The `_LONG` suffix is a maintainer-facing reminder that this token does not flow through the runtime config-overlay chain (`QONTOCTL_REFRESH_TOKEN` was removed as a runtime env var in [#495](https://github.com/alexey-pelykh/qontoctl/issues/495) precisely because env-overlay semantics are incompatible with per-exchange rotation). It is consumed on every successful run.
 
 ## Scope: what this covers and what stays excluded
 

--- a/packages/e2e/src/auth/oauth-flow.e2e.test.ts
+++ b/packages/e2e/src/auth/oauth-flow.e2e.test.ts
@@ -7,7 +7,6 @@ import {
   refreshAccessToken,
   revokeToken,
   SANDBOX_BASE_URL,
-  saveOAuthTokens,
 } from "@qontoctl/core";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -24,12 +23,15 @@ import {
 // against the real Qonto sandbox OAuth server. Closes #460 (Group 8 of #449).
 //
 // Gate: requires OAuth client credentials, a staging token (sandbox routing),
-// AND a seed refresh token (`QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var
-// or `oauth.refresh-token` in `.qontoctl.yaml`). The seed token is consumed
-// on each successful run (Qonto rotates refresh tokens on every refresh) —
-// see `docs/oauth-flow-e2e.md` for the rationale and the local rotation
-// workflow. This suite is local-only by design (CI is intentionally out of
-// scope).
+// AND a DEDICATED seed refresh token in the
+// `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var. There is intentionally no
+// `.qontoctl.yaml` `oauth.refresh-token` fallback: this suite rotates and
+// revokes the token it is handed, so seeding it from the developer's main
+// session poisoned that session mid-run (#671). Without the env var the suite
+// skips cleanly. The seed token is consumed on each successful run (Qonto
+// rotates refresh tokens on every refresh) — see `docs/oauth-flow-e2e.md` for
+// the rationale and the local seed-token workflow. This suite is local-only
+// by design (CI is intentionally out of scope).
 //
 // `exchangeCode` is intentionally NOT covered: the authorization-code flow
 // requires browser interaction (user authentication + consent) which cannot
@@ -93,23 +95,10 @@ describe.skipIf(!hasOAuthCredentials() || !hasStagingToken() || !hasE2ERefreshTo
 
       freshAccessToken = tokens.accessToken;
 
-      // Persist the rotated tokens back to .qontoctl.yaml so subsequent E2E
-      // suites (bank-accounts, beneficiaries, cards, etc.) use the live
-      // refresh token instead of the now-invalidated seed. Only persist when
-      // the seed came from the config file — when the dedicated env var was
-      // set, the file should remain untouched.
-      //
-      // accessTokenExpiresAt is set to epoch-0 so the OAuth factory
-      // force-refreshes on the next CLI call (this access token will be
-      // revoked by the revoke test below, but the refresh token remains
-      // valid for one more rotation).
-      if (!process.env["QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG"]) {
-        await saveOAuthTokens({
-          accessToken: tokens.accessToken,
-          refreshToken: tokens.refreshToken,
-          accessTokenExpiresAt: new Date(0).toISOString(),
-        });
-      }
+      // The rotated refresh token is intentionally NOT persisted anywhere. The
+      // seed is a dedicated, disposable `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`
+      // token — never the developer's `.qontoctl.yaml` session (#671) — so
+      // letting it rotate away affects nothing beyond this suite.
     });
 
     // AC: Given a freshly-issued access token from `refreshAccessToken`,

--- a/packages/e2e/src/sandbox.ts
+++ b/packages/e2e/src/sandbox.ts
@@ -195,11 +195,15 @@ export function getTransferProofId(): string {
 
 /**
  * Check whether a sandbox OAuth refresh token is available for the
- * OAuth-flow round-trip E2E suite — either via the
- * `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var (a dedicated test seed
- * surface, kept distinct from runtime refresh-token env vars per #495) or
- * via `oauth.refresh-token` in `.qontoctl.yaml` (local developer flow,
- * populated by `qontoctl auth login`).
+ * OAuth-flow round-trip E2E suite, via the dedicated
+ * `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var (a test seed surface, kept
+ * distinct from runtime refresh-token env vars per #495).
+ *
+ * There is intentionally **no** `.qontoctl.yaml` `oauth.refresh-token`
+ * fallback: the OAuth-flow suite rotates and revokes whatever refresh token
+ * it is handed, so falling back to the developer's main session token
+ * cannibalized that session mid-run (#671). Without the dedicated env var the
+ * suite skips cleanly, leaving the main session intact.
  *
  * Used by `describe.skipIf(... || !hasE2ERefreshToken())` on the
  * OAuth-flow E2E suite. Pair with `!hasOAuthCredentials()` and
@@ -209,21 +213,19 @@ export function getTransferProofId(): string {
  * The suite is **local-only by design**: Qonto rotates refresh tokens on
  * every `oauth/token` exchange (per RFC 6749 §6), so CI-seeded secrets
  * burn on every run. See [`docs/oauth-flow-e2e.md`](../../../docs/oauth-flow-e2e.md)
- * for the rationale and the local rotation workflow.
+ * for the rationale and the local seed-token workflow.
  */
 export function hasE2ERefreshToken(): boolean {
-  if (process.env["QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG"]) {
-    return true;
-  }
-  return Boolean(readConfigFileCredentials()?.refreshToken);
+  return Boolean(process.env["QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG"]);
 }
 
 /**
  * Retrieve the sandbox OAuth refresh token for the OAuth-flow round-trip
- * E2E suite. Resolution order: `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG`
- * env var, then `oauth.refresh-token` in `.qontoctl.yaml`.
+ * E2E suite, from the dedicated `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env
+ * var. There is intentionally no `.qontoctl.yaml` `oauth.refresh-token`
+ * fallback — see {@link hasE2ERefreshToken} and #671.
  *
- * Throws if no refresh token is available — callers should be guarded by
+ * Throws if the env var is unset — callers should be guarded by
  * {@link hasE2ERefreshToken}.
  */
 export function getE2ERefreshToken(): string {
@@ -231,13 +233,11 @@ export function getE2ERefreshToken(): string {
   if (envToken) {
     return envToken;
   }
-  const fileToken = readConfigFileCredentials()?.refreshToken;
-  if (fileToken) {
-    return fileToken;
-  }
   throw new Error(
-    "No E2E OAuth refresh token available " +
-      "(checked QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG env var and oauth.refresh-token in .qontoctl.yaml)",
+    "No E2E OAuth refresh token available: set QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG to a " +
+      "dedicated, disposable sandbox refresh token. The oauth-flow suite intentionally does NOT " +
+      "fall back to oauth.refresh-token in .qontoctl.yaml, because the suite rotates and revokes " +
+      "the token it is given — doing that to your main session token poisons it mid-run (#671).",
   );
 }
 


### PR DESCRIPTION
## Problem

A full `pnpm test:e2e` run **invalidated the local `.qontoctl.yaml` OAuth session**. Afterward, live OAuth calls fell back to api-key and 401'd — even though `qontoctl auth status` still reported `Active` (it reads the local expiry *timestamp*, not server-side revocation). This cascaded 401s into every OAuth-required suite that ran after the poisoning point.

## Root cause

`getE2ERefreshToken()` / `hasE2ERefreshToken()` resolved the seed refresh token as: `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var, **else `oauth.refresh-token` from `.qontoctl.yaml`**. In the common local case (env var unset), the `auth/oauth-flow` suite consumed the **main session's** refresh token, then **rotated** it (its `refreshAccessToken` test) and **revoked** the derived access token (its `revokeToken` test) — killing the main session for the rest of the run.

## Fix — Option A: remove the fallback

- `hasE2ERefreshToken()` / `getE2ERefreshToken()` now read **only** the dedicated `QONTOCTL_E2E_OAUTH_REFRESH_TOKEN_LONG` env var. Without it the suite **skips cleanly**, leaving the main session untouched.
- Removed the now-dead "persist rotated tokens back to `.qontoctl.yaml`" block in the suite — it only ran in the fallback case, which no longer exists — and its now-unused `saveOAuthTokens` import.
- Updated `docs/e2e-testing.md` and `docs/oauth-flow-e2e.md`: the env var is now **required** (not an optional override), and the local workflow uses a dedicated, disposable sandbox token (not your main session).

Chosen over Option B (persist the rotated token back) — that still burns the seed each run and keeps mutating the developer's config; Option A cleanly guarantees the suite never touches the main session.

## Validation

With OAuth creds + staging token present but the env var **unset**, the oauth-flow suite now **skips**:

```
Test Files  1 skipped (1)
     Tests  2 skipped (2)
```

(Previously it would have *run* and rotated/revoked the shared session.) Build 5/5, lint 8/8, prettier clean, `coverage-drift-check` passed.

**Live full-suite validation deferred**: the AC "a full `pnpm test:e2e` leaves the main session usable" needs live OAuth creds (the local session is currently expired). The mechanism is proven above — the destructive suite no longer runs without a dedicated seed — so a subsequent full run is a confirmation, not a gate.

Closes #671