### PR TITLE
(fix) widen card_level + status card schemas from enum to open string (#678)

### DIFF
--- a/packages/core/src/cards/schemas.test.ts
+++ b/packages/core/src/cards/schemas.test.ts
@@ -157,31 +157,24 @@ describe("CardSchema", () => {
     expect(result.parent_card_summary).toEqual({ id: "card-0", last_digits: "5678" });
   });
 
-  it("validates all card status values", () => {
-    const statuses = [
-      "pending",
-      "live",
-      "paused",
-      "stolen",
-      "lost",
-      "pin_blocked",
-      "discarded",
-      "expired",
-      "shipped_lost",
-      "onhold",
-      "order_canceled",
-      "pre_expired",
-      "abusive",
-    ];
-    for (const status of statuses) {
+  it("accepts status values beyond the former enum (#678)", () => {
+    // `status` used to be a closed 13-value `z.enum([...])`; a new card lifecycle
+    // state from Qonto would fail the ENTIRE card response. It is now an open
+    // string. The last two values below would each throw under the old enum —
+    // this guards against a regression. Follow-up to #672 (same fix for `card_type`).
+    for (const status of ["pending", "live", "paused", "expired", "frozen", "some_new_state"]) {
       const result = CardSchema.parse(makeCard({ status }));
       expect(result.status).toBe(status);
     }
   });
 
-  it("validates card_level values", () => {
-    const levels = ["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"];
-    for (const card_level of levels) {
+  it("accepts card_level values beyond the former enum (#678)", () => {
+    // `card_level` used to be a closed `z.enum([...])`, which failed the ENTIRE
+    // card response whenever Qonto returned a new tier (breaking `card list`/
+    // `card show`). It is now an open string, matching `CardLevelAppearancesSchema`.
+    // The last three values below would each throw under the old enum — this
+    // guards against a regression. Follow-up to #672 (same fix for `card_type`).
+    for (const card_level of ["standard", "metal", "flash", "titanium", "world_elite", "gold"]) {
       const result = CardSchema.parse(makeCard({ card_level }));
       expect(result.card_level).toBe(card_level);
     }
@@ -199,8 +192,10 @@ describe("CardSchema", () => {
     }
   });
 
-  it("rejects invalid status", () => {
-    expect(() => CardSchema.parse(makeCard({ status: "invalid" }))).toThrow();
+  it("rejects non-string status (open string, not z.any() — #678)", () => {
+    // Widening status to an open string (#678) must not degrade it to `z.any()`:
+    // a non-string value is still a malformed response and must be rejected.
+    expect(() => CardSchema.parse(makeCard({ status: 42 }))).toThrow();
   });
 
   it("strips extra fields", () => {

--- a/packages/core/src/cards/schemas.ts
+++ b/packages/core/src/cards/schemas.ts
@@ -41,21 +41,12 @@ export const CardSchema = z
     id: z.string(),
     nickname: z.string(),
     embossed_name: z.string().nullable().optional(),
-    status: z.enum([
-      "pending",
-      "live",
-      "paused",
-      "stolen",
-      "lost",
-      "pin_blocked",
-      "discarded",
-      "expired",
-      "shipped_lost",
-      "onhold",
-      "order_canceled",
-      "pre_expired",
-      "abusive",
-    ]),
+    // `status` is an open string, not a closed enum: Qonto can introduce new
+    // card lifecycle states, and a strict enum fails the WHOLE card response on
+    // any unlisted value — breaking `card list`/`card show` for the entire
+    // account, not just the one card. Follow-up to #672 (same fix for
+    // `card_type`). (#678)
+    status: z.string(),
     pin_set: z.boolean(),
     mask_pan: z.string().nullable().optional(),
     exp_month: z.string().nullable().optional(),
@@ -93,7 +84,11 @@ export const CardSchema = z
     // entire account, not just the one card. Mirrors `CardTypeAppearancesSchema`
     // below, which already models `card_type` as `z.string()`. (#672)
     card_type: z.string(),
-    card_level: z.enum(["standard", "plus", "metal", "virtual", "virtual_partner", "flash", "advertising"]),
+    // `card_level` is an open string, not a closed enum: Qonto can add card
+    // tiers, and a strict enum fails the WHOLE card response on any unlisted
+    // value. Mirrors `CardLevelAppearancesSchema` below, which already models
+    // `card_level` as `z.string()`. Follow-up to #672. (#678)
+    card_level: z.string(),
     payment_lifespan_limit: z.number().nullable().optional(),
     payment_lifespan_spent: z.number(),
     pre_expires_at: z.string().nullable().optional(),
@@ -104,6 +99,10 @@ export const CardSchema = z
     had_operation: z.boolean(),
     had_pin_operation: z.boolean(),
     card_design: z.string(),
+    // `type_of_print` (here) and `appearance.theme` stay CLOSED enums by design:
+    // print options and UI themes are low-churn sets, so strict validation is
+    // worth more than the small resilience risk of a future unlisted value —
+    // unlike the higher-churn `card_type`/`card_level`/`status`. (#678)
     type_of_print: z.enum(["print", "embossed"]).nullable().optional(),
     upsold: z.boolean(),
     upsell: z.boolean(),

--- a/packages/core/src/types/card.ts
+++ b/packages/core/src/types/card.ts
@@ -32,20 +32,9 @@ export interface Card {
   readonly id: string;
   readonly nickname: string;
   readonly embossed_name?: string | null | undefined;
-  readonly status:
-    | "pending"
-    | "live"
-    | "paused"
-    | "stolen"
-    | "lost"
-    | "pin_blocked"
-    | "discarded"
-    | "expired"
-    | "shipped_lost"
-    | "onhold"
-    | "order_canceled"
-    | "pre_expired"
-    | "abusive";
+  // Open string, not a closed union — Qonto can add card lifecycle states; see
+  // `CardSchema.status` in ../cards/schemas.ts. (#678, follow-up to #672)
+  readonly status: string;
   readonly pin_set: boolean;
   readonly mask_pan?: string | null | undefined;
   readonly exp_month?: string | null | undefined;
@@ -80,7 +69,9 @@ export interface Card {
   // Open string, not a closed union — Qonto surfaces card types beyond
   // "debit"/"prepaid"; see `CardSchema.card_type` in ../cards/schemas.ts. (#672)
   readonly card_type: string;
-  readonly card_level: "standard" | "plus" | "metal" | "virtual" | "virtual_partner" | "flash" | "advertising";
+  // Open string, not a closed union — Qonto can add card tiers; see
+  // `CardSchema.card_level` in ../cards/schemas.ts. (#678, follow-up to #672)
+  readonly card_level: string;
   readonly payment_lifespan_limit?: number | null | undefined;
   readonly payment_lifespan_spent: number;
   readonly pre_expires_at?: string | null | undefined;


### PR DESCRIPTION
## Summary

Follow-up to #672 (`b38b463`), scoped in #678. Widens the two remaining **open-set** response enums in `CardSchema` — `card_level` and `status` — from closed `z.enum([...])` to `z.string()`, so a value Qonto returns outside the hardcoded list no longer fails the **entire** card response (which breaks `card list` / `card show` for the whole account, not just the one card).

## Changes

- `packages/core/src/cards/schemas.ts` — `card_level` (7-value) + `status` (13-value) → `z.string()`; `type_of_print` gains a rationale comment for staying closed.
- `packages/core/src/types/card.ts` — `Card.card_level` + `Card.status` unions → `string`.
- `packages/core/src/cards/schemas.test.ts` — replaced the enum-enumeration tests with beyond-enum acceptance tests; re-pointed the now-dead `rejects invalid status` → `rejects non-string status` (widening must not degrade to `z.any()`).

## Why these two, and not the others

Both are **pure pass-through** (every consumer echoes them; nothing branches exhaustively — grep-verified), so widening loses no type-safety. The genuinely **low-churn** enums (`type_of_print`, `appearance.theme`) are deliberately **kept closed** — the validation value outweighs the small resilience risk. Bonus: `mcp/tools/card.ts:219` already declared `card_level: z.string()` in an output shape, so this also removes a core↔MCP inconsistency.

## Verification

- Unit: **RED first** (`card_level: "titanium"` / `status: "frozen"` threw `ZodError` under the old enums), then **GREEN 30/30** after widening.
- `pnpm build` (5/5 tsc), `pnpm lint` (8/8), `pnpm format:check`, `pnpm test` (cli 773 + core + mcp), `pnpm coverage-drift-check` — all pass locally.

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
