### PR TITLE
(docs) sync public-facing surfaces: complete tool list, disclaimer parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ QontoCtl lets AI assistants (Claude, etc.) interact with Qonto through the [Mode
 - **SEPA Beneficiaries** — list, add, update, trust/untrust SEPA beneficiaries
 - **SEPA Transfers** — list, create, cancel transfers; download proofs; verify payees
 - **Internal Transfers** — create transfers between accounts in the same organization
-- **Bulk Transfers** — list and view bulk transfer batches
-- **Recurring Transfers** — list and view recurring transfers
+- **Bulk Transfers** — list, view, and create bulk SEPA transfer batches
+- **Recurring Transfers** — list, view, create, cancel recurring transfers
+- **International Transfers (SWIFT)** — create SWIFT transfers and manage international beneficiaries
+- **Cards** — list, create, update, lock/unlock, report lost/stolen, discard cards
+- **Teams** — list and create teams
+- **Webhooks** — create and manage webhook subscriptions
+- **Payment Links** — create, deactivate, and manage Stripe-backed payment links
+- **Insurance** — show, create, update insurance contracts and manage documents
 - **Terminals (POS)** — list Qonto Terminals and initiate terminal payments
 - **Products** — list catalogue products
 - **Clients** — list, create, update, delete clients

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -36,6 +36,11 @@ export function createProgram(): Command {
 
   program.name("qontoctl").description("The complete CLI & MCP for Qonto").version(packageJson.version);
 
+  program.addHelpText(
+    "after",
+    "\nQontoCtl is an independent, unofficial project and is not affiliated with, endorsed by, or supported by Qonto.\n",
+  );
+
   program
     .addOption(
       new Option("--config <path>", "path to configuration file (overrides --profile and QONTOCTL_CONFIG_FILE)"),

--- a/packages/qontoctl/README.md
+++ b/packages/qontoctl/README.md
@@ -11,6 +11,8 @@ CLI and MCP server for the [Qonto](https://qonto.com) banking API.
 
 This project is brought to you by [Alexey Pelykh](https://github.com/alexey-pelykh).
 
+> **Unofficial project.** QontoCtl is independent and not affiliated with, endorsed by, or supported by Qonto. See the [Disclaimer](#disclaimer).
+
 ## What It Does
 
 QontoCtl lets AI assistants (Claude, etc.) interact with Qonto through the [Model Context Protocol](https://modelcontextprotocol.io). It can:
@@ -600,9 +602,9 @@ qontoctl --debug transaction list     # full headers and response bodies
 
 ## Disclaimer
 
-`qontoctl` is an **independent project** not affiliated with, endorsed by, or officially connected to **Qonto** or Qonto SAS.
+`qontoctl` is an **independent project** not affiliated with, endorsed by, or officially connected to **Qonto**. It runs on your own machine with your own credentials.
 
-Qonto is a trademark of Qonto SAS.
+"Qonto" and the Qonto logo are trademarks of Olinda SAS (the company operating Qonto); `qontoctl` uses the name only to describe the service it interoperates with.
 
 ## License
 


### PR DESCRIPTION
## What

Public-facing accuracy + disclaimer hygiene across three surfaces (the follow-ups noted on #675).

## Changes

- **Root README tool list** — `What It Does` was stale: missing **Cards, International Transfers (SWIFT), Teams, Webhooks, Payment Links, Insurance**. Completed to match the npm package README's authoritative list (all verified registered in `packages/mcp/src/server.ts`).
- **npm package README disclaimer parity** (`packages/qontoctl/README.md`) — reconciled the trademark owner to **Olinda SAS** (per Qonto's own [legal notice](https://qonto-assets.s3.eu-central-1.amazonaws.com/documents/QONTO-LEGAL-NOTICE-EN.pdf), was "Qonto SAS") and added the same **"Unofficial project"** top callout the root README carries.
- **CLI** — `qontoctl --help` now shows an unofficial / not-affiliated note (`addHelpText`).

## Heads-up: the two READMEs have drifted

`README.md` (rendered on GitHub + the website) and `packages/qontoctl/README.md` (published to npm) are hand-maintained separately — there's no sync step (`prepack` only copies `LICENSE`) — and they had diverged: root lacked the newer tool domains, while npm lacked the updated disclaimer and the positioning section from #675. This PR patches both back to consistency, but consider **consolidating to a single source of truth** (a symlink, or a `prepack` copy of the root README) to prevent this recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
